### PR TITLE
feat: add MatchBodyFuzzy criterion for field-level body matching

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -2,10 +2,12 @@ package httptape
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"regexp"
 )
 
@@ -329,6 +331,158 @@ func headerContains(h http.Header, canonicalKey, value string) bool {
 		}
 	}
 	return false
+}
+
+// MatchBodyFuzzy returns a MatchCriterion that compares specific fields in
+// the JSON request body between the incoming request and the candidate tape.
+// Only the fields at the specified paths are compared; all other fields are
+// ignored. This is useful when request bodies contain volatile fields
+// (timestamps, nonces, request IDs) that vary per invocation.
+//
+// Paths use the same JSONPath-like syntax as RedactBodyPaths and FakeFields:
+//   - $.field             -- top-level field
+//   - $.nested.field      -- nested field access
+//   - $.array[*].field    -- field within each element of an array
+//
+// Matching semantics:
+//   - Both bodies are unmarshaled as JSON. If either body is not valid JSON,
+//     the criterion returns 0 (no match).
+//   - For each specified path, the value is extracted from both the request
+//     and the tape body. If a path does not exist in both bodies, it is
+//     skipped (does not cause a mismatch).
+//   - If a path exists in both bodies, the extracted values must be
+//     deeply equal (compared via reflect.DeepEqual on the unmarshaled
+//     any values). If any compared field differs, the criterion returns 0.
+//   - If no paths are provided, or no paths match fields present in both
+//     bodies, the criterion returns 0 (no match — nothing to compare means
+//     no evidence of a match).
+//   - If at least one path matched and all matched fields are equal, the
+//     criterion returns its score.
+//
+// The request body is read fully, then restored (replaced with a new reader
+// over the same bytes) so subsequent criteria can read it again.
+//
+// Invalid or unsupported paths are silently ignored (same as RedactBodyPaths).
+//
+// Returns score 6 on match, 0 on mismatch.
+//
+// Note: using both MatchBodyFuzzy and MatchBodyHash in the same
+// CompositeMatcher is safe but semantically redundant. If MatchBodyHash
+// passes (exact match), MatchBodyFuzzy will also pass. If MatchBodyHash
+// fails, the candidate is already eliminated. Choose one or the other.
+//
+// Example:
+//
+//	matcher := NewCompositeMatcher(
+//	    MatchMethod(),
+//	    MatchPath(),
+//	    MatchBodyFuzzy("$.action", "$.user.id", "$.items[*].sku"),
+//	)
+func MatchBodyFuzzy(paths ...string) MatchCriterion {
+	// Parse all paths at construction time (reuses parsePath from sanitizer.go).
+	var parsed []parsedPath
+	for _, p := range paths {
+		if pp, ok := parsePath(p); ok {
+			parsed = append(parsed, pp)
+		}
+	}
+
+	return func(req *http.Request, candidate Tape) int {
+		if len(parsed) == 0 {
+			return 0
+		}
+
+		// Read and restore the incoming request body.
+		var reqBody []byte
+		if req.Body != nil {
+			bodyBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				return 0
+			}
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			reqBody = bodyBytes
+		}
+
+		// Unmarshal both bodies.
+		var reqData, tapeData any
+		if err := json.Unmarshal(reqBody, &reqData); err != nil {
+			return 0
+		}
+		if err := json.Unmarshal(candidate.Request.Body, &tapeData); err != nil {
+			return 0
+		}
+
+		// Compare specified fields.
+		matched := 0
+		for _, p := range parsed {
+			reqVal, reqOk := extractAtPath(reqData, p.segments)
+			tapeVal, tapeOk := extractAtPath(tapeData, p.segments)
+
+			if !reqOk || !tapeOk {
+				// Path doesn't exist in one or both — skip, not a mismatch.
+				continue
+			}
+
+			if !reflect.DeepEqual(reqVal, tapeVal) {
+				return 0 // field exists in both but values differ — eliminate.
+			}
+			matched++
+		}
+
+		if matched == 0 {
+			return 0 // no fields compared — no evidence of match.
+		}
+		return 6
+	}
+}
+
+// extractAtPath traverses the JSON structure following the given segments
+// and returns the value at the leaf. Returns (value, true) if the path
+// exists, or (nil, false) if any segment is missing or the structure does
+// not match (e.g., expected object but found array).
+//
+// For wildcard segments (array[*].field), it collects the matching values
+// from all array elements into a []any slice and returns that.
+func extractAtPath(data any, segments []segment) (any, bool) {
+	if len(segments) == 0 {
+		return data, true
+	}
+
+	seg := segments[0]
+	rest := segments[1:]
+
+	obj, ok := data.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	val, exists := obj[seg.key]
+	if !exists {
+		return nil, false
+	}
+
+	if seg.wildcard {
+		arr, ok := val.([]any)
+		if !ok {
+			return nil, false
+		}
+		if len(rest) == 0 {
+			// Wildcard at leaf: return the array itself.
+			return arr, true
+		}
+		// Collect values from each element.
+		collected := make([]any, 0, len(arr))
+		for _, elem := range arr {
+			v, ok := extractAtPath(elem, rest)
+			if !ok {
+				return nil, false // all-or-nothing for arrays
+			}
+			collected = append(collected, v)
+		}
+		return collected, true
+	}
+
+	return extractAtPath(val, rest)
 }
 
 // stringSlicesEqual reports whether two string slices contain the same elements

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -1009,6 +1010,488 @@ func TestCompositeMatcher_ExactBeatsRegex(t *testing.T) {
 	if exactPathScore <= regexPathScore {
 		t.Errorf("MatchPath score (%d) should be greater than MatchPathRegex score (%d)",
 			exactPathScore, regexPathScore)
+	}
+}
+
+// --- MatchBodyFuzzy tests ---
+
+func TestMatchBodyFuzzy_SingleField(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create","timestamp":"2026-01-01T00:00:00Z"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create","timestamp":"2025-06-15T12:00:00Z"}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_MultipleFields(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action", "$.user")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create","user":"alice","nonce":"abc123"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create","user":"alice","nonce":"xyz789"}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_NestedField(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.user.id")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"user":{"id":42,"session":"s1"}}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"user":{"id":42,"session":"s2"}}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() nested = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_ArrayWildcard(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.items[*].sku")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"items":[{"sku":"A1","qty":5},{"sku":"B2","qty":3}]}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"items":[{"sku":"A1","qty":10},{"sku":"B2","qty":7}]}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() array wildcard = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_FieldValueDiffers(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"delete"}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() mismatch = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_NonJSONRequestBody(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader("not json"))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create"}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() non-JSON request = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_NonJSONTapeBody(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte("not json"),
+	}}
+
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() non-JSON tape = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_EmptyPaths(t *testing.T) {
+	criterion := MatchBodyFuzzy()
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create"}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() empty paths = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_PathInRequestNotInTape(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action", "$.extra")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create","extra":"value"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create"}`),
+	}}
+
+	// "extra" is skipped (not in tape), "action" matches => score 6
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() path in req not tape = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_PathInTapeNotInRequest(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action", "$.extra")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create","extra":"value"}`),
+	}}
+
+	// "extra" is skipped (not in request), "action" matches => score 6
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() path in tape not req = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_BothBodiesEmpty(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action")
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	tape := Tape{Request: RecordedReq{Body: nil}}
+
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() both empty = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_InvalidPaths(t *testing.T) {
+	// All paths invalid => parsed list is empty => returns 0
+	criterion := MatchBodyFuzzy("not-a-path", "also-bad")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create"}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() invalid paths = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_AllPathsMissing(t *testing.T) {
+	// Valid paths but none exist in either body => matched=0 => returns 0
+	criterion := MatchBodyFuzzy("$.nonexistent")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"action":"create"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create"}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() all paths missing = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_BodyRestored(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action")
+
+	body := `{"action":"create"}`
+	req := httptest.NewRequest("POST", "/test", strings.NewReader(body))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"action":"create"}`),
+	}}
+
+	criterion(req, tape)
+
+	// Body should be restored for subsequent reads.
+	restored, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading restored body: %v", err)
+	}
+	if string(restored) != body {
+		t.Errorf("restored body = %q, want %q", string(restored), body)
+	}
+}
+
+func TestMatchBodyFuzzy_DeepNestedObject(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.a.b.c")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"a":{"b":{"c":"deep"}}}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"a":{"b":{"c":"deep"}}}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() deep nested = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_NumericValue(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.count")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"count":42}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"count":42}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() numeric = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_BooleanValue(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.active")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"active":true}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"active":true}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() boolean = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_NullValue(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.data")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"data":null}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"data":null}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() null = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_ObjectValue(t *testing.T) {
+	// Comparing an entire nested object
+	criterion := MatchBodyFuzzy("$.config")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"config":{"retries":3,"timeout":30},"id":"abc"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"config":{"retries":3,"timeout":30},"id":"xyz"}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 6 {
+		t.Errorf("MatchBodyFuzzy() object value = %d, want 6", got)
+	}
+}
+
+func TestMatchBodyFuzzy_ArrayWildcard_DifferentValues(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.items[*].sku")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"items":[{"sku":"A1"},{"sku":"B2"}]}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"items":[{"sku":"A1"},{"sku":"C3"}]}`),
+	}}
+
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() array wildcard mismatch = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_ArrayWildcard_DifferentLengths(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.items[*].sku")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"items":[{"sku":"A1"},{"sku":"B2"}]}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"items":[{"sku":"A1"}]}`),
+	}}
+
+	// Different array lengths produce different collected slices
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() array different lengths = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_Composability(t *testing.T) {
+	m := NewCompositeMatcher(
+		MatchMethod(),
+		MatchPath(),
+		MatchBodyFuzzy("$.action"),
+	)
+
+	candidates := []Tape{
+		{
+			ID: "create",
+			Request: RecordedReq{
+				Method: "POST",
+				URL:    "/api/do",
+				Body:   []byte(`{"action":"create","ts":"2025-01-01"}`),
+			},
+		},
+		{
+			ID: "delete",
+			Request: RecordedReq{
+				Method: "POST",
+				URL:    "/api/do",
+				Body:   []byte(`{"action":"delete","ts":"2025-02-01"}`),
+			},
+		},
+	}
+
+	req := httptest.NewRequest("POST", "/api/do",
+		strings.NewReader(`{"action":"delete","ts":"2026-03-30"}`))
+	tape, ok := m.Match(req, candidates)
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if tape.ID != "delete" {
+		t.Errorf("got tape ID=%s, want delete", tape.ID)
+	}
+}
+
+func TestMatchBodyFuzzy_WildcardNotArray(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.items[*].sku")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"items":"not-an-array"}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"items":"not-an-array"}`),
+	}}
+
+	// items is not an array, so path extraction fails => skipped => matched=0 => 0
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() wildcard not array = %d, want 0", got)
+	}
+}
+
+func TestMatchBodyFuzzy_WildcardMissingFieldInElement(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.items[*].sku")
+
+	req := httptest.NewRequest("POST", "/test",
+		strings.NewReader(`{"items":[{"sku":"A1"},{"name":"B2"}]}`))
+	tape := Tape{Request: RecordedReq{
+		Body: []byte(`{"items":[{"sku":"A1"},{"sku":"B2"}]}`),
+	}}
+
+	// Second element in request doesn't have "sku" => extractAtPath returns false (all-or-nothing)
+	got := criterion(req, tape)
+	if got != 0 {
+		t.Errorf("MatchBodyFuzzy() wildcard missing field = %d, want 0", got)
+	}
+}
+
+// --- extractAtPath tests ---
+
+func TestExtractAtPath_TopLevel(t *testing.T) {
+	data := map[string]any{"name": "alice"}
+	val, ok := extractAtPath(data, []segment{{key: "name"}})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if val != "alice" {
+		t.Errorf("got %v, want alice", val)
+	}
+}
+
+func TestExtractAtPath_Nested(t *testing.T) {
+	data := map[string]any{"user": map[string]any{"id": float64(42)}}
+	val, ok := extractAtPath(data, []segment{{key: "user"}, {key: "id"}})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if val != float64(42) {
+		t.Errorf("got %v, want 42", val)
+	}
+}
+
+func TestExtractAtPath_Missing(t *testing.T) {
+	data := map[string]any{"name": "alice"}
+	_, ok := extractAtPath(data, []segment{{key: "missing"}})
+	if ok {
+		t.Error("expected ok=false for missing key")
+	}
+}
+
+func TestExtractAtPath_NotObject(t *testing.T) {
+	data := "just a string"
+	_, ok := extractAtPath(data, []segment{{key: "field"}})
+	if ok {
+		t.Error("expected ok=false for non-object data")
+	}
+}
+
+func TestExtractAtPath_Wildcard(t *testing.T) {
+	data := map[string]any{
+		"items": []any{
+			map[string]any{"sku": "A1"},
+			map[string]any{"sku": "B2"},
+		},
+	}
+	val, ok := extractAtPath(data, []segment{
+		{key: "items", wildcard: true},
+		{key: "sku"},
+	})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	expected := []any{"A1", "B2"}
+	if !reflect.DeepEqual(val, expected) {
+		t.Errorf("got %v, want %v", val, expected)
+	}
+}
+
+func TestExtractAtPath_WildcardAtLeaf(t *testing.T) {
+	data := map[string]any{
+		"tags": []any{"go", "test"},
+	}
+	val, ok := extractAtPath(data, []segment{
+		{key: "tags", wildcard: true},
+	})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	expected := []any{"go", "test"}
+	if !reflect.DeepEqual(val, expected) {
+		t.Errorf("got %v, want %v", val, expected)
+	}
+}
+
+func TestExtractAtPath_EmptySegments(t *testing.T) {
+	data := map[string]any{"name": "alice"}
+	val, ok := extractAtPath(data, nil)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if !reflect.DeepEqual(val, data) {
+		t.Errorf("got %v, want %v", val, data)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Implements `MatchBodyFuzzy(paths ...string) MatchCriterion` per ADR-14 (#40)
- Compares specific JSON fields between incoming request body and candidate tape body, ignoring volatile fields (timestamps, nonces, request IDs)
- New `extractAtPath` helper reuses `parsePath`/`parsedPath`/`segment` from `sanitizer.go`
- Score 6 (between `MatchQueryParams`=4 and `MatchBodyHash`=8), `reflect.DeepEqual` comparison, graceful non-JSON handling

## Test plan

- [x] Match on single body field, ignoring other differences
- [x] Match on multiple body fields
- [x] Match on nested fields (`$.nested.field`)
- [x] Match on array element fields (`$.array[*].field`)
- [x] No match when a specified field value differs
- [x] Non-JSON body gracefully returns 0
- [x] Empty paths list returns 0
- [x] Path exists in request but not in tape (skipped, not mismatch)
- [x] Path exists in tape but not in request (skipped, not mismatch)
- [x] Both bodies empty returns 0
- [x] Invalid/unsupported paths silently ignored
- [x] Body restored after read for subsequent criteria
- [x] Composability with MatchMethod, MatchPath in CompositeMatcher
- [x] Deep nested objects, numeric/boolean/null values
- [x] Array wildcard edge cases (not array, missing field in element, different lengths)
- [x] `extractAtPath` unit tests (top-level, nested, missing, wildcard, leaf wildcard, empty segments)
- [x] `go build ./...`, `go test ./... -race`, `go vet ./...` all pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)