### PR TITLE
feat: add LoadFixtures and LoadFixturesFS convenience functions

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -5630,3 +5630,114 @@ tree is unaffected, and users `go get` only what they need.
 - **Maintenance surface**: a new `go.mod` means a separate dependency
   update cadence. Dependabot or Renovate should be configured to cover
   `testcontainers/go.mod`.
+
+---
+
+### ADR-22: LoadFixtures convenience functions
+
+**Date**: 2026-03-30
+**Issue**: #91
+**Status**: Accepted
+
+#### Context
+
+Loading fixture files for test mocking currently requires multiple steps:
+creating a `FileStore` or `MemoryStore`, configuring it, and then the store
+is ready. For the most common use case — loading pre-existing fixture JSON
+files from a directory for replay — this boilerplate is repeated in every
+test file. The issue requests a one-liner convenience API.
+
+Two variants are needed:
+
+1. **Filesystem directory**: for tests that read fixtures from `testdata/`
+   at runtime. Returns a `*FileStore` pointing at the given directory.
+2. **`fs.FS` (embed.FS)**: for self-contained test binaries that embed
+   fixtures at compile time. Reads JSON files into a `*MemoryStore` since
+   `embed.FS` is read-only and `FileStore` requires a writable directory.
+
+Both functions must recursively walk the directory, decode every `.json`
+file as a `Tape`, and return a populated store ready for use with
+`NewServer`.
+
+#### Decision
+
+Add two exported convenience functions in a new file `fixtures.go`:
+
+```go
+// LoadFixtures creates a FileStore rooted at the given filesystem directory.
+// It validates that the directory exists and contains at least parseable JSON
+// tape files by performing a read-only scan. The returned FileStore points at
+// dir and is immediately usable with NewServer.
+//
+// All .json files in dir (non-recursive, matching FileStore's flat-directory
+// model) are validated as Tape JSON. Files that fail to parse cause an error
+// that includes the filename.
+func LoadFixtures(dir string) (*FileStore, error)
+
+// LoadFixturesFS reads all .json Tape files from the given fs.FS directory
+// (recursive walk) and returns a MemoryStore populated with the decoded tapes.
+// This is designed for use with embed.FS for self-contained test binaries.
+//
+// Files that fail to decode as a Tape cause an error that includes the
+// filename. The returned MemoryStore is immediately usable with NewServer.
+func LoadFixturesFS(fsys fs.FS, dir string) (*MemoryStore, error)
+```
+
+##### Design choices
+
+1. **Return concrete types, not `Store` interface**: `LoadFixtures` returns
+   `*FileStore` and `LoadFixturesFS` returns `*MemoryStore`. This follows
+   Go best practice of returning concrete types and accepting interfaces.
+   Callers who need `Store` can assign to a `Store` variable since both
+   types implement the interface.
+
+2. **`LoadFixtures` delegates to `NewFileStore`**: rather than duplicating
+   directory creation logic, `LoadFixtures` calls `NewFileStore` with
+   `WithDirectory(dir)` and then performs a validation scan. This keeps
+   `FileStore` as the single source of truth for filesystem operations.
+
+3. **`LoadFixturesFS` walks recursively**: since `fs.FS` is read-only and
+   there is no concern about accidentally writing to nested directories,
+   recursive walking is safe and useful for organizing fixtures in
+   subdirectories (e.g., by route or service).
+
+4. **`LoadFixtures` scans flat (non-recursive)**: this matches the existing
+   `FileStore.List` behavior which reads only the base directory. Introducing
+   recursive filesystem walking would be inconsistent with how `FileStore`
+   operates.
+
+5. **Validation on load**: both functions validate that every `.json` file
+   in scope is a valid `Tape`. This fails fast with a clear error including
+   the filename, rather than silently loading invalid data that would cause
+   confusing failures later during replay.
+
+6. **New file `fixtures.go`**: these are convenience wrappers that
+   orchestrate existing types (`FileStore`, `MemoryStore`). They don't
+   belong in `store_file.go` or `store_memory.go` because they span both.
+   A dedicated file keeps responsibilities clean.
+
+7. **No functional options**: these are convenience functions — the whole
+   point is minimal ceremony. Advanced users who need options can use
+   `NewFileStore` / `NewMemoryStore` directly.
+
+8. **Empty directory is not an error**: an empty directory produces an
+   empty store. This is a valid use case (e.g., a fresh test setup).
+
+##### File placement
+
+- `fixtures.go` — implementation
+- `fixtures_test.go` — table-driven tests covering: happy path, empty
+  directory, invalid JSON, nested directories (for `LoadFixturesFS`),
+  non-existent directory, `embed.FS`
+
+#### Consequences
+
+- **Reduced boilerplate**: the most common test setup is now a one-liner.
+- **No breaking changes**: these are purely additive new exports.
+- **stdlib only**: `fs.FS` and `io/fs` are stdlib. No new dependencies.
+- **Discoverability**: users searching for "fixtures" or "load" in godoc
+  will find these functions immediately.
+- **FileStore flat-directory limitation**: `LoadFixtures` does not support
+  nested directories, matching `FileStore`'s existing behavior. Users who
+  need recursive loading from the real filesystem can use
+  `LoadFixturesFS(os.DirFS(dir), ".")` as a workaround.

