### PR TITLE
feat: add deterministic faking with HMAC-SHA256 (FakeFields)

### DIFF
--- a/sanitizer.go
+++ b/sanitizer.go
@@ -2,8 +2,13 @@ package httptape
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -315,4 +320,239 @@ func redactValue(v any) any {
 		// nil, map[string]any, []any -- leave unchanged.
 		return v
 	}
+}
+
+// FakeFields returns a SanitizeFunc that replaces field values in JSON
+// request and response bodies with deterministic fakes derived from
+// HMAC-SHA256.
+//
+// The seed is a project-level secret used as the HMAC key. The same seed
+// and input value always produce the same fake output, preserving
+// cross-fixture consistency. Different seeds produce different fakes.
+//
+// Paths use the same JSONPath-like syntax as RedactBodyPaths:
+//   - $.field             -- top-level field
+//   - $.nested.field      -- nested field access
+//   - $.array[*].field    -- field within each element of an array
+//
+// Faking strategies are determined by the detected type of each value:
+//   - Email (string with @): user_<hash>@example.com
+//   - UUID (8-4-4-4-12 hex): deterministic UUID v5
+//   - Number (float64): deterministic positive integer
+//   - Generic string: fake_<hash_prefix>
+//   - Booleans, nulls, objects, arrays: left unchanged
+//
+// If the body is not valid JSON, it is left unchanged (no error).
+// If a path does not match any field in the body, it is silently skipped.
+// Invalid or unsupported paths are silently ignored.
+//
+// The returned function does not mutate the input Tape -- it copies the
+// body byte slices before modification.
+//
+// Example:
+//
+//	sanitizer := NewPipeline(
+//	    RedactHeaders(),
+//	    FakeFields("my-project-seed",
+//	        "$.user.email",
+//	        "$.user.id",
+//	        "$.tokens[*].value",
+//	    ),
+//	)
+func FakeFields(seed string, paths ...string) SanitizeFunc {
+	// Parse all paths at construction time.
+	var parsed []parsedPath
+	for _, p := range paths {
+		if pp, ok := parsePath(p); ok {
+			parsed = append(parsed, pp)
+		}
+	}
+
+	return func(t Tape) Tape {
+		newReqBody := fakeBodyFields(t.Request.Body, parsed, seed)
+		if !bytes.Equal(newReqBody, t.Request.Body) {
+			t.Request.Body = newReqBody
+			t.Request.BodyHash = BodyHashFromBytes(newReqBody)
+		} else {
+			t.Request.Body = newReqBody
+		}
+		t.Response.Body = fakeBodyFields(t.Response.Body, parsed, seed)
+		return t
+	}
+}
+
+// fakeBodyFields unmarshals the body as JSON, applies all path-based
+// faking, and re-marshals the result. If the body is nil, empty, or
+// not valid JSON, it is returned unchanged.
+func fakeBodyFields(body []byte, paths []parsedPath, seed string) []byte {
+	if len(body) == 0 {
+		return body
+	}
+
+	var data any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return body
+	}
+
+	for _, p := range paths {
+		fakeAtPath(data, p.segments, seed)
+	}
+
+	result, err := json.Marshal(data)
+	if err != nil {
+		return body
+	}
+	return result
+}
+
+// fakeAtPath recursively traverses the JSON structure following the
+// given segments and replaces the leaf value with a deterministic fake.
+// It modifies the data in-place (caller must ensure data is a fresh
+// copy from json.Unmarshal).
+func fakeAtPath(data any, segments []segment, seed string) {
+	if len(segments) == 0 {
+		return
+	}
+
+	seg := segments[0]
+	rest := segments[1:]
+
+	obj, ok := data.(map[string]any)
+	if !ok {
+		return
+	}
+
+	val, exists := obj[seg.key]
+	if !exists {
+		return
+	}
+
+	if seg.wildcard {
+		arr, ok := val.([]any)
+		if !ok {
+			return
+		}
+		if len(rest) == 0 {
+			// Wildcard at leaf targets array elements (containers) -- skip.
+			return
+		}
+		for _, elem := range arr {
+			fakeAtPath(elem, rest, seed)
+		}
+		return
+	}
+
+	// Not a wildcard segment.
+	if len(rest) == 0 {
+		// Leaf: apply deterministic faking.
+		obj[seg.key] = fakeValue(val, seed)
+		return
+	}
+
+	// Intermediate: recurse deeper.
+	fakeAtPath(val, rest, seed)
+}
+
+// fakeValue returns a deterministic fake replacement for the given JSON
+// value. The fake is derived from the HMAC-SHA256 of the value's string
+// representation using the provided seed.
+//
+// Faking strategies:
+//   - Email string: user_<hash>@example.com
+//   - UUID string: deterministic UUID v5
+//   - float64: deterministic positive integer
+//   - Generic string: fake_<hash_prefix>
+//   - bool, nil, objects, arrays: returned unchanged
+func fakeValue(v any, seed string) any {
+	switch val := v.(type) {
+	case string:
+		h := computeHMAC(seed, val)
+		if isEmail(val) {
+			return fakeEmail(h)
+		}
+		if isUUID(val) {
+			return fakeUUID(h)
+		}
+		return fakeString(h)
+	case float64:
+		h := computeHMAC(seed, strconv.FormatFloat(val, 'f', -1, 64))
+		return fakeNumericID(h)
+	default:
+		// bool, nil, map[string]any, []any -- leave unchanged.
+		return v
+	}
+}
+
+// computeHMAC returns the HMAC-SHA256 of the given message using the
+// provided key. Both key and message are strings; the HMAC operates on
+// their UTF-8 byte representations.
+func computeHMAC(key, message string) []byte {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(message))
+	return mac.Sum(nil)
+}
+
+// isEmail returns true if s looks like an email address: contains exactly
+// one '@' with non-empty parts on both sides. This is a heuristic, not a
+// full RFC 5322 parser.
+func isEmail(s string) bool {
+	at := strings.IndexByte(s, '@')
+	return at > 0 && at < len(s)-1 && strings.Count(s, "@") == 1
+}
+
+// isUUID returns true if s matches the UUID format:
+// 8-4-4-4-12 hex characters separated by hyphens.
+func isUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, c := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// fakeEmail generates a deterministic fake email from the HMAC hash.
+// Format: user_<first 8 hex chars>@example.com
+func fakeEmail(hash []byte) string {
+	return "user_" + hex.EncodeToString(hash[:4]) + "@example.com"
+}
+
+// fakeUUID generates a deterministic UUID v5-style value from the HMAC hash.
+// It takes the first 16 bytes, sets version=5 and variant=RFC4122,
+// then formats as standard UUID string.
+func fakeUUID(hash []byte) string {
+	var buf [16]byte
+	copy(buf[:], hash[:16])
+	buf[6] = (buf[6] & 0x0f) | 0x50 // version 5
+	buf[8] = (buf[8] & 0x3f) | 0x80 // variant RFC 4122
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
+}
+
+// fakeNumericID generates a deterministic positive integer from the HMAC
+// hash. Uses the first 4 bytes interpreted as big-endian uint32, masked
+// to [1, 2^31-1] to ensure a positive non-zero int.
+func fakeNumericID(hash []byte) float64 {
+	n := uint32(hash[0])<<24 | uint32(hash[1])<<16 | uint32(hash[2])<<8 | uint32(hash[3])
+	n = n & 0x7FFFFFFF // clear sign bit: [0, 2^31-1]
+	if n == 0 {
+		n = 1 // avoid zero
+	}
+	return float64(n)
+}
+
+// fakeString generates a deterministic fake string from the HMAC hash.
+// Format: fake_<first 8 hex chars>
+func fakeString(hash []byte) string {
+	return "fake_" + hex.EncodeToString(hash[:4])
 }

