### PR TITLE
feat: error handling and edge cases (ADR-17)

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -40,7 +40,9 @@ type Recorder struct {
 	sampleRate float64          // 0.0–1.0; 1.0 = record everything
 	randFloat func() float64   // returns [0.0, 1.0); injectable for testing
 	bufSize   int               // channel buffer size (only used when async=true)
-	onError   func(error)       // callback for async write errors; defaults to no-op
+	onError       func(error)   // callback for async write errors; defaults to no-op
+	maxBodySize   int           // max body size in bytes; 0 = no limit
+	skipRedirects bool          // when true, skip recording 3xx responses
 
 	// async internals
 	sendMu    sync.Mutex   // coordinates closed-check-then-send with close-channel
@@ -120,6 +122,35 @@ func WithBufferSize(size int) RecorderOption {
 func WithOnError(fn func(error)) RecorderOption {
 	return func(r *Recorder) {
 		r.onError = fn
+	}
+}
+
+// WithMaxBodySize sets the maximum body size in bytes for both request and
+// response bodies. Bodies exceeding this size are truncated and the
+// Truncated flag is set on the recorded request/response.
+// A value of 0 means no limit (default).
+// Negative values are treated as 0 (no limit).
+func WithMaxBodySize(n int) RecorderOption {
+	return func(r *Recorder) {
+		if n < 0 {
+			n = 0
+		}
+		r.maxBodySize = n
+	}
+}
+
+// WithSkipRedirects controls whether intermediate redirect responses (3xx)
+// are skipped during recording. When true, 3xx responses are not recorded --
+// only the final non-redirect response is stored. When false (default),
+// all responses are recorded including redirects.
+//
+// This is useful when using an http.Client that follows redirects
+// automatically: each redirect hop produces a separate RoundTrip call to
+// the Recorder. With SkipRedirects(true), only the terminal response is
+// stored, keeping fixtures clean.
+func WithSkipRedirects(skip bool) RecorderOption {
+	return func(r *Recorder) {
+		r.skipRedirects = skip
 	}
 }
 
@@ -211,6 +242,11 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
+	// Skip redirect responses if configured.
+	if r.skipRedirects && resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return resp, nil
+	}
+
 	// Capture response body.
 	var respBody []byte
 	if resp.Body != nil {
@@ -225,18 +261,51 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
+	// Detect body encodings based on Content-Type headers.
+	reqBodyEncoding := detectBodyEncoding(req.Header.Get("Content-Type"))
+	respBodyEncoding := detectBodyEncoding(resp.Header.Get("Content-Type"))
+
+	// Apply body truncation if maxBodySize is set.
+	var reqTruncated, respTruncated bool
+	var reqOrigSize, respOrigSize int64
+
+	if r.maxBodySize > 0 {
+		if len(reqBody) > r.maxBodySize {
+			reqOrigSize = int64(len(reqBody))
+			reqBody = reqBody[:r.maxBodySize]
+			reqTruncated = true
+			if r.onError != nil {
+				r.onError(fmt.Errorf("httptape: request body truncated from %d to %d bytes", reqOrigSize, r.maxBodySize))
+			}
+		}
+		if len(respBody) > r.maxBodySize {
+			respOrigSize = int64(len(respBody))
+			respBody = respBody[:r.maxBodySize]
+			respTruncated = true
+			if r.onError != nil {
+				r.onError(fmt.Errorf("httptape: response body truncated from %d to %d bytes", respOrigSize, r.maxBodySize))
+			}
+		}
+	}
+
 	// Build the tape.
 	recordedReq := RecordedReq{
-		Method:   req.Method,
-		URL:      req.URL.String(),
-		Headers:  req.Header.Clone(),
-		Body:     reqBody,
-		BodyHash: BodyHashFromBytes(reqBody),
+		Method:           req.Method,
+		URL:              req.URL.String(),
+		Headers:          req.Header.Clone(),
+		Body:             reqBody,
+		BodyHash:         BodyHashFromBytes(reqBody),
+		BodyEncoding:     reqBodyEncoding,
+		Truncated:        reqTruncated,
+		OriginalBodySize: reqOrigSize,
 	}
 	recordedResp := RecordedResp{
-		StatusCode: resp.StatusCode,
-		Headers:    resp.Header.Clone(),
-		Body:       respBody,
+		StatusCode:       resp.StatusCode,
+		Headers:          resp.Header.Clone(),
+		Body:             respBody,
+		BodyEncoding:     respBodyEncoding,
+		Truncated:        respTruncated,
+		OriginalBodySize: respOrigSize,
 	}
 
 	tape := NewTape(r.route, recordedReq, recordedResp)

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -1373,3 +1373,495 @@ func BenchmarkRecorderRoundTrip_Sync(b *testing.B) {
 		})
 	}
 }
