### PR TITLE
fix: address milestone 1 architecture review findings

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -800,6 +800,10 @@ provide a simple function instead of implementing the full interface.
 
 ##### ExactMatcher default (`server.go`)
 
+> **Note (ADR-4):** `ExactMatcher` is no longer the constructor default.
+> `DefaultMatcher()` (from ADR-4) replaced it as the server default. `ExactMatcher`
+> remains available for backward compatibility. Both now live in `matcher.go`.
+
 A minimal built-in matcher is provided so the Server is usable out of the box
 without requiring issue #30's full matcher implementation:
 
@@ -849,7 +853,7 @@ type Server struct {
 Fields explained:
 - `store`: required dependency — where tapes live.
 - `matcher`: required dependency — how to find the right tape. Defaults to
-  `ExactMatcher()` if not provided via options.
+  `DefaultMatcher()` if not provided via options (updated by ADR-4).
 - `fallbackStatus`: HTTP status code returned when no tape matches. Defaults
   to `http.StatusNotFound` (404). Configurable via `WithFallbackStatus`.
 - `fallbackBody`: body bytes written in the fallback response. Defaults to
@@ -872,13 +876,14 @@ type ServerOption func(*Server)
 // NewServer creates a new Server that replays tapes from the given store.
 //
 // By default:
-//   - matcher is ExactMatcher() (matches by method + URL path)
+//   - matcher is DefaultMatcher() (matches by method + URL path with scoring;
+//     updated by ADR-4, was ExactMatcher() originally)
 //   - fallback status is 404 Not Found
 //   - fallback body is "httptape: no matching tape found"
 //   - no onNoMatch callback
 //
-// The store must not be nil. If it is, NewServer returns a Server that
-// always responds with 500 Internal Server Error and a descriptive body.
+// The store must not be nil. Passing a nil store is a programming error
+// and will panic.
 func NewServer(store Store, opts ...ServerOption) *Server
 ```
 
@@ -889,7 +894,7 @@ The matcher is an option because a sensible default exists.
 
 ```go
 // WithMatcher sets the Matcher used to find tapes for incoming requests.
-// If not set, ExactMatcher() is used.
+// If not set, DefaultMatcher() is used (updated by ADR-4).
 func WithMatcher(m Matcher) ServerOption
 
 // WithFallbackStatus sets the HTTP status code returned when no tape matches

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,56 @@
+// Package httptape provides HTTP traffic recording, sanitization, and replay
+// for Go tests and development environments.
+//
+// httptape captures HTTP request/response pairs via a recording
+// [http.RoundTripper], sanitizes sensitive data on write, and replays them
+// through a mock [http.Handler]. It is designed to be embedded directly in
+// Go applications and test suites with zero external dependencies.
+//
+// # Core types
+//
+// [Tape] is a value type representing a single recorded HTTP interaction
+// (request + response). Tapes are created by the [Recorder] and replayed by
+// the [Server].
+//
+// # Recording
+//
+// [Recorder] wraps an [http.RoundTripper] and transparently captures every
+// HTTP call as a [Tape]. Recording is asynchronous by default to minimize
+// hot-path overhead.
+//
+//	rec := httptape.NewRecorder(store, httptape.WithRoute("users-api"))
+//	client := &http.Client{Transport: rec}
+//	// ... use client normally ...
+//	rec.Close() // flush pending recordings
+//
+// # Replay
+//
+// [Server] implements [http.Handler] and replays recorded tapes. It uses a
+// [Matcher] to find the best-matching tape for each incoming request.
+//
+//	srv := httptape.NewServer(store)
+//	ts := httptest.NewServer(srv)
+//	defer ts.Close()
+//
+// # Storage
+//
+// The [Store] interface abstracts tape persistence. Two implementations are
+// provided:
+//   - [MemoryStore]: in-memory storage, ideal for tests.
+//   - [FileStore]: filesystem-backed storage with JSON fixtures.
+//
+// # Matching
+//
+// The [Matcher] interface controls how incoming requests are matched to
+// recorded tapes. [DefaultMatcher] provides method + path matching via a
+// [CompositeMatcher]. Individual [MatchCriterion] functions (e.g.,
+// [MatchMethod], [MatchPath], [MatchQueryParams], [MatchBodyHash]) can be
+// composed for custom matching strategies.
+//
+// # Design principles
+//
+// httptape follows hexagonal architecture: core types have zero I/O, all
+// persistence goes through the [Store] port, and all components are
+// configured via functional options. The library has zero external
+// dependencies (stdlib only) and no global mutable state.
+package httptape

--- a/matcher.go
+++ b/matcher.go
@@ -7,6 +7,42 @@ import (
 	"net/url"
 )
 
+// Matcher selects a Tape from a list of candidates that best matches
+// the incoming HTTP request. Implementations define the matching strategy
+// (exact, fuzzy, regex, etc.).
+type Matcher interface {
+	// Match returns the best-matching Tape for the given request.
+	// If no tape matches, it returns false as the second return value.
+	// The candidates slice is never nil but may be empty.
+	// Implementations must not modify the request or the candidate tapes.
+	Match(req *http.Request, candidates []Tape) (Tape, bool)
+}
+
+// MatcherFunc is an adapter to allow the use of ordinary functions as Matchers.
+type MatcherFunc func(req *http.Request, candidates []Tape) (Tape, bool)
+
+// Match calls f(req, candidates).
+func (f MatcherFunc) Match(req *http.Request, candidates []Tape) (Tape, bool) {
+	return f(req, candidates)
+}
+
+// ExactMatcher is a simple Matcher that matches requests by HTTP method and
+// URL path. It returns the first candidate whose method and URL path are
+// equal to the incoming request's method and URL path.
+//
+// This is intentionally minimal. For advanced matching (headers, body,
+// query params, regex), use CompositeMatcher or DefaultMatcher.
+func ExactMatcher() Matcher {
+	return MatcherFunc(func(req *http.Request, candidates []Tape) (Tape, bool) {
+		for _, t := range candidates {
+			if t.Request.Method == req.Method && t.Request.URL == req.URL.Path {
+				return t, true
+			}
+		}
+		return Tape{}, false
+	})
+}
+
 // MatchCriterion evaluates how well a candidate Tape matches an incoming
 // request for a single dimension (method, path, body, etc.).
 //

--- a/server.go
+++ b/server.go
@@ -4,42 +4,6 @@ import (
 	"net/http"
 )
 
-// Matcher selects a Tape from a list of candidates that best matches
-// the incoming HTTP request. Implementations define the matching strategy
-// (exact, fuzzy, regex, etc.).
-type Matcher interface {
-	// Match returns the best-matching Tape for the given request.
-	// If no tape matches, it returns false as the second return value.
-	// The candidates slice is never nil but may be empty.
-	// Implementations must not modify the request or the candidate tapes.
-	Match(req *http.Request, candidates []Tape) (Tape, bool)
-}
-
-// MatcherFunc is an adapter to allow the use of ordinary functions as Matchers.
-type MatcherFunc func(req *http.Request, candidates []Tape) (Tape, bool)
-
-// Match calls f(req, candidates).
-func (f MatcherFunc) Match(req *http.Request, candidates []Tape) (Tape, bool) {
-	return f(req, candidates)
-}
-
-// ExactMatcher is a simple Matcher that matches requests by HTTP method and
-// URL path. It returns the first candidate whose method and URL path are
-// equal to the incoming request's method and URL path.
-//
-// This is intentionally minimal. For advanced matching (headers, body,
-// query params, regex), use the matchers from issue #30.
-func ExactMatcher() Matcher {
-	return MatcherFunc(func(req *http.Request, candidates []Tape) (Tape, bool) {
-		for _, t := range candidates {
-			if t.Request.Method == req.Method && t.Request.URL == req.URL.Path {
-				return t, true
-			}
-		}
-		return Tape{}, false
-	})
-}
-
 // Server is an http.Handler that replays recorded HTTP interactions.
 // It receives incoming requests, finds a matching Tape via a Matcher,
 // and writes the recorded response. If no match is found, it returns
@@ -90,9 +54,13 @@ func WithOnNoMatch(fn func(*http.Request)) ServerOption {
 //   - fallback body is "httptape: no matching tape found"
 //   - no onNoMatch callback
 //
-// The store must not be nil. If it is, NewServer returns a Server that
-// always responds with 500 Internal Server Error and a descriptive body.
+// The store must not be nil. Passing a nil store is a programming error and
+// will panic.
 func NewServer(store Store, opts ...ServerOption) *Server {
+	if store == nil {
+		panic("httptape: NewServer requires a non-nil Store")
+	}
+
 	s := &Server{
 		store:          store,
 		matcher:        DefaultMatcher(),
@@ -111,13 +79,7 @@ func NewServer(store Store, opts ...ServerOption) *Server {
 //
 // The method is safe for concurrent use.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Step 2: nil store check.
-	if s.store == nil {
-		http.Error(w, "httptape: server misconfigured (nil store)", http.StatusInternalServerError)
-		return
-	}
-
-	// Step 3: retrieve all tapes from store.
+	// Step 2: retrieve all tapes from store.
 	tapes, err := s.store.List(r.Context(), Filter{})
 	if err != nil {
 		http.Error(w, "httptape: store error", http.StatusInternalServerError)
@@ -138,9 +100,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 6: write the matched tape's response.
-	// 6a: copy response headers.
+	// 6a: copy response headers (clone slices to prevent aliasing with tape data).
 	for key, values := range tape.Response.Headers {
-		w.Header()[key] = values
+		w.Header()[key] = append([]string(nil), values...)
 	}
 	// 6b: write status code.
 	w.WriteHeader(tape.Response.StatusCode)

--- a/server_test.go
+++ b/server_test.go
@@ -150,20 +150,21 @@ func TestServer_NoMatch_Callback(t *testing.T) {
 	mu.Unlock()
 }
 
-func TestServer_NilStore(t *testing.T) {
-	srv := NewServer(nil)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/anything", nil)
-
-	srv.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
-	}
-	if !strings.Contains(rec.Body.String(), "nil store") {
-		t.Errorf("body = %q, want it to contain 'nil store'", rec.Body.String())
-	}
+func TestNewServer_NilStore_Panics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for nil store, got none")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
+		if !strings.Contains(msg, "nil Store") {
+			t.Errorf("panic message = %q, want it to contain 'nil Store'", msg)
+		}
+	}()
+	NewServer(nil)
 }
 
 func TestServer_StoreError(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses all findings from the Milestone 1 architecture review (issue #27).

### Recommended fixes (2)
- **Server response header aliasing**: Clone header value slices in `ServeHTTP` using `append([]string(nil), values...)` instead of assigning tape slices directly to the response writer. Prevents potential aliasing with future Store implementations.
- **Inconsistent nil-Store handling**: `NewServer` now panics on nil store, matching `NewRecorder` behavior. Passing nil is a programming error. The runtime nil-check in `ServeHTTP` is removed since it's no longer reachable.

### Nit fixes (4)
- **Move matching types to matcher.go**: `Matcher` interface, `MatcherFunc` adapter, and `ExactMatcher` moved from `server.go` to `matcher.go` for discoverability alongside `CompositeMatcher`, `DefaultMatcher`, and all `MatchCriterion` functions.
- **Add doc.go**: Package-level documentation covering core types, recording, replay, storage, matching, and design principles.
- **Update stale ADR-3 references**: Added supersession notes in `decisions.md` where ADR-3 text referenced `ExactMatcher()` as the default (now `DefaultMatcher()` per ADR-4).
- **Update ExactMatcher godoc**: Reference `CompositeMatcher`/`DefaultMatcher` instead of "matchers from issue #30".

### Nits not addressed (rationale)
- **options.go consolidation**: Options remain co-located with their constructors for better discoverability (each option type is adjacent to the constructor it configures). This is arguably better than a separate file.
- **Recorder.onError nil vs no-op**: Functionally equivalent; the nil-check pattern is idiomatic Go.
- **Sanitizer placement**: Already correct per Go convention (interface at point of use). Will stay in recorder.go.
- **FileStore.List scan performance**: Not a Milestone 2 blocker; noted for future optimization.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -race` passes
- [x] `go vet ./...` clean
- [x] Nil-store test updated from runtime 500 check to panic recovery test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