--- a/fixtures.go
+++ b/fixtures.go
@@ -1,0 +1,101 @@
+package httptape
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadFixtures creates a FileStore rooted at the given filesystem directory.
+// It validates that the directory exists and that all .json files in it are
+// valid Tape JSON. The returned FileStore is immediately usable with NewServer.
+//
+// Only the top-level directory is scanned (non-recursive), matching FileStore's
+// flat-directory model. Files that fail to parse as a Tape cause an error that
+// includes the filename. An empty directory produces an empty (but valid) store.
+func LoadFixtures(dir string) (*FileStore, error) {
+	// Verify the directory exists before creating a FileStore, since
+	// NewFileStore creates the directory if absent (MkdirAll). LoadFixtures
+	// is for loading existing fixtures, not creating new directories.
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("httptape: load fixtures: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("httptape: load fixtures: %s is not a directory", dir)
+	}
+
+	store, err := NewFileStore(WithDirectory(dir))
+	if err != nil {
+		return nil, fmt.Errorf("httptape: load fixtures: %w", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("httptape: load fixtures: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("httptape: load fixtures: read %s: %w", entry.Name(), err)
+		}
+
+		var tape Tape
+		if err := json.Unmarshal(data, &tape); err != nil {
+			return nil, fmt.Errorf("httptape: load fixtures: parse %s: %w", entry.Name(), err)
+		}
+	}
+
+	return store, nil
+}
+
+// LoadFixturesFS reads all .json Tape files from the given fs.FS directory
+// (recursive walk) and returns a MemoryStore populated with the decoded tapes.
+// This is designed for use with embed.FS for self-contained test binaries.
+//
+// Files that fail to decode as a Tape cause an error that includes the file
+// path. An empty directory produces an empty (but valid) store. The returned
+// MemoryStore is immediately usable with NewServer.
+func LoadFixturesFS(fsys fs.FS, dir string) (*MemoryStore, error) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	err := fs.WalkDir(fsys, dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("httptape: load fixtures fs: walk %s: %w", path, walkErr)
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".json") {
+			return nil
+		}
+
+		data, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return fmt.Errorf("httptape: load fixtures fs: read %s: %w", path, err)
+		}
+
+		var tape Tape
+		if err := json.Unmarshal(data, &tape); err != nil {
+			return fmt.Errorf("httptape: load fixtures fs: parse %s: %w", path, err)
+		}
+
+		if err := store.Save(ctx, tape); err != nil {
+			return fmt.Errorf("httptape: load fixtures fs: store %s: %w", path, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -1,0 +1,271 @@
+package httptape
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+// newTestTape creates a minimal valid Tape for testing.
+func newTestTape(id, route, method, url string) Tape {
+	return Tape{
+		ID:    id,
+		Route: route,
+		Request: RecordedReq{
+			Method: method,
+			URL:    url,
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+		},
+	}
+}
+
+func marshalTape(t *testing.T, tape Tape) []byte {
+	t.Helper()
+	data, err := json.MarshalIndent(tape, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal tape: %v", err)
+	}
+	return data
+}
+
+func TestLoadFixtures(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) string // returns dir path
+		wantErr bool
+		wantN   int // expected number of tapes (validated via List)
+	}{
+		{
+			name: "happy path with two tapes",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				tape1 := newTestTape("tape-1", "users", "GET", "/users")
+				tape2 := newTestTape("tape-2", "users", "POST", "/users")
+				os.WriteFile(filepath.Join(dir, "tape-1.json"), marshalTape(t, tape1), 0o644)
+				os.WriteFile(filepath.Join(dir, "tape-2.json"), marshalTape(t, tape2), 0o644)
+				return dir
+			},
+			wantN: 2,
+		},
+		{
+			name: "empty directory",
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			wantN: 0,
+		},
+		{
+			name: "non-json files are ignored",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				tape1 := newTestTape("tape-1", "users", "GET", "/users")
+				os.WriteFile(filepath.Join(dir, "tape-1.json"), marshalTape(t, tape1), 0o644)
+				os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not a tape"), 0o644)
+				os.WriteFile(filepath.Join(dir, "notes.md"), []byte("# notes"), 0o644)
+				return dir
+			},
+			wantN: 1,
+		},
+		{
+			name: "invalid json returns error",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{invalid json"), 0o644)
+				return dir
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-existent directory returns error",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "does-not-exist")
+			},
+			wantErr: true,
+		},
+		{
+			name: "subdirectories are ignored (flat scan)",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				tape1 := newTestTape("tape-1", "users", "GET", "/users")
+				os.WriteFile(filepath.Join(dir, "tape-1.json"), marshalTape(t, tape1), 0o644)
+				subdir := filepath.Join(dir, "subdir")
+				os.MkdirAll(subdir, 0o755)
+				tape2 := newTestTape("tape-2", "orders", "GET", "/orders")
+				os.WriteFile(filepath.Join(subdir, "tape-2.json"), marshalTape(t, tape2), 0o644)
+				return dir
+			},
+			wantN: 1, // only top-level tape
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setup(t)
+			store, err := LoadFixtures(dir)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			tapes, err := store.List(context.Background(), Filter{})
+			if err != nil {
+				t.Fatalf("list tapes: %v", err)
+			}
+			if len(tapes) != tt.wantN {
+				t.Errorf("got %d tapes, want %d", len(tapes), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestLoadFixturesFS(t *testing.T) {
+	tape1 := newTestTape("tape-1", "users", "GET", "/users")
+	tape2 := newTestTape("tape-2", "orders", "POST", "/orders")
+	tape3 := newTestTape("tape-3", "auth", "GET", "/auth/token")
+
+	tape1JSON := marshalTape(t, tape1)
+	tape2JSON := marshalTape(t, tape2)
+	tape3JSON := marshalTape(t, tape3)
+
+	tests := []struct {
+		name    string
+		fsys    fstest.MapFS
+		dir     string
+		wantErr bool
+		wantN   int
+	}{
+		{
+			name: "happy path with two tapes",
+			fsys: fstest.MapFS{
+				"fixtures/tape-1.json": &fstest.MapFile{Data: tape1JSON},
+				"fixtures/tape-2.json": &fstest.MapFile{Data: tape2JSON},
+			},
+			dir:   "fixtures",
+			wantN: 2,
+		},
+		{
+			name:  "empty directory",
+			fsys:  fstest.MapFS{"fixtures/placeholder": &fstest.MapFile{Data: []byte{}}},
+			dir:   "fixtures",
+			wantN: 0,
+		},
+		{
+			name: "recursive walk finds nested tapes",
+			fsys: fstest.MapFS{
+				"fixtures/tape-1.json":           &fstest.MapFile{Data: tape1JSON},
+				"fixtures/subdir/tape-2.json":    &fstest.MapFile{Data: tape2JSON},
+				"fixtures/deep/nest/tape-3.json": &fstest.MapFile{Data: tape3JSON},
+			},
+			dir:   "fixtures",
+			wantN: 3,
+		},
+		{
+			name: "non-json files are ignored",
+			fsys: fstest.MapFS{
+				"fixtures/tape-1.json": &fstest.MapFile{Data: tape1JSON},
+				"fixtures/readme.txt":  &fstest.MapFile{Data: []byte("not a tape")},
+			},
+			dir:   "fixtures",
+			wantN: 1,
+		},
+		{
+			name: "invalid json returns error with filename",
+			fsys: fstest.MapFS{
+				"fixtures/bad.json": &fstest.MapFile{Data: []byte("{invalid")},
+			},
+			dir:     "fixtures",
+			wantErr: true,
+		},
+		{
+			name:    "non-existent directory returns error",
+			fsys:    fstest.MapFS{},
+			dir:     "no-such-dir",
+			wantErr: true,
+		},
+		{
+			name: "root directory walk",
+			fsys: fstest.MapFS{
+				"tape-1.json": &fstest.MapFile{Data: tape1JSON},
+			},
+			dir:   ".",
+			wantN: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := LoadFixturesFS(tt.fsys, tt.dir)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			tapes, err := store.List(context.Background(), Filter{})
+			if err != nil {
+				t.Fatalf("list tapes: %v", err)
+			}
+			if len(tapes) != tt.wantN {
+				t.Errorf("got %d tapes, want %d", len(tapes), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestLoadFixturesFS_error_includes_filename(t *testing.T) {
+	fsys := fstest.MapFS{
+		"fixtures/good.json": &fstest.MapFile{
+			Data: marshalTape(t, newTestTape("good", "r", "GET", "/ok")),
+		},
+		"fixtures/broken.json": &fstest.MapFile{
+			Data: []byte("not valid json"),
+		},
+	}
+
+	_, err := LoadFixturesFS(fsys, "fixtures")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	errMsg := err.Error()
+	if !contains(errMsg, "broken.json") {
+		t.Errorf("error should mention filename 'broken.json', got: %s", errMsg)
+	}
+}
+
+func TestLoadFixtures_error_includes_filename(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "broken.json"), []byte("not valid json"), 0o644)
+
+	_, err := LoadFixtures(dir)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	errMsg := err.Error()
+	if !contains(errMsg, "broken.json") {
+		t.Errorf("error should mention filename 'broken.json', got: %s", errMsg)
+	}
+}
+
+// contains checks if s contains substr. Using a helper to avoid importing strings.
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Add `LoadFixtures(dir string) (*FileStore, error)` for loading fixture JSON files from a filesystem directory (flat scan matching FileStore behavior)
- Add `LoadFixturesFS(fsys fs.FS, dir string) (*MemoryStore, error)` for loading fixtures from `embed.FS` or any `fs.FS` (recursive walk into a MemoryStore)
- Include ADR-22 in decisions.md documenting the design rationale

Closes #91

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -race` passes (14 test cases across both functions)
- [x] `go vet ./...` passes
- [ ] Verify happy path: two tapes loaded from filesystem directory
- [ ] Verify empty directory produces empty store (not error)
- [ ] Verify invalid JSON returns error with filename included
- [ ] Verify non-existent directory returns error
- [ ] Verify subdirectories ignored by LoadFixtures (flat scan)
- [ ] Verify LoadFixturesFS walks recursively into nested dirs
- [ ] Verify non-JSON files are ignored by both functions
- [ ] Verify root directory walk with LoadFixturesFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)