### PR TITLE
feat(#28): add Recorder RoundTripper wrapper

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"sync"
+	"sync/atomic"
 )
 
 // Sanitizer transforms a Tape before it is persisted, redacting or faking
@@ -38,6 +39,7 @@ type Recorder struct {
 	onError   func(error)       // callback for async write errors; defaults to no-op
 
 	// async internals
+	closed    atomic.Bool  // set to true when Close is called; guards against send-on-closed-channel
 	tapeCh    chan Tape     // buffered channel for async mode
 	done      chan struct{} // closed when background goroutine exits
 	closeOnce sync.Once    // ensures Close is idempotent
@@ -165,6 +167,12 @@ func NewRecorder(store Store, opts ...RecorderOption) *Recorder {
 // Sampling: if a random float is >= sampleRate, the request is passed through
 // without recording.
 func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Closed guard: if the recorder has been closed, pass through without recording.
+	// This prevents sending on a closed channel in async mode.
+	if r.closed.Load() {
+		return r.transport.RoundTrip(req)
+	}
+
 	// Sampling check: skip recording if not sampled.
 	if r.sampleRate < 1.0 && r.randFloat() >= r.sampleRate {
 		return r.transport.RoundTrip(req)
@@ -258,6 +266,7 @@ func (r *Recorder) Close() error {
 		return nil
 	}
 	r.closeOnce.Do(func() {
+		r.closed.Store(true)
 		close(r.tapeCh)
 		<-r.done
 	})

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -924,6 +924,51 @@ func (r *failingReader) Read(p []byte) (int, error) {
 
 func (r *failingReader) Close() error { return nil }
 
+// --- RoundTrip after Close (closed guard) ---
+
+func TestRecorder_RoundTripAfterClose(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("still works"))
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithRoute("after-close"),
+		WithAsync(true),
+		WithBufferSize(16),
+	)
+
+	// Close the recorder first.
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	// RoundTrip after Close must not panic and must pass through to the transport.
+	req, _ := http.NewRequest("GET", srv.URL+"/after-close", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip after Close should succeed, got: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "still works" {
+		t.Errorf("response body = %q, want %q", body, "still works")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// No new tapes should have been recorded after Close.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 0 {
+		t.Errorf("len(tapes) = %d, want 0 (no recording after Close)", len(tapes))
+	}
+}
+
 // --- http.RoundTripper interface compliance ---
 
 func TestRecorder_ImplementsRoundTripper(t *testing.T) {


### PR DESCRIPTION
Closes #28

## Summary

Implements the Recorder RoundTripper wrapper as designed in ADR-2:

- **`Recorder` struct** implementing `http.RoundTripper` — transparently intercepts HTTP calls, captures request/response pairs as `Tape` values, and persists them to a `Store`
- **`Sanitizer` interface** — placeholder for the future sanitization milestone; accepted via `WithSanitizer` option
- **Async mode** (default): tapes sent to a buffered channel, drained by a background goroutine. Non-blocking `select` with `default` ensures the hot path never blocks. Graceful shutdown via `Close()` with `sync.Once` idempotency
- **Sync mode**: direct `store.Save()` in `RoundTrip` for simpler use cases
- **Sampling**: probabilistic rate in [0.0, 1.0] with early return before any body capture
- **Functional options**: `WithTransport`, `WithRoute`, `WithSanitizer`, `WithSampling`, `WithAsync`, `WithBufferSize`, `WithOnError`
- **Error isolation**: recording errors never propagate to the caller's HTTP flow

## New files

| File | Description |
|---|---|
| `recorder.go` | `Sanitizer` interface, `Recorder` struct, `RecorderOption`, constructor, options, `RoundTrip`, `Close`, `drain` |
| `recorder_test.go` | 25 tests covering sync/async modes, sampling, sanitizer, error handling, concurrency, buffer overflow, integration |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (25 new tests, all green)
- [x] `go vet ./...` clean
- [x] Coverage: 93.4% overall, 94.4% for `RoundTrip`
- [x] Tests cover: sync mode, async mode, nil request body, transport errors, sampling (all/none/probabilistic), sanitizer integration, store errors (sync + async), buffer full drop, Close idempotency, concurrent requests, full http.Client integration
