### PR TITLE
feat: fix Recorder TOCTOU race and add concurrency godocs

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -89,6 +89,9 @@ func WithSince(t time.Time) ExportOption {
 // in memory. The caller must read the reader to completion or cancel the
 // context to release resources.
 //
+// ExportBundle is safe for concurrent use — it is a stateless function.
+// Concurrent safety of the underlying Store is the Store's responsibility.
+//
 // Bundle layout:
 //
 //	manifest.json          — bundle metadata (see Manifest type)
@@ -197,6 +200,9 @@ func writeBundle(ctx context.Context, w io.Writer, tapes []Tape, cfg exportConfi
 
 // ImportBundle imports tapes from a tar.gz bundle into the given store.
 // The bundle must have been produced by ExportBundle (see Manifest for the format).
+//
+// ImportBundle is safe for concurrent use — it is a stateless function.
+// Concurrent safety of the underlying Store is the Store's responsibility.
 //
 // Merge strategy: fixtures in the bundle overwrite any existing fixtures with
 // the same ID in the store. Fixtures already in the store whose IDs are not

--- a/matcher.go
+++ b/matcher.go
@@ -230,6 +230,8 @@ func MatchBodyHash() MatchCriterion {
 // If no candidates survive all criteria, CompositeMatcher returns (Tape{}, false).
 // If multiple candidates have the same highest score, the first one in the
 // candidates slice wins (stable ordering).
+//
+// CompositeMatcher is safe for concurrent use — immutable after construction.
 type CompositeMatcher struct {
 	criteria []MatchCriterion
 }

--- a/race_test.go
+++ b/race_test.go
@@ -1,0 +1,262 @@
+package httptape
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestMemoryStore_ConcurrentSaveLoad exercises concurrent Save and Load
+// operations on MemoryStore under the race detector.
+func TestMemoryStore_ConcurrentSaveLoad(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	const n = 100
+
+	var wg sync.WaitGroup
+
+	// Concurrent saves.
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tape := makeTape("route", "GET", fmt.Sprintf("http://example.com/%d", i))
+			if err := store.Save(ctx, tape); err != nil {
+				t.Errorf("Save(%d) error: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Concurrent loads.
+	tapes, err := store.List(ctx, Filter{})
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	for _, tape := range tapes {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			if _, err := store.Load(ctx, id); err != nil {
+				t.Errorf("Load(%s) error: %v", id, err)
+			}
+		}(tape.ID)
+	}
+	wg.Wait()
+
+	// Concurrent mixed reads and writes.
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			tape := makeTape("mixed", "POST", fmt.Sprintf("http://example.com/mixed/%d", i))
+			_ = store.Save(ctx, tape)
+		}(i)
+		go func() {
+			defer wg.Done()
+			_, _ = store.List(ctx, Filter{})
+		}()
+	}
+	wg.Wait()
+}
+
+// TestFileStore_ConcurrentSaveLoad exercises concurrent Save and Load
+// operations on FileStore under the race detector.
+func TestFileStore_ConcurrentSaveLoad(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), "httptape-race-filestore-"+t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	store, err := NewFileStore(WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("NewFileStore() error: %v", err)
+	}
+
+	ctx := context.Background()
+	const n = 50
+
+	var wg sync.WaitGroup
+
+	// Concurrent saves.
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tape := makeTape("route", "GET", fmt.Sprintf("http://example.com/%d", i))
+			if err := store.Save(ctx, tape); err != nil {
+				t.Errorf("Save(%d) error: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Concurrent loads.
+	tapes, listErr := store.List(ctx, Filter{})
+	if listErr != nil {
+		t.Fatalf("List() error: %v", listErr)
+	}
+	for _, tape := range tapes {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			if _, err := store.Load(ctx, id); err != nil {
+				t.Errorf("Load(%s) error: %v", id, err)
+			}
+		}(tape.ID)
+	}
+	wg.Wait()
+
+	// Concurrent mixed reads and writes.
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			tape := makeTape("mixed", "POST", fmt.Sprintf("http://example.com/mixed/%d", i))
+			_ = store.Save(ctx, tape)
+		}(i)
+		go func() {
+			defer wg.Done()
+			_, _ = store.List(ctx, Filter{})
+		}()
+	}
+	wg.Wait()
+}
+
+// TestRecorder_ConcurrentRoundTrip exercises concurrent RoundTrip calls
+// followed by Close under the race detector, verifying the TOCTOU fix.
+func TestRecorder_ConcurrentRoundTrip(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer backend.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(backend.Client().Transport),
+		WithRoute("race-test"),
+		WithBufferSize(256),
+	)
+
+	const n = 100
+	var wg sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req, err := http.NewRequest("GET", backend.URL+fmt.Sprintf("/path/%d", i), nil)
+			if err != nil {
+				t.Errorf("NewRequest error: %v", err)
+				return
+			}
+			resp, err := rec.RoundTrip(req)
+			if err != nil {
+				t.Errorf("RoundTrip(%d) error: %v", i, err)
+				return
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}(i)
+	}
+	wg.Wait()
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+}
+
+// TestRecorder_ConcurrentRoundTripAndClose exercises the specific race between
+// RoundTrip and Close that the sendMu fix addresses.
+func TestRecorder_ConcurrentRoundTripAndClose(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer backend.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(backend.Client().Transport),
+		WithRoute("close-race"),
+		WithBufferSize(16),
+	)
+
+	const n = 50
+	var wg sync.WaitGroup
+
+	// Launch many concurrent RoundTrips.
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req, err := http.NewRequest("POST", backend.URL+"/api",
+				strings.NewReader(fmt.Sprintf(`{"i":%d}`, i)))
+			if err != nil {
+				t.Errorf("NewRequest error: %v", err)
+				return
+			}
+			resp, err := rec.RoundTrip(req)
+			if err != nil {
+				// Errors after close are acceptable.
+				return
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}(i)
+	}
+
+	// Close concurrently while RoundTrips are in flight.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rec.Close()
+	}()
+
+	wg.Wait()
+}
+
+// TestServer_ConcurrentServeHTTP exercises concurrent ServeHTTP calls
+// under the race detector.
+func TestServer_ConcurrentServeHTTP(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Pre-load some tapes.
+	for i := 0; i < 10; i++ {
+		tape := makeTape("server-race", "GET", fmt.Sprintf("/items/%d", i))
+		if err := store.Save(ctx, tape); err != nil {
+			t.Fatalf("Save() error: %v", err)
+		}
+	}
+
+	srv := NewServer(store)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	const n = 100
+	var wg sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			path := fmt.Sprintf("/items/%d", i%10)
+			resp, err := http.Get(ts.URL + path)
+			if err != nil {
+				t.Errorf("GET %s error: %v", path, err)
+				return
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}(i)
+	}
+	wg.Wait()
+}