+
+// --- ADR-17: Edge case tests ---
+
+// TestDetectBodyEncoding verifies that detectBodyEncoding classifies
+// Content-Type headers into identity (text) vs base64 (binary).
+func TestDetectBodyEncoding(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        BodyEncoding
+	}{
+		{"empty", "", BodyEncodingIdentity},
+		{"text/plain", "text/plain", BodyEncodingIdentity},
+		{"text/html", "text/html; charset=utf-8", BodyEncodingIdentity},
+		{"application/json", "application/json", BodyEncodingIdentity},
+		{"json with charset", "application/json; charset=utf-8", BodyEncodingIdentity},
+		{"json suffix", "application/vnd.api+json", BodyEncodingIdentity},
+		{"application/xml", "application/xml", BodyEncodingIdentity},
+		{"xml suffix", "application/atom+xml", BodyEncodingIdentity},
+		{"image/png", "image/png", BodyEncodingBase64},
+		{"image/jpeg", "image/jpeg", BodyEncodingBase64},
+		{"audio/mpeg", "audio/mpeg", BodyEncodingBase64},
+		{"video/mp4", "video/mp4", BodyEncodingBase64},
+		{"octet-stream", "application/octet-stream", BodyEncodingBase64},
+		{"protobuf", "application/protobuf", BodyEncodingBase64},
+		{"grpc", "application/grpc", BodyEncodingBase64},
+		{"x-protobuf", "application/x-protobuf", BodyEncodingBase64},
+		{"unparseable", "///invalid", BodyEncodingIdentity},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectBodyEncoding(tt.contentType)
+			if got != tt.want {
+				t.Errorf("detectBodyEncoding(%q) = %q, want %q", tt.contentType, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecorder_BinaryBody verifies that binary response bodies are recorded
+// with BodyEncoding set to base64.
+func TestRecorder_BinaryBody(t *testing.T) {
+	binaryData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A} // PNG header
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(http.StatusOK)
+		w.Write(binaryData)
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithRoute("binary-test"),
+		WithAsync(false),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/image.png", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+
+	tape := tapes[0]
+	if tape.Response.BodyEncoding != BodyEncodingBase64 {
+		t.Errorf("response BodyEncoding = %q, want %q", tape.Response.BodyEncoding, BodyEncodingBase64)
+	}
+	if !bytes.Equal(tape.Response.Body, binaryData) {
+		t.Error("binary body not preserved correctly")
+	}
+}
+
+// TestRecorder_TextBody verifies that text response bodies get BodyEncodingIdentity.
+func TestRecorder_TextBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithAsync(false),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+	if tapes[0].Response.BodyEncoding != BodyEncodingIdentity {
+		t.Errorf("response BodyEncoding = %q, want %q", tapes[0].Response.BodyEncoding, BodyEncodingIdentity)
+	}
+}
+
+// TestRecorder_MaxBodySize_Truncation verifies that bodies exceeding
+// the max size are truncated and metadata is set.
+func TestRecorder_MaxBodySize_Truncation(t *testing.T) {
+	largeBody := bytes.Repeat([]byte("A"), 2000)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write(largeBody)
+	}))
+	defer srv.Close()
+
+	var warnings []string
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithMaxBodySize(500),
+		WithAsync(false),
+		WithOnError(func(err error) {
+			warnings = append(warnings, err.Error())
+		}),
+	)
+
+	reqBody := bytes.Repeat([]byte("B"), 1000)
+	req, _ := http.NewRequest("POST", srv.URL+"/upload", io.NopCloser(bytes.NewReader(reqBody)))
+	req.Header.Set("Content-Type", "text/plain")
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+
+	tape := tapes[0]
+
+	// Request body should be truncated.
+	if !tape.Request.Truncated {
+		t.Error("request Truncated should be true")
+	}
+	if tape.Request.OriginalBodySize != 1000 {
+		t.Errorf("request OriginalBodySize = %d, want 1000", tape.Request.OriginalBodySize)
+	}
+	if len(tape.Request.Body) != 500 {
+		t.Errorf("request body len = %d, want 500", len(tape.Request.Body))
+	}
+
+	// Response body should be truncated.
+	if !tape.Response.Truncated {
+		t.Error("response Truncated should be true")
+	}
+	if tape.Response.OriginalBodySize != 2000 {
+		t.Errorf("response OriginalBodySize = %d, want 2000", tape.Response.OriginalBodySize)
+	}
+	if len(tape.Response.Body) != 500 {
+		t.Errorf("response body len = %d, want 500", len(tape.Response.Body))
+	}
+
+	// BodyHash should be computed on truncated body.
+	expectedHash := BodyHashFromBytes(tape.Request.Body)
+	if tape.Request.BodyHash != expectedHash {
+		t.Errorf("request BodyHash does not match truncated body hash")
+	}
+
+	// Warnings should be emitted.
+	if len(warnings) != 2 {
+		t.Errorf("expected 2 warnings, got %d: %v", len(warnings), warnings)
+	}
+}
+
+// TestRecorder_MaxBodySize_NoTruncation verifies that bodies within the
+// limit are not truncated.
+func TestRecorder_MaxBodySize_NoTruncation(t *testing.T) {
+	smallBody := []byte("small")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write(smallBody)
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithMaxBodySize(1000),
+		WithAsync(false),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/small", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+
+	tape := tapes[0]
+	if tape.Response.Truncated {
+		t.Error("response should not be truncated")
+	}
+	if tape.Response.OriginalBodySize != 0 {
+		t.Errorf("OriginalBodySize = %d, want 0", tape.Response.OriginalBodySize)
+	}
+}
+
+// TestRecorder_MaxBodySize_Zero verifies that maxBodySize=0 means no limit.
+func TestRecorder_MaxBodySize_Zero(t *testing.T) {
+	largeBody := bytes.Repeat([]byte("X"), 10000)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(largeBody)
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithMaxBodySize(0),
+		WithAsync(false),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/big", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+	if len(tapes[0].Response.Body) != 10000 {
+		t.Errorf("body len = %d, want 10000", len(tapes[0].Response.Body))
+	}
+}
+
+// TestWithMaxBodySize_Negative verifies that negative maxBodySize is treated as 0.
+func TestWithMaxBodySize_Negative(t *testing.T) {
+	store := NewMemoryStore()
+	rec := NewRecorder(store, WithMaxBodySize(-100), WithAsync(false))
+	if rec.maxBodySize != 0 {
+		t.Errorf("maxBodySize = %d, want 0", rec.maxBodySize)
+	}
+}
+
+// TestRecorder_204NoContent verifies that recording a 204 response produces
+// a tape with empty body and correct status code.
+func TestRecorder_204NoContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithAsync(false),
+	)
+
+	req, _ := http.NewRequest("DELETE", srv.URL+"/resource", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+
+	tape := tapes[0]
+	if tape.Response.StatusCode != 204 {
+		t.Errorf("status code = %d, want 204", tape.Response.StatusCode)
+	}
+	if len(tape.Response.Body) != 0 {
+		t.Errorf("body should be empty, got %d bytes", len(tape.Response.Body))
+	}
+	if tape.Request.BodyHash != "" {
+		t.Errorf("request BodyHash should be empty for nil body, got %q", tape.Request.BodyHash)
+	}
+}
+
+// TestRecorder_204NoContent_ExplicitEmptyBody verifies that a 204 response
+// with an explicit empty body also records correctly.
+func TestRecorder_204NoContent_ExplicitEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+		w.Write([]byte{}) // explicit empty write
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithAsync(false),
+	)
+
+	req, _ := http.NewRequest("DELETE", srv.URL+"/resource", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+
+	tape := tapes[0]
+	if tape.Response.StatusCode != 204 {
+		t.Errorf("status code = %d, want 204", tape.Response.StatusCode)
+	}
+}
+
+// TestRecorder_SkipRedirects verifies that 3xx responses are not recorded
+// when skipRedirects is true.
+func TestRecorder_SkipRedirects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			w.Header().Set("Location", "/final")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("final response"))
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithSkipRedirects(true),
+		WithAsync(false),
+	)
+
+	// First call: redirect response (302) -- should be skipped.
+	req, _ := http.NewRequest("GET", srv.URL+"/redirect", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("expected 302, got %d", resp.StatusCode)
+	}
+
+	// Second call: final response (200) -- should be recorded.
+	req2, _ := http.NewRequest("GET", srv.URL+"/final", nil)
+	resp2, err := rec.RoundTrip(req2)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp2.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape (redirect skipped), got %d", len(tapes))
+	}
+	if tapes[0].Response.StatusCode != 200 {
+		t.Errorf("recorded tape status = %d, want 200", tapes[0].Response.StatusCode)
+	}
+}
+
+// TestRecorder_SkipRedirects_False verifies that 3xx responses are recorded
+// when skipRedirects is false (default).
+func TestRecorder_SkipRedirects_False(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/final")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithSkipRedirects(false),
+		WithAsync(false),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/old", nil)
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape (redirects recorded), got %d", len(tapes))
+	}
+	if tapes[0].Response.StatusCode != 301 {
+		t.Errorf("recorded tape status = %d, want 301", tapes[0].Response.StatusCode)
+	}
+}
+
+// TestRecorder_SkipRedirects_AllCodes verifies that all 3xx codes are skipped.
+func TestRecorder_SkipRedirects_AllCodes(t *testing.T) {
+	codes := []int{300, 301, 302, 303, 304, 307, 308}
+	for _, code := range codes {
+		t.Run(fmt.Sprintf("status_%d", code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", "/target")
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			store := NewMemoryStore()
+			rec := NewRecorder(store,
+				WithTransport(srv.Client().Transport),
+				WithSkipRedirects(true),
+				WithAsync(false),
+			)
+
+			req, _ := http.NewRequest("GET", srv.URL+"/test", nil)
+			resp, err := rec.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("RoundTrip error: %v", err)
+			}
+			resp.Body.Close()
+
+			tapes, _ := store.List(context.Background(), Filter{})
+			if len(tapes) != 0 {
+				t.Errorf("expected 0 tapes for status %d, got %d", code, len(tapes))
+			}
+		})
+	}
+}
+
+// TestRecorder_MalformedJSON verifies that malformed JSON bodies are
+// stored as raw bytes without error.
+func TestRecorder_MalformedJSON(t *testing.T) {
+	malformed := []byte(`{"broken: json}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(malformed)
+	}))
+	defer srv.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(srv.Client().Transport),
+		WithSanitizer(NewPipeline(RedactBodyPaths("$.secret"))),
+		WithAsync(false),
+	)
+
+	req, _ := http.NewRequest("POST", srv.URL+"/api", io.NopCloser(bytes.NewReader(malformed)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := rec.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+
+	// Body should be stored as-is (sanitizer skips malformed JSON).
+	if !bytes.Equal(tapes[0].Response.Body, malformed) {
+		t.Error("malformed JSON body was unexpectedly modified")
+	}
+	if !bytes.Equal(tapes[0].Request.Body, malformed) {
+		t.Error("malformed JSON request body was unexpectedly modified")
+	}
+}

--- a/sanitizer.go
+++ b/sanitizer.go
@@ -236,7 +236,9 @@ func RedactBodyPaths(paths ...string) SanitizeFunc {
 
 // redactBodyFields unmarshals the body as JSON, applies all path
 // redactions, and re-marshals the result. If the body is nil, empty,
-// or not valid JSON, it is returned unchanged.
+// or not valid JSON, it is returned unchanged. This is intentional:
+// malformed JSON bodies are stored as raw bytes and body-level
+// sanitization is silently skipped. See ADR-17.
 func redactBodyFields(body []byte, paths []parsedPath) []byte {
 	if len(body) == 0 {
 		return body
@@ -383,7 +385,9 @@ func FakeFields(seed string, paths ...string) SanitizeFunc {
 
 // fakeBodyFields unmarshals the body as JSON, applies all path-based
 // faking, and re-marshals the result. If the body is nil, empty, or
-// not valid JSON, it is returned unchanged.
+// not valid JSON, it is returned unchanged. This is intentional:
+// malformed JSON bodies are stored as raw bytes and body-level
+// sanitization is silently skipped. See ADR-17.
 func fakeBodyFields(body []byte, paths []parsedPath, seed string) []byte {
 	if len(body) == 0 {
 		return body

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package httptape
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -514,5 +515,95 @@ func TestExactMatcher(t *testing.T) {
 				t.Errorf("Match() status = %d, want %d", tape.Response.StatusCode, tt.wantStatus)
 			}
 		})
+	}
+}
+
+// --- ADR-17: Server edge case tests ---
+
+// TestServer_Replay204NoContent verifies that the server correctly replays
+// a 204 No Content response with empty body.
+func TestServer_Replay204NoContent(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "DELETE", "/resource/1", 204, "", nil)
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/resource/1", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 204 {
+		t.Errorf("status = %d, want 204", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body should be empty, got %d bytes: %q", rec.Body.Len(), rec.Body.String())
+	}
+}
+
+// TestServer_ReplayBinaryBody verifies that binary bodies are replayed correctly.
+func TestServer_ReplayBinaryBody(t *testing.T) {
+	binaryData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF}
+
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/image.png",
+	}, RecordedResp{
+		StatusCode:   200,
+		Headers:      http.Header{"Content-Type": {"image/png"}},
+		Body:         binaryData,
+		BodyEncoding: BodyEncodingBase64,
+	})
+	if err := store.Save(context.Background(), tape); err != nil {
+		t.Fatalf("save tape: %v", err)
+	}
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/image.png", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), binaryData) {
+		t.Error("binary body not replayed correctly")
+	}
+	if rec.Header().Get("Content-Type") != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", rec.Header().Get("Content-Type"))
+	}
+}
+
+// TestServer_ReplayTruncatedBody verifies that a truncated body is replayed as-is.
+func TestServer_ReplayTruncatedBody(t *testing.T) {
+	truncatedBody := []byte("partial content...")
+
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/large",
+	}, RecordedResp{
+		StatusCode:       200,
+		Headers:          http.Header{"Content-Type": {"text/plain"}},
+		Body:             truncatedBody,
+		Truncated:        true,
+		OriginalBodySize: 100000,
+	})
+	if err := store.Save(context.Background(), tape); err != nil {
+		t.Fatalf("save tape: %v", err)
+	}
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/large", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), truncatedBody) {
+		t.Errorf("truncated body not replayed correctly, got %q", rec.Body.String())
 	}
 }

--- a/tape.go
+++ b/tape.go
@@ -5,8 +5,24 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"mime"
 	"net/http"
+	"strings"
 	"time"
+)
+
+// BodyEncoding indicates how the body was encoded for storage.
+// "identity" means UTF-8 text stored as-is by JSON marshaling.
+// "base64" means binary content (Go's encoding/json handles this
+// transparently for []byte fields).
+type BodyEncoding string
+
+const (
+	// BodyEncodingIdentity indicates the body is UTF-8 text.
+	BodyEncodingIdentity BodyEncoding = "identity"
+	// BodyEncodingBase64 indicates the body is binary, base64-encoded by
+	// Go's encoding/json marshaler.
+	BodyEncodingBase64 BodyEncoding = "base64"
 )
 
 // Tape represents a single recorded HTTP interaction (request + response pair).
@@ -47,6 +63,18 @@ type RecordedReq struct {
 	// BodyHash is a hex-encoded SHA-256 hash of the original request body.
 	// Used for matching without comparing full bodies.
 	BodyHash string `json:"body_hash"`
+
+	// BodyEncoding describes how the body is encoded in the JSON fixture.
+	// Set automatically by the Recorder based on Content-Type detection.
+	BodyEncoding BodyEncoding `json:"body_encoding,omitempty"`
+
+	// Truncated is true if the body was truncated due to exceeding the
+	// configured maximum body size.
+	Truncated bool `json:"truncated,omitempty"`
+
+	// OriginalBodySize is the original body size in bytes before truncation.
+	// Only set when Truncated is true.
+	OriginalBodySize int64 `json:"original_body_size,omitempty"`
 }
 
 // RecordedResp captures the essential parts of an HTTP response for replay.
@@ -59,6 +87,18 @@ type RecordedResp struct {
 
 	// Body is the full response body bytes.
 	Body []byte `json:"body"`
+
+	// BodyEncoding describes how the body is encoded in the JSON fixture.
+	// Set automatically by the Recorder based on Content-Type detection.
+	BodyEncoding BodyEncoding `json:"body_encoding,omitempty"`
+
+	// Truncated is true if the body was truncated due to exceeding the
+	// configured maximum body size.
+	Truncated bool `json:"truncated,omitempty"`
+
+	// OriginalBodySize is the original body size in bytes before truncation.
+	// Only set when Truncated is true.
+	OriginalBodySize int64 `json:"original_body_size,omitempty"`
 }
 
 // NewTape creates a new Tape with a generated ID and the current UTC timestamp.
@@ -80,6 +120,34 @@ func BodyHashFromBytes(b []byte) string {
 	}
 	h := sha256.Sum256(b)
 	return hex.EncodeToString(h[:])
+}
+
+// detectBodyEncoding returns BodyEncodingBase64 if the Content-Type header
+// indicates a binary content type, otherwise BodyEncodingIdentity.
+// Binary types: image/*, audio/*, video/*, application/octet-stream,
+// application/protobuf, application/grpc, application/x-protobuf,
+// or any type with a non-text, non-json, non-xml primary type.
+func detectBodyEncoding(contentType string) BodyEncoding {
+	if contentType == "" {
+		return BodyEncodingIdentity
+	}
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+	if mediaType == "" {
+		return BodyEncodingIdentity
+	}
+	// Text types are identity.
+	if strings.HasPrefix(mediaType, "text/") {
+		return BodyEncodingIdentity
+	}
+	// JSON and XML are text-like.
+	if mediaType == "application/json" ||
+		strings.HasSuffix(mediaType, "+json") ||
+		mediaType == "application/xml" ||
+		strings.HasSuffix(mediaType, "+xml") {
+		return BodyEncodingIdentity
+	}
+	// Everything else is binary.
+	return BodyEncodingBase64
 }
 
 // newUUID generates a UUID v4 string using crypto/rand.


### PR DESCRIPTION
## Summary

Implements issue #43 per ADR-17 decisions:

- **Binary bodies**: New `BodyEncoding` type (`identity`/`base64`) on `RecordedReq` and `RecordedResp`, auto-detected from `Content-Type` via stdlib `mime.ParseMediaType`
- **Large bodies**: New `WithMaxBodySize(int)` recorder option; truncated bodies get `Truncated` and `OriginalBodySize` metadata fields, warnings via `onError`
- **Malformed JSON**: Documented existing sanitizer passthrough behavior with ADR-17 reference comments (no functional change)
- **Empty responses (204)**: Added verification tests confirming existing correct behavior
- **Redirect chains**: New `WithSkipRedirects(bool)` recorder option to filter 3xx responses before body capture

All new fields use `omitempty` for backward compatibility. Zero breaking changes, zero new external dependencies.

## Test plan

- [x] `TestDetectBodyEncoding` -- table-driven test for Content-Type classification
- [x] `TestRecorder_BinaryBody` -- binary PNG body recorded with `BodyEncodingBase64`
- [x] `TestRecorder_TextBody` -- JSON body recorded with `BodyEncodingIdentity`
- [x] `TestRecorder_MaxBodySize_Truncation` -- both req/resp truncated, metadata set, warnings emitted
- [x] `TestRecorder_MaxBodySize_NoTruncation` -- bodies within limit left intact
- [x] `TestRecorder_MaxBodySize_Zero` -- zero means no limit
- [x] `TestWithMaxBodySize_Negative` -- negative clamped to zero
- [x] `TestRecorder_204NoContent` -- nil body, status 204, empty hash
- [x] `TestRecorder_204NoContent_ExplicitEmptyBody` -- explicit empty write
- [x] `TestRecorder_SkipRedirects` -- 302 skipped, 200 recorded
- [x] `TestRecorder_SkipRedirects_False` -- default records 3xx
- [x] `TestRecorder_SkipRedirects_AllCodes` -- all 3xx codes (300-308) skipped
- [x] `TestRecorder_MalformedJSON` -- malformed body stored as-is through sanitizer
- [x] `TestServer_Replay204NoContent` -- replays 204 with empty body
- [x] `TestServer_ReplayBinaryBody` -- replays binary body bytes correctly
- [x] `TestServer_ReplayTruncatedBody` -- replays truncated body as-is
- [x] `go test ./... -race` passes
- [x] `go vet ./...` passes

Closes #43

Generated with [Claude Code](https://claude.com/claude-code)