--- a/sanitizer_test.go
+++ b/sanitizer_test.go
@@ -3,6 +3,7 @@ package httptape
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -815,5 +816,615 @@ func TestRedactBodyPaths_WildcardAtLeaf(t *testing.T) {
 	want := []byte(`{"items":[{"a":1},{"a":2}]}`)
 	if !jsonEqual(t, result.Request.Body, want) {
 		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+// --- FakeFields tests ---
+
+func TestFakeFields_GenericString(t *testing.T) {
+	body := []byte(`{"name":"Alice"}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.name")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	name, ok := got["name"].(string)
+	if !ok {
+		t.Fatal("name is not a string")
+	}
+	if !strings.HasPrefix(name, "fake_") {
+		t.Errorf("expected fake_ prefix, got %q", name)
+	}
+	if len(name) != 13 { // "fake_" (5) + 8 hex chars
+		t.Errorf("expected length 13, got %d (%q)", len(name), name)
+	}
+}
+
+func TestFakeFields_Email(t *testing.T) {
+	body := []byte(`{"email":"alice@corp.com"}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.email")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	email, ok := got["email"].(string)
+	if !ok {
+		t.Fatal("email is not a string")
+	}
+	if !strings.HasPrefix(email, "user_") {
+		t.Errorf("expected user_ prefix, got %q", email)
+	}
+	if !strings.HasSuffix(email, "@example.com") {
+		t.Errorf("expected @example.com suffix, got %q", email)
+	}
+}
+
+func TestFakeFields_UUID(t *testing.T) {
+	body := []byte(`{"id":"550e8400-e29b-41d4-a716-446655440000"}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.id")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	id, ok := got["id"].(string)
+	if !ok {
+		t.Fatal("id is not a string")
+	}
+	if len(id) != 36 {
+		t.Errorf("expected UUID length 36, got %d (%q)", len(id), id)
+	}
+	// Check version nibble is 5.
+	if id[14] != '5' {
+		t.Errorf("expected version 5 at position 14, got %c in %q", id[14], id)
+	}
+	// Check hyphens at correct positions.
+	for _, pos := range []int{8, 13, 18, 23} {
+		if id[pos] != '-' {
+			t.Errorf("expected '-' at position %d, got %c in %q", pos, id[pos], id)
+		}
+	}
+}
+
+func TestFakeFields_NumericID(t *testing.T) {
+	body := []byte(`{"user_id":42}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.user_id")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	uid, ok := got["user_id"].(float64)
+	if !ok {
+		t.Fatal("user_id is not a number")
+	}
+	if uid <= 0 {
+		t.Errorf("expected positive number, got %f", uid)
+	}
+	if uid != float64(int64(uid)) {
+		t.Errorf("expected integer, got %f", uid)
+	}
+	if uid > float64(1<<31-1) {
+		t.Errorf("expected value <= 2^31-1, got %f", uid)
+	}
+}
+
+func TestFakeFields_BoolUnchanged(t *testing.T) {
+	body := []byte(`{"active":true}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.active")
+	result := fn(tape)
+
+	want := []byte(`{"active":true}`)
+	if !jsonEqual(t, result.Request.Body, want) {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+func TestFakeFields_NullUnchanged(t *testing.T) {
+	body := []byte(`{"token":null}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.token")
+	result := fn(tape)
+
+	want := []byte(`{"token":null}`)
+	if !jsonEqual(t, result.Request.Body, want) {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+func TestFakeFields_ObjectUnchanged(t *testing.T) {
+	body := []byte(`{"data":{"nested":"val"}}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.data")
+	result := fn(tape)
+
+	want := []byte(`{"data":{"nested":"val"}}`)
+	if !jsonEqual(t, result.Request.Body, want) {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+func TestFakeFields_ArrayUnchanged(t *testing.T) {
+	body := []byte(`{"items":[1,2]}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.items")
+	result := fn(tape)
+
+	want := []byte(`{"items":[1,2]}`)
+	if !jsonEqual(t, result.Request.Body, want) {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+func TestFakeFields_Deterministic(t *testing.T) {
+	body := []byte(`{"name":"Alice","email":"alice@corp.com","id":"550e8400-e29b-41d4-a716-446655440000","score":99}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.name", "$.email", "$.id", "$.score")
+
+	// Run twice and verify identical output.
+	result1 := fn(tape)
+	result2 := fn(tape)
+
+	if string(result1.Request.Body) != string(result2.Request.Body) {
+		t.Errorf("not deterministic:\nfirst:  %s\nsecond: %s", result1.Request.Body, result2.Request.Body)
+	}
+	if string(result1.Response.Body) != string(result2.Response.Body) {
+		t.Errorf("response not deterministic:\nfirst:  %s\nsecond: %s", result1.Response.Body, result2.Response.Body)
+	}
+}
+
+func TestFakeFields_CrossFixtureConsistency(t *testing.T) {
+	// Same value in two different fixtures should produce the same fake.
+	body1 := []byte(`{"email":"shared@corp.com","other":"a"}`)
+	body2 := []byte(`{"email":"shared@corp.com","other":"b"}`)
+	tape1 := makeTapeWithBody(body1, body1)
+	tape2 := makeTapeWithBody(body2, body2)
+
+	fn := FakeFields("test-seed", "$.email")
+
+	result1 := fn(tape1)
+	result2 := fn(tape2)
+
+	var got1, got2 map[string]any
+	if err := json.Unmarshal(result1.Request.Body, &got1); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := json.Unmarshal(result2.Request.Body, &got2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got1["email"] != got2["email"] {
+		t.Errorf("same email should produce same fake across fixtures: %q vs %q", got1["email"], got2["email"])
+	}
+}
+
+func TestFakeFields_DifferentSeedsDifferentOutput(t *testing.T) {
+	body := []byte(`{"name":"Alice"}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn1 := FakeFields("seed-a", "$.name")
+	fn2 := FakeFields("seed-b", "$.name")
+
+	result1 := fn1(tape)
+	result2 := fn2(tape)
+
+	if string(result1.Request.Body) == string(result2.Request.Body) {
+		t.Error("different seeds should produce different fakes")
+	}
+}
+
+func TestFakeFields_DifferentInputsDifferentOutput(t *testing.T) {
+	body1 := []byte(`{"name":"Alice"}`)
+	body2 := []byte(`{"name":"Bob"}`)
+	tape1 := makeTapeWithBody(body1, body1)
+	tape2 := makeTapeWithBody(body2, body2)
+
+	fn := FakeFields("test-seed", "$.name")
+
+	result1 := fn(tape1)
+	result2 := fn(tape2)
+
+	if string(result1.Request.Body) == string(result2.Request.Body) {
+		t.Error("different inputs should produce different fakes")
+	}
+}
+
+func TestFakeFields_NestedField(t *testing.T) {
+	body := []byte(`{"user":{"email":"a@b.c"}}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.user.email")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	user := got["user"].(map[string]any)
+	email := user["email"].(string)
+	if !strings.HasPrefix(email, "user_") || !strings.HasSuffix(email, "@example.com") {
+		t.Errorf("expected fake email, got %q", email)
+	}
+}
+
+func TestFakeFields_ArrayWildcard(t *testing.T) {
+	body := []byte(`{"users":[{"name":"Alice"},{"name":"Bob"}]}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.users[*].name")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	users := got["users"].([]any)
+	for i, u := range users {
+		name := u.(map[string]any)["name"].(string)
+		if !strings.HasPrefix(name, "fake_") {
+			t.Errorf("users[%d].name: expected fake_ prefix, got %q", i, name)
+		}
+	}
+	// Alice and Bob should produce different fakes.
+	name0 := users[0].(map[string]any)["name"].(string)
+	name1 := users[1].(map[string]any)["name"].(string)
+	if name0 == name1 {
+		t.Errorf("different names should produce different fakes: %q == %q", name0, name1)
+	}
+}
+
+func TestFakeFields_MultiplePaths(t *testing.T) {
+	body := []byte(`{"name":"Alice","email":"alice@corp.com"}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.name", "$.email")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	name := got["name"].(string)
+	email := got["email"].(string)
+	if !strings.HasPrefix(name, "fake_") {
+		t.Errorf("name: expected fake_ prefix, got %q", name)
+	}
+	if !strings.HasPrefix(email, "user_") {
+		t.Errorf("email: expected user_ prefix, got %q", email)
+	}
+}
+
+func TestFakeFields_MissingPath(t *testing.T) {
+	body := []byte(`{"foo":"bar"}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.nonexistent")
+	result := fn(tape)
+
+	want := []byte(`{"foo":"bar"}`)
+	if !jsonEqual(t, result.Request.Body, want) {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+func TestFakeFields_NonJSONBody(t *testing.T) {
+	body := []byte("plain text body")
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.field")
+	result := fn(tape)
+
+	if string(result.Request.Body) != "plain text body" {
+		t.Errorf("request body changed: got %q", result.Request.Body)
+	}
+}
+
+func TestFakeFields_NilBody(t *testing.T) {
+	tape := makeTapeWithBody(nil, nil)
+
+	fn := FakeFields("test-seed", "$.field")
+	result := fn(tape)
+
+	if result.Request.Body != nil {
+		t.Errorf("expected nil request body, got %v", result.Request.Body)
+	}
+	if result.Response.Body != nil {
+		t.Errorf("expected nil response body, got %v", result.Response.Body)
+	}
+}
+
+func TestFakeFields_EmptyBody(t *testing.T) {
+	tape := makeTapeWithBody([]byte{}, []byte{})
+
+	fn := FakeFields("test-seed", "$.field")
+	result := fn(tape)
+
+	if len(result.Request.Body) != 0 {
+		t.Errorf("expected empty request body, got %v", result.Request.Body)
+	}
+}
+
+func TestFakeFields_BothRequestAndResponse(t *testing.T) {
+	reqBody := []byte(`{"name":"req-name"}`)
+	respBody := []byte(`{"name":"resp-name"}`)
+	tape := makeTapeWithBody(reqBody, respBody)
+
+	fn := FakeFields("test-seed", "$.name")
+	result := fn(tape)
+
+	var reqGot, respGot map[string]any
+	if err := json.Unmarshal(result.Request.Body, &reqGot); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if err := json.Unmarshal(result.Response.Body, &respGot); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	reqName := reqGot["name"].(string)
+	respName := respGot["name"].(string)
+	if !strings.HasPrefix(reqName, "fake_") {
+		t.Errorf("request name: expected fake_ prefix, got %q", reqName)
+	}
+	if !strings.HasPrefix(respName, "fake_") {
+		t.Errorf("response name: expected fake_ prefix, got %q", respName)
+	}
+	// Different original values should produce different fakes.
+	if reqName == respName {
+		t.Errorf("different original values should produce different fakes: %q == %q", reqName, respName)
+	}
+}
+
+func TestFakeFields_DoesNotMutateOriginal(t *testing.T) {
+	body := []byte(`{"name":"Alice"}`)
+	original := make([]byte, len(body))
+	copy(original, body)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.name")
+	_ = fn(tape)
+
+	if string(tape.Request.Body) != string(original) {
+		t.Errorf("original request body mutated: got %q", tape.Request.Body)
+	}
+	if string(tape.Response.Body) != string(original) {
+		t.Errorf("original response body mutated: got %q", tape.Response.Body)
+	}
+}
+
+func TestFakeFields_BodyHashRecalculated(t *testing.T) {
+	body := []byte(`{"name":"Alice"}`)
+	tape := makeTapeWithBody(body, body)
+	originalHash := tape.Request.BodyHash
+
+	fn := FakeFields("test-seed", "$.name")
+	result := fn(tape)
+
+	if result.Request.BodyHash == originalHash {
+		t.Error("expected BodyHash to change after body faking")
+	}
+	expectedHash := BodyHashFromBytes(result.Request.Body)
+	if result.Request.BodyHash != expectedHash {
+		t.Errorf("BodyHash mismatch: got %q, want %q", result.Request.BodyHash, expectedHash)
+	}
+}
+
+func TestFakeFields_InvalidPath(t *testing.T) {
+	body := []byte(`{"a":"b"}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "foo.bar")
+	result := fn(tape)
+
+	want := []byte(`{"a":"b"}`)
+	if !jsonEqual(t, result.Request.Body, want) {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+func TestFakeFields_NoPaths(t *testing.T) {
+	body := []byte(`{"a":"b"}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed") // no paths => no-op
+	result := fn(tape)
+
+	want := []byte(`{"a":"b"}`)
+	if !jsonEqual(t, result.Request.Body, want) {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+func TestFakeFields_PipelineComposition(t *testing.T) {
+	body := []byte(`{"secret":"value","name":"Alice"}`)
+	tape := Tape{
+		ID:    "test-id",
+		Route: "test-route",
+		Request: RecordedReq{
+			Method:   "POST",
+			URL:      "https://example.com/test",
+			Headers:  http.Header{"Authorization": {"Bearer token"}, "Content-Type": {"application/json"}},
+			Body:     body,
+			BodyHash: BodyHashFromBytes(body),
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/json"}},
+			Body:       body,
+		},
+	}
+
+	p := NewPipeline(
+		RedactHeaders("Authorization"),
+		FakeFields("test-seed", "$.name"),
+	)
+	result := p.Sanitize(tape)
+
+	// Headers should be redacted.
+	if got := result.Request.Headers.Get("Authorization"); got != Redacted {
+		t.Errorf("Authorization: expected %q, got %q", Redacted, got)
+	}
+	// Name should be faked.
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	name := got["name"].(string)
+	if !strings.HasPrefix(name, "fake_") {
+		t.Errorf("name: expected fake_ prefix, got %q", name)
+	}
+	// Secret should be unchanged (not targeted).
+	if got["secret"] != "value" {
+		t.Errorf("secret should be unchanged, got %q", got["secret"])
+	}
+}
+
+func TestFakeFields_WildcardAtLeaf(t *testing.T) {
+	body := []byte(`{"items":[{"a":1},{"a":2}]}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.items[*]")
+	result := fn(tape)
+
+	want := []byte(`{"items":[{"a":1},{"a":2}]}`)
+	if !jsonEqual(t, result.Request.Body, want) {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, want)
+	}
+}
+
+// --- isEmail tests ---
+
+func TestIsEmail(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"alice@corp.com", true},
+		{"a@b", true},
+		{"user@example.com", true},
+		{"", false},
+		{"@", false},
+		{"@domain", false},
+		{"user@", false},
+		{"no-at-sign", false},
+		{"two@@ats", false},
+		{"a@b@c", false},
+	}
+	for _, tt := range tests {
+		got := isEmail(tt.input)
+		if got != tt.want {
+			t.Errorf("isEmail(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+// --- isUUID tests ---
+
+func TestIsUUID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"550e8400-e29b-41d4-a716-446655440000", true},
+		{"00000000-0000-0000-0000-000000000000", true},
+		{"ABCDEF01-2345-6789-abcd-ef0123456789", true},
+		{"", false},
+		{"not-a-uuid", false},
+		{"550e8400e29b41d4a716446655440000", false},   // no hyphens
+		{"550e8400-e29b-41d4-a716-44665544000", false}, // too short
+		{"550e8400-e29b-41d4-a716-4466554400000", false}, // too long
+		{"550e8400-e29b-41d4-a716-44665544000g", false},  // invalid hex char
+		{"550e8400+e29b-41d4-a716-446655440000", false},  // wrong separator
+	}
+	for _, tt := range tests {
+		got := isUUID(tt.input)
+		if got != tt.want {
+			t.Errorf("isUUID(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFakeFields_FloatNumber(t *testing.T) {
+	body := []byte(`{"price":3.14}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.price")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	price, ok := got["price"].(float64)
+	if !ok {
+		t.Fatal("price is not a number")
+	}
+	if price <= 0 {
+		t.Errorf("expected positive number, got %f", price)
+	}
+	// Must be an integer (fakeNumericID always returns integers).
+	if price != float64(int64(price)) {
+		t.Errorf("expected integer, got %f", price)
+	}
+}
+
+func TestFakeFields_ScalarBody(t *testing.T) {
+	body := []byte(`"hello"`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.field")
+	result := fn(tape)
+
+	if string(result.Request.Body) != `"hello"` {
+		t.Errorf("request body: got %s, want %s", result.Request.Body, `"hello"`)
+	}
+}
+
+func TestFakeFields_DeepNested(t *testing.T) {
+	body := []byte(`{"a":{"b":{"c":"secret"}}}`)
+	tape := makeTapeWithBody(body, body)
+
+	fn := FakeFields("test-seed", "$.a.b.c")
+	result := fn(tape)
+
+	var got map[string]any
+	if err := json.Unmarshal(result.Request.Body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	c := got["a"].(map[string]any)["b"].(map[string]any)["c"].(string)
+	if !strings.HasPrefix(c, "fake_") {
+		t.Errorf("expected fake_ prefix, got %q", c)
+	}
+}
+
+func TestFakeFields_BodyHashUnchangedForNonJSON(t *testing.T) {
+	body := []byte("not json")
+	tape := makeTapeWithBody(body, body)
+	originalHash := tape.Request.BodyHash
+
+	fn := FakeFields("test-seed", "$.field")
+	result := fn(tape)
+
+	if result.Request.BodyHash != originalHash {
+		t.Errorf("BodyHash should not change for non-JSON body: got %q, want %q",
+			result.Request.BodyHash, originalHash)
 	}
 }


### PR DESCRIPTION
## Summary

- Implements ADR-7: `FakeFields(seed string, paths ...string) SanitizeFunc` for deterministic body field faking using HMAC-SHA256
- Type-aware faking: email -> `user_<hex8>@example.com`, UUID -> deterministic UUID v5, numeric -> positive integer, generic string -> `fake_<hex8>`, booleans/nulls/objects/arrays unchanged
- Reuses path parsing infrastructure (`parsePath`, `parsedPath`, `segment`) from `RedactBodyPaths`
- stdlib only: `crypto/hmac`, `crypto/sha256`, `encoding/hex`, `strconv`, `fmt`

## Implementation

All code added to `sanitizer.go` (no new files):
- `FakeFields` -- public constructor returning `SanitizeFunc`
- `fakeBodyFields`, `fakeAtPath` -- mirror `redactBodyFields`/`redactAtPath` pattern
- `fakeValue` -- dispatcher with type detection
- `computeHMAC` -- HMAC-SHA256 helper
- `isEmail`, `isUUID` -- type detection heuristics
- `fakeEmail`, `fakeUUID`, `fakeNumericID`, `fakeString` -- type-specific fakers

## Test plan

- [x] Generic string faking (fake_ prefix, correct length)
- [x] Email detection and faking (user_*@example.com)
- [x] UUID detection and faking (version 5, correct format)
- [x] Numeric ID faking (positive integer in range)
- [x] Booleans, nulls, objects, arrays left unchanged
- [x] Determinism: same input + seed = same output across calls
- [x] Cross-fixture consistency: same value in different tapes = same fake
- [x] Different seeds produce different fakes
- [x] Different inputs produce different fakes
- [x] Nested fields, array wildcards, multiple paths
- [x] Missing paths, invalid paths, non-JSON bodies, nil/empty bodies
- [x] Does not mutate original tape
- [x] BodyHash recalculated on change
- [x] Pipeline composition with RedactHeaders
- [x] `isEmail` and `isUUID` unit tests
- [x] `go test ./... -race` passes
- [x] `go vet ./...` clean

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)