--- a/recorder.go
+++ b/recorder.go
@@ -27,6 +27,10 @@ type Sanitizer interface {
 // By default, recording is asynchronous — tapes are sent to a buffered channel
 // and a background goroutine drains them to the store. Call Close to flush
 // pending recordings and release resources.
+//
+// Recorder is safe for concurrent use by multiple goroutines. RoundTrip may be
+// called from multiple goroutines simultaneously. Close must be called exactly
+// once when recording is complete.
 type Recorder struct {
 	transport http.RoundTripper // inner transport to delegate to
 	store     Store             // where to persist tapes
@@ -39,6 +43,7 @@ type Recorder struct {
 	onError   func(error)       // callback for async write errors; defaults to no-op
 
 	// async internals
+	sendMu    sync.Mutex   // coordinates closed-check-then-send with close-channel
 	closed    atomic.Bool  // set to true when Close is called; guards against send-on-closed-channel
 	tapeCh    chan Tape     // buffered channel for async mode
 	done      chan struct{} // closed when background goroutine exits
@@ -241,14 +246,21 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Persist the tape.
 	if r.async {
-		select {
-		case r.tapeCh <- tape:
-			// sent
-		default:
-			// channel full — drop tape, call onError if set
-			if r.onError != nil {
-				r.onError(fmt.Errorf("httptape: recorder buffer full, tape dropped"))
+		r.sendMu.Lock()
+		if r.closed.Load() {
+			r.sendMu.Unlock()
+			// recorder closed — drop tape silently
+		} else {
+			select {
+			case r.tapeCh <- tape:
+				// sent
+			default:
+				// channel full — drop tape, call onError if set
+				if r.onError != nil {
+					r.onError(fmt.Errorf("httptape: recorder buffer full, tape dropped"))
+				}
 			}
+			r.sendMu.Unlock()
 		}
 	} else {
 		saveErr := r.store.Save(req.Context(), tape)
@@ -270,8 +282,10 @@ func (r *Recorder) Close() error {
 		return nil
 	}
 	r.closeOnce.Do(func() {
+		r.sendMu.Lock()
 		r.closed.Store(true)
 		close(r.tapeCh)
+		r.sendMu.Unlock()
 		<-r.done
 	})
 	return nil

--- a/server.go
+++ b/server.go
@@ -9,7 +9,8 @@ import (
 // and writes the recorded response. If no match is found, it returns
 // a configurable fallback status code.
 //
-// Server is safe for concurrent use.
+// Server is safe for concurrent use by multiple goroutines. All fields are
+// immutable after construction.
 type Server struct {
 	store          Store
 	matcher        Matcher

--- a/store_file.go
+++ b/store_file.go
@@ -16,7 +16,11 @@ import (
 var ErrInvalidID = errors.New("httptape: invalid tape ID")
 
 // FileStore is a filesystem-backed Store implementation. Each tape is persisted
-// as a single JSON file. Safe for concurrent use within a single process.
+// as a single JSON file.
+//
+// FileStore is safe for concurrent use by multiple goroutines within a single
+// process. It is not safe for multi-process concurrent access to the same
+// directory.
 type FileStore struct {
 	dir string // base directory for fixtures
 	mu  sync.RWMutex

--- a/store_memory.go
+++ b/store_memory.go
@@ -7,8 +7,10 @@ import (
 	"sync"
 )
 
-// MemoryStore is an in-memory Store implementation. It is safe for concurrent use.
+// MemoryStore is an in-memory Store implementation.
 // Intended primarily for testing, but usable in production for ephemeral recordings.
+//
+// MemoryStore is safe for concurrent use by multiple goroutines.
 type MemoryStore struct {
 	mu    sync.RWMutex
 	tapes map[string]Tape // keyed by Tape.ID


### PR DESCRIPTION
## Summary

- **Fix Recorder TOCTOU race**: Added `sendMu sync.Mutex` to coordinate the closed-check-then-send sequence in `RoundTrip` with the close-channel sequence in `Close`, preventing panic from send-on-closed-channel
- **Add godoc concurrency guarantees**: All public types (MemoryStore, FileStore, Recorder, Server, Pipeline, CompositeMatcher, ExportBundle, ImportBundle) now document their concurrency contracts
- **Add concurrent race tests**: New `race_test.go` with tests for MemoryStore, FileStore, Recorder, and Server under concurrent access; all pass with `go test -race ./...`

Implements ADR-15 from #41.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all existing + new race tests)
- [x] `TestRecorder_ConcurrentRoundTripAndClose` specifically exercises the TOCTOU fix
- [x] No breaking API changes

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)