### PR TITLE
feat(#94,#95,#96): add CORS support, latency simulation, and error simulation

### DIFF
--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -114,6 +114,9 @@ func runServe(args []string) error {
 	port := fs.Int("port", 8081, "Listen port")
 	fallbackStatus := fs.Int("fallback-status", 404, "HTTP status when no tape matches")
 	_ = fs.String("config", "", "Path to sanitization config JSON (accepted but not used by serve)")
+	cors := fs.Bool("cors", false, "Enable CORS headers (Access-Control-Allow-Origin: *)")
+	delay := fs.Duration("delay", 0, "Fixed delay before every response (e.g., 200ms, 1s)")
+	errorRate := fs.Float64("error-rate", 0, "Fraction of requests that return 500 (0.0-1.0)")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -129,7 +132,19 @@ func runServe(args []string) error {
 		return fmt.Errorf("create store: %w", err)
 	}
 
-	server := httptape.NewServer(store, httptape.WithFallbackStatus(*fallbackStatus))
+	var serverOpts []httptape.ServerOption
+	serverOpts = append(serverOpts, httptape.WithFallbackStatus(*fallbackStatus))
+	if *cors {
+		serverOpts = append(serverOpts, httptape.WithCORS())
+	}
+	if *delay > 0 {
+		serverOpts = append(serverOpts, httptape.WithDelay(*delay))
+	}
+	if *errorRate > 0 {
+		serverOpts = append(serverOpts, httptape.WithErrorRate(*errorRate))
+	}
+
+	server := httptape.NewServer(store, serverOpts...)
 
 	addr := fmt.Sprintf(":%d", *port)
 	httpServer := &http.Server{
@@ -166,6 +181,7 @@ func runRecord(args []string) error {
 	fixtures := fs.String("fixtures", "", "Path to fixture directory (required)")
 	configPath := fs.String("config", "", "Path to sanitization config JSON")
 	port := fs.Int("port", 8081, "Listen port")
+	cors := fs.Bool("cors", false, "Enable CORS headers (Access-Control-Allow-Origin: *)")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -218,10 +234,25 @@ func runRecord(args []string) error {
 		Transport: recorder,
 	}
 
+	var handler http.Handler = proxy
+	if *cors {
+		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With, Accept")
+			w.Header().Set("Access-Control-Max-Age", "86400")
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			proxy.ServeHTTP(w, r)
+		})
+	}
+
 	addr := fmt.Sprintf(":%d", *port)
 	httpServer := &http.Server{
 		Addr:    addr,
-		Handler: proxy,
+		Handler: handler,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/decisions.md
+++ b/decisions.md
@@ -5904,3 +5904,548 @@ func Binary(b []byte) Body  // no auto content type
 - **Limited matching**: stubs only support method + path matching. This is
   intentional — the DSL optimizes for the 80% case. Advanced users compose
   Tape + CompositeMatcher directly.
+
+
+### ADR-24: CORS support, latency simulation, and error simulation
+
+**Date**: 2026-03-30
+**Issues**: #94, #95, #96
+**Status**: Accepted
+
+#### Context
+
+Milestone 8 (UI-First Dev) focuses on making httptape a first-class mock
+backend for frontend development. Three related features are needed:
+
+1. **CORS support (#94)**: Browsers block cross-origin requests from the
+   frontend dev server (e.g., `localhost:3000`) to the httptape mock
+   (e.g., `localhost:3001`). Without CORS headers, httptape is unusable
+   for frontend development.
+
+2. **Latency simulation (#95)**: Real APIs have latency, but mock servers
+   respond instantly. Frontend developers cannot test loading states,
+   spinners, or timeout handling without simulated delay.
+
+3. **Error simulation (#96)**: Real APIs fail. Without error simulation,
+   error handling code paths (retry logic, error toasts, fallback UI)
+   go untested during development.
+
+All three features modify Server behavior, are opt-in via ServerOption
+functions, and need corresponding CLI flags. They are designed together
+to ensure consistent architecture and avoid conflicting middleware
+ordering.
+
+#### Decision
+
+Add three new ServerOption functions and corresponding CLI flags. All
+implementation goes in `server.go` with tests in `server_test.go`. CLI
+changes go in `cmd/httptape/main.go`.
+
+##### Middleware execution order
+
+When multiple features are enabled, they execute in this order within
+`ServeHTTP`:
+
+1. **CORS** (first) -- add CORS headers and handle OPTIONS preflight
+2. **Error simulation** (second) -- short-circuit with 500 before any work
+3. **Delay** (third) -- sleep before writing the real response
+4. **Normal replay** (last) -- existing match-and-respond logic
+
+This order is intentional:
+- CORS headers must be present even on error responses (browsers need them)
+- Error simulation should skip the delay (a simulated 500 returns fast)
+- Delay applies only to successful replay responses
+
+##### Feature 1: CORS support (#94)
+
+**New Server fields:**
+
+```go
+type Server struct {
+    // ... existing fields ...
+    cors bool // if true, add CORS headers to all responses
+}
+```
+
+**New ServerOption:**
+
+```go
+// WithCORS enables CORS headers on all responses. When enabled, the
+// server adds permissive CORS headers (Access-Control-Allow-Origin: *)
+// and handles OPTIONS preflight requests automatically with 204 No Content.
+//
+// This is intended for local development where the frontend dev server
+// (e.g., localhost:3000) calls the mock backend (e.g., localhost:3001).
+// It is opt-in only.
+func WithCORS() ServerOption {
+    return func(s *Server) { s.cors = true }
+}
+```
+
+**ServeHTTP changes:**
+
+At the top of `ServeHTTP`, before any other logic:
+
+```go
+// CORS: add headers to every response if enabled.
+if s.cors {
+    w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.Header().Set("Access-Control-Allow-Methods",
+        "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD")
+    w.Header().Set("Access-Control-Allow-Headers",
+        "Content-Type, Authorization, X-Requested-With, Accept")
+    w.Header().Set("Access-Control-Max-Age", "86400")
+
+    // Handle OPTIONS preflight: return 204 with CORS headers, no body.
+    if r.Method == http.MethodOptions {
+        w.WriteHeader(http.StatusNoContent)
+        return
+    }
+}
+```
+
+**CLI flag:**
+
+```go
+// In runServe:
+cors := fs.Bool("cors", false, "Enable CORS headers (Access-Control-Allow-Origin: *)")
+
+// When building ServerOptions:
+if *cors {
+    serverOpts = append(serverOpts, httptape.WithCORS())
+}
+```
+
+The `--cors` flag is also added to `runRecord` since the recording proxy
+may also serve a frontend during development.
+
+##### Feature 2: Latency simulation (#95)
+
+**New Server fields:**
+
+```go
+type Server struct {
+    // ... existing fields ...
+    delay time.Duration // fixed delay before every response; zero means no delay
+}
+```
+
+**New ServerOption:**
+
+```go
+// WithDelay adds a fixed delay before every response. The delay is
+// applied after matching but before writing the response. If the
+// request context is cancelled during the delay (e.g., client
+// disconnects), ServeHTTP returns immediately without writing.
+//
+// A zero or negative duration is a no-op.
+func WithDelay(d time.Duration) ServerOption {
+    return func(s *Server) { s.delay = d }
+}
+```
+
+**ServeHTTP changes:**
+
+After matching a tape, before writing the response:
+
+```go
+// Delay: sleep before writing the response if configured.
+if s.delay > 0 {
+    timer := time.NewTimer(s.delay)
+    defer timer.Stop()
+    select {
+    case <-timer.C:
+        // delay elapsed, proceed to write response
+    case <-r.Context().Done():
+        // client disconnected during delay, bail out
+        return
+    }
+}
+```
+
+The delay is applied only to successful matches. Fallback (no-match)
+responses are not delayed -- there is no point in delaying an error
+response for a missing fixture.
+
+**Per-fixture delay** (from issue #95 acceptance criteria): The Tape
+`Metadata` map (type `map[string]any`, already present in the Tape
+struct's JSON representation) can carry a `"delay"` key with a Go
+duration string value. When present, it overrides the global delay for
+that specific fixture.
+
+```go
+// After matching, check per-fixture delay override.
+effectiveDelay := s.delay
+if tape.Metadata != nil {
+    if raw, ok := tape.Metadata["delay"]; ok {
+        if ds, ok := raw.(string); ok {
+            if parsed, err := time.ParseDuration(ds); err == nil {
+                effectiveDelay = parsed
+            }
+        }
+    }
+}
+```
+
+**CLI flag:**
+
+```go
+// In runServe:
+delay := fs.Duration("delay", 0, "Fixed delay before every response (e.g., 200ms, 1s)")
+
+// When building ServerOptions:
+if *delay > 0 {
+    serverOpts = append(serverOpts, httptape.WithDelay(*delay))
+}
+```
+
+Note: `flag.Duration` parses Go duration strings natively -- no custom
+parsing needed.
+
+##### Feature 3: Error simulation (#96)
+
+**New Server fields:**
+
+```go
+type Server struct {
+    // ... existing fields ...
+    errorRate float64              // fraction of requests that return 500 (0.0-1.0)
+    randFloat func() float64      // random number generator (injectable for testing)
+}
+```
+
+**New ServerOptions:**
+
+```go
+// WithErrorRate causes a fraction of requests to return 500 Internal
+// Server Error with an "X-Httptape-Error: simulated" header instead of
+// the recorded response. The rate must be between 0.0 and 1.0 inclusive.
+//
+// A rate of 0.0 disables error simulation (default). A rate of 1.0
+// causes all requests to fail.
+//
+// Panics if rate is outside [0.0, 1.0]. This is a programming error,
+// following the constructor-guard convention (see L-11).
+func WithErrorRate(rate float64) ServerOption {
+    return func(s *Server) {
+        if rate < 0 || rate > 1 {
+            panic("httptape: WithErrorRate rate must be between 0.0 and 1.0")
+        }
+        s.errorRate = rate
+    }
+}
+
+// withRandFloat overrides the random number generator for testing.
+// This is unexported -- only used in tests to make error simulation
+// deterministic.
+func withRandFloat(fn func() float64) ServerOption {
+    return func(s *Server) { s.randFloat = fn }
+}
+```
+
+**NewServer default for randFloat:**
+
+```go
+// In NewServer, after applying options:
+if s.randFloat == nil {
+    s.randFloat = rand.Float64
+}
+```
+
+This uses `math/rand.Float64` from the top-level package (which is
+auto-seeded since Go 1.20). The injectable `randFloat` field allows
+tests to provide a deterministic function.
+
+**ServeHTTP changes:**
+
+After CORS handling, before delay and matching:
+
+```go
+// Error simulation: randomly return 500 if error rate is set.
+if s.errorRate > 0 && s.randFloat() < s.errorRate {
+    if s.cors {
+        // CORS headers already set above
+    }
+    w.Header().Set("X-Httptape-Error", "simulated")
+    http.Error(w, "httptape: simulated error", http.StatusInternalServerError)
+    return
+}
+```
+
+**Per-fixture error** (from issue #96 acceptance criteria): When a tape's
+Metadata contains an `"error"` key with a map value containing `"status"`
+(int) and optionally `"body"` (string), that tape always returns the
+specified error instead of the recorded response.
+
+```go
+// After matching, check per-fixture error override.
+if tape.Metadata != nil {
+    if raw, ok := tape.Metadata["error"]; ok {
+        if errMap, ok := raw.(map[string]any); ok {
+            status := http.StatusInternalServerError
+            body := "httptape: fixture error"
+            if s, ok := errMap["status"].(float64); ok {
+                status = int(s)
+            }
+            if b, ok := errMap["body"].(string); ok {
+                body = b
+            }
+            w.Header().Set("X-Httptape-Error", "simulated")
+            http.Error(w, body, status)
+            return
+        }
+    }
+}
+```
+
+Note: JSON unmarshaling into `map[string]any` produces `float64` for
+numbers, which is why the status is read as `float64` and cast to `int`.
+
+**CLI flag:**
+
+```go
+// In runServe:
+errorRate := fs.Float64("error-rate", 0, "Fraction of requests that return 500 (0.0-1.0)")
+
+// When building ServerOptions:
+if *errorRate > 0 {
+    serverOpts = append(serverOpts, httptape.WithErrorRate(*errorRate))
+}
+```
+
+##### Complete ServeHTTP flow (revised)
+
+```go
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    // 1. CORS headers (if enabled).
+    if s.cors {
+        w.Header().Set("Access-Control-Allow-Origin", "*")
+        w.Header().Set("Access-Control-Allow-Methods",
+            "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD")
+        w.Header().Set("Access-Control-Allow-Headers",
+            "Content-Type, Authorization, X-Requested-With, Accept")
+        w.Header().Set("Access-Control-Max-Age", "86400")
+        if r.Method == http.MethodOptions {
+            w.WriteHeader(http.StatusNoContent)
+            return
+        }
+    }
+
+    // 2. Random error simulation (if enabled).
+    if s.errorRate > 0 && s.randFloat() < s.errorRate {
+        w.Header().Set("X-Httptape-Error", "simulated")
+        http.Error(w, "httptape: simulated error", http.StatusInternalServerError)
+        return
+    }
+
+    // 3. Retrieve tapes from store.
+    tapes, err := s.store.List(r.Context(), Filter{})
+    if err != nil {
+        http.Error(w, "httptape: store error", http.StatusInternalServerError)
+        return
+    }
+
+    // 4. Find a matching tape.
+    tape, ok := s.matcher.Match(r, tapes)
+    if !ok {
+        if s.onNoMatch != nil {
+            s.onNoMatch(r)
+        }
+        w.WriteHeader(s.fallbackStatus)
+        w.Write(s.fallbackBody)
+        return
+    }
+
+    // 5. Per-fixture error override.
+    if tape.Metadata != nil {
+        if raw, ok := tape.Metadata["error"]; ok {
+            if errMap, ok := raw.(map[string]any); ok {
+                status := http.StatusInternalServerError
+                body := "httptape: fixture error"
+                if s, ok := errMap["status"].(float64); ok {
+                    status = int(s)
+                }
+                if b, ok := errMap["body"].(string); ok {
+                    body = b
+                }
+                w.Header().Set("X-Httptape-Error", "simulated")
+                http.Error(w, body, status)
+                return
+            }
+        }
+    }
+
+    // 6. Delay (global or per-fixture override).
+    effectiveDelay := s.delay
+    if tape.Metadata != nil {
+        if raw, ok := tape.Metadata["delay"]; ok {
+            if ds, ok := raw.(string); ok {
+                if parsed, err := time.ParseDuration(ds); err == nil {
+                    effectiveDelay = parsed
+                }
+            }
+        }
+    }
+    if effectiveDelay > 0 {
+        timer := time.NewTimer(effectiveDelay)
+        defer timer.Stop()
+        select {
+        case <-timer.C:
+        case <-r.Context().Done():
+            return
+        }
+    }
+
+    // 7. Write the matched tape's response.
+    for key, values := range tape.Response.Headers {
+        w.Header()[key] = append([]string(nil), values...)
+    }
+    w.Header().Del("Content-Length")
+    w.WriteHeader(tape.Response.StatusCode)
+    w.Write(tape.Response.Body)
+}
+```
+
+##### CLI changes summary
+
+Both `runServe` and `runRecord` get three new flags:
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--cors` | bool | false | Enable CORS headers |
+| `--delay` | duration | 0 | Fixed delay before responses |
+| `--error-rate` | float64 | 0.0 | Fraction of requests returning 500 |
+
+The `runServe` function collects `[]httptape.ServerOption` before calling
+`httptape.NewServer`, passing all configured options. The `runRecord`
+function wraps the reverse proxy handler the same way. Since `runRecord`
+uses `httputil.ReverseProxy` as the handler (not `Server`), the CORS and
+error-rate middleware for `runRecord` is applied by wrapping the proxy
+handler in an `http.HandlerFunc` that applies the same CORS/delay/error
+logic. Alternatively, a simpler approach: for `runRecord`, only `--cors`
+is relevant (CORS headers on the proxy response). Delay and error-rate
+do not make sense for recording mode since you want accurate recordings.
+Therefore: `--cors` is added to both `runServe` and `runRecord`, but
+`--delay` and `--error-rate` are added to `runServe` only.
+
+##### Metadata field on Tape
+
+The per-fixture features (delay override, error override) require a
+`Metadata` field on `Tape`. If `Tape` does not already have this field,
+add it:
+
+```go
+type Tape struct {
+    // ... existing fields ...
+
+    // Metadata holds optional key-value pairs for fixture-level
+    // configuration (e.g., delay, error simulation). Not used for
+    // matching. Values are preserved through JSON round-trip.
+    Metadata map[string]any `json:"metadata,omitempty"`
+}
+```
+
+The `omitempty` tag ensures existing fixtures without metadata produce
+clean JSON. The field is not used by matchers, sanitizers, or the
+recorder -- it is consumed only by `Server.ServeHTTP`.
+
+##### New imports in server.go
+
+```go
+import (
+    "math/rand"
+    "net/http"
+    "time"
+)
+```
+
+##### Design choices
+
+1. **All in `server.go`**: these features are Server concerns. They modify
+   `ServeHTTP` behavior via functional options. No new files needed.
+
+2. **Inline middleware, not separate handlers**: wrapping `http.Handler`
+   in middleware chains is idiomatic Go, but these features are tightly
+   coupled to Server internals (e.g., per-fixture metadata requires
+   access to the matched tape). Inline checks in `ServeHTTP` are simpler
+   and avoid the complexity of passing matched-tape context through
+   middleware.
+
+3. **CORS is permissive (`*`)**: this is a dev tool. Granular origin
+   control is out of scope for v1 (per issue #94).
+
+4. **`randFloat` injection**: the `withRandFloat` unexported option lets
+   tests supply a deterministic function (e.g., always returns 0.0 or
+   1.0) without exposing internals. This follows the existing pattern of
+   unexported test helpers in the codebase.
+
+5. **`time.NewTimer` + select for delay**: this is the correct way to
+   implement a cancellable sleep in Go. Using `time.Sleep` would not
+   respect context cancellation.
+
+6. **Error simulation before matching**: random errors skip the
+   store.List call entirely. This is both more efficient and more
+   realistic (a 500 from an overloaded server happens before request
+   processing).
+
+7. **Per-fixture error after matching**: per-fixture errors are
+   deterministic overrides, not random. They always fire for the matched
+   fixture, regardless of `errorRate`.
+
+8. **CORS on error responses**: CORS headers are set first, before any
+   short-circuit. This ensures browsers can read error responses (without
+   CORS headers, the browser hides the response body from JavaScript).
+
+##### File placement
+
+- `server.go` -- all three ServerOption functions, updated ServeHTTP
+- `server_test.go` -- new test cases for CORS, delay, error rate
+- `tape.go` -- add Metadata field if not already present
+- `cmd/httptape/main.go` -- new CLI flags
+
+##### Test plan
+
+**CORS tests:**
+- CORS headers present when `WithCORS()` enabled
+- CORS headers absent when not enabled
+- OPTIONS preflight returns 204 with CORS headers
+- OPTIONS without CORS returns normal fallback
+- CORS headers present on error simulation responses
+- CORS headers present on no-match fallback responses
+
+**Delay tests:**
+- Response delayed by configured duration (measure with time.Since)
+- Zero delay is a no-op (fast response)
+- Per-fixture delay overrides global delay
+- Context cancellation during delay returns immediately
+- Delay not applied to no-match fallback responses
+
+**Error simulation tests:**
+- Error rate 0: no errors (randFloat always returns 0.5)
+- Error rate 1: all errors (randFloat always returns 0.5)
+- Error rate 0.5 with randFloat returning 0.3: error
+- Error rate 0.5 with randFloat returning 0.7: no error
+- X-Httptape-Error header present on simulated errors
+- Per-fixture error always fires regardless of error rate
+- Per-fixture error with custom status and body
+- WithErrorRate panics on rate < 0 or rate > 1
+
+**Integration tests:**
+- All three features combined: CORS + delay + error rate
+- CORS headers present on simulated error responses
+
+#### Consequences
+
+- **Frontend-ready mock server**: httptape becomes usable for frontend
+  development out of the box with `--cors --delay 200ms`.
+- **Realistic testing**: developers can test loading states and error
+  handling without modifying fixtures.
+- **No breaking changes**: all features are opt-in via new ServerOption
+  functions. Existing behavior is unchanged when no options are set.
+- **stdlib only**: `math/rand`, `time`, `net/http` are all stdlib.
+- **Metadata field**: adding `Metadata` to Tape is a minor schema change.
+  Existing fixtures without the field will unmarshal correctly (nil map).
+  New fixtures with metadata will have `"metadata": {...}` in JSON.
+- **Per-fixture features require manual JSON editing**: there is no DSL
+  or CLI for setting per-fixture metadata. This is acceptable for v1 --
+  users edit fixture JSON directly.

--- a/server.go
+++ b/server.go
@@ -1,7 +1,9 @@
 package httptape
 
 import (
+	"math/rand"
 	"net/http"
+	"time"
 )
 
 // Server is an http.Handler that replays recorded HTTP interactions.
@@ -17,6 +19,10 @@ type Server struct {
 	fallbackStatus int              // HTTP status when no tape matches
 	fallbackBody   []byte           // response body when no tape matches
 	onNoMatch      func(*http.Request) // optional callback when no tape matches
+	cors           bool             // if true, add CORS headers to all responses
+	delay          time.Duration    // fixed delay before every response; zero means no delay
+	errorRate      float64          // fraction of requests that return 500 (0.0-1.0)
+	randFloat      func() float64   // random number generator (injectable for testing)
 }
 
 // ServerOption configures a Server.
@@ -47,6 +53,52 @@ func WithOnNoMatch(fn func(*http.Request)) ServerOption {
 	return func(s *Server) { s.onNoMatch = fn }
 }
 
+// WithCORS enables CORS headers on all responses. When enabled, the
+// server adds permissive CORS headers (Access-Control-Allow-Origin: *)
+// and handles OPTIONS preflight requests automatically with 204 No Content.
+//
+// This is intended for local development where the frontend dev server
+// (e.g., localhost:3000) calls the mock backend (e.g., localhost:3001).
+// It is opt-in only.
+func WithCORS() ServerOption {
+	return func(s *Server) { s.cors = true }
+}
+
+// WithDelay adds a fixed delay before every response. The delay is
+// applied after matching but before writing the response. If the
+// request context is cancelled during the delay (e.g., client
+// disconnects), ServeHTTP returns immediately without writing.
+//
+// A zero or negative duration is a no-op.
+func WithDelay(d time.Duration) ServerOption {
+	return func(s *Server) { s.delay = d }
+}
+
+// WithErrorRate causes a fraction of requests to return 500 Internal
+// Server Error with an "X-Httptape-Error: simulated" header instead of
+// the recorded response. The rate must be between 0.0 and 1.0 inclusive.
+//
+// A rate of 0.0 disables error simulation (default). A rate of 1.0
+// causes all requests to fail.
+//
+// Panics if rate is outside [0.0, 1.0]. This is a programming error,
+// following the constructor-guard convention.
+func WithErrorRate(rate float64) ServerOption {
+	return func(s *Server) {
+		if rate < 0 || rate > 1 {
+			panic("httptape: WithErrorRate rate must be between 0.0 and 1.0")
+		}
+		s.errorRate = rate
+	}
+}
+
+// withRandFloat overrides the random number generator for testing.
+// This is unexported -- only used in tests to make error simulation
+// deterministic.
+func withRandFloat(fn func() float64) ServerOption {
+	return func(s *Server) { s.randFloat = fn }
+}
+
 // NewServer creates a new Server that replays tapes from the given store.
 //
 // By default:
@@ -54,6 +106,9 @@ func WithOnNoMatch(fn func(*http.Request)) ServerOption {
 //   - fallback status is 404 Not Found
 //   - fallback body is "httptape: no matching tape found"
 //   - no onNoMatch callback
+//   - CORS disabled
+//   - no delay
+//   - no error simulation
 //
 // The store must not be nil. Passing a nil store is a programming error and
 // will panic.
@@ -71,6 +126,12 @@ func NewServer(store Store, opts ...ServerOption) *Server {
 	for _, opt := range opts {
 		opt(s)
 	}
+
+	// Default random number generator for error simulation.
+	if s.randFloat == nil {
+		s.randFloat = rand.Float64
+	}
+
 	return s
 }
 
@@ -78,27 +139,54 @@ func NewServer(store Store, opts ...ServerOption) *Server {
 // and writing the recorded response. If no tape matches, it writes the
 // configured fallback response.
 //
+// When multiple features are enabled, they execute in this order:
+//  1. CORS -- add CORS headers and handle OPTIONS preflight
+//  2. Error simulation -- short-circuit with 500 before any work
+//  3. Normal replay -- existing match-and-respond logic
+//  4. Per-fixture error override -- after matching, before writing
+//  5. Delay -- sleep before writing the real response
+//  6. Write response
+//
 // Performance note: ServeHTTP calls Store.List with an empty filter on every
 // request, resulting in an O(n) scan over all tapes. This is acceptable for
-// v1 test usage with small fixture sets. For large fixture sets (500+ tapes),
-// consider adding a WithFilter option to scope the list call, or caching
-// tapes with a configurable TTL.
-//
-// TODO: add optional tape caching or scoped filtering for large fixture sets.
+// v1 test usage with small fixture sets.
 //
 // The method is safe for concurrent use.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Step 2: retrieve all tapes from store.
+	// 1. CORS headers (if enabled).
+	if s.cors {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods",
+			"GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD")
+		w.Header().Set("Access-Control-Allow-Headers",
+			"Content-Type, Authorization, X-Requested-With, Accept")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+
+		// Handle OPTIONS preflight: return 204 with CORS headers, no body.
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
+
+	// 2. Random error simulation (if enabled).
+	if s.errorRate > 0 && s.randFloat() < s.errorRate {
+		w.Header().Set("X-Httptape-Error", "simulated")
+		http.Error(w, "httptape: simulated error", http.StatusInternalServerError)
+		return
+	}
+
+	// 3. Retrieve all tapes from store.
 	tapes, err := s.store.List(r.Context(), Filter{})
 	if err != nil {
 		http.Error(w, "httptape: store error", http.StatusInternalServerError)
 		return
 	}
 
-	// Step 4: find a matching tape.
+	// 4. Find a matching tape.
 	tape, ok := s.matcher.Match(r, tapes)
 
-	// Step 5: no match.
+	// 5. No match.
 	if !ok {
 		if s.onNoMatch != nil {
 			s.onNoMatch(r)
@@ -108,16 +196,58 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Step 6: write the matched tape's response.
-	// 6a: copy response headers (clone slices to prevent aliasing with tape data).
+	// 6. Per-fixture error override.
+	if tape.Metadata != nil {
+		if raw, ok := tape.Metadata["error"]; ok {
+			if errMap, ok := raw.(map[string]any); ok {
+				status := http.StatusInternalServerError
+				body := "httptape: fixture error"
+				if s, ok := errMap["status"].(float64); ok {
+					status = int(s)
+				}
+				if b, ok := errMap["body"].(string); ok {
+					body = b
+				}
+				w.Header().Set("X-Httptape-Error", "simulated")
+				http.Error(w, body, status)
+				return
+			}
+		}
+	}
+
+	// 7. Delay (global or per-fixture override).
+	effectiveDelay := s.delay
+	if tape.Metadata != nil {
+		if raw, ok := tape.Metadata["delay"]; ok {
+			if ds, ok := raw.(string); ok {
+				if parsed, err := time.ParseDuration(ds); err == nil {
+					effectiveDelay = parsed
+				}
+			}
+		}
+	}
+	if effectiveDelay > 0 {
+		timer := time.NewTimer(effectiveDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			// delay elapsed, proceed to write response
+		case <-r.Context().Done():
+			// client disconnected during delay, bail out
+			return
+		}
+	}
+
+	// 8. Write the matched tape's response.
+	// 8a: copy response headers (clone slices to prevent aliasing with tape data).
 	for key, values := range tape.Response.Headers {
 		w.Header()[key] = append([]string(nil), values...)
 	}
-	// 6b: remove Content-Length — the recorded value may be stale if the body
+	// 8b: remove Content-Length — the recorded value may be stale if the body
 	// was modified by sanitization. Let net/http set it from the actual body.
 	w.Header().Del("Content-Length")
-	// 6c: write status code.
+	// 8c: write status code.
 	w.WriteHeader(tape.Response.StatusCode)
-	// 6d: write body.
+	// 8d: write body.
 	w.Write(tape.Response.Body) //nolint:errcheck // response write failure is not actionable
 }

--- a/server_test.go
+++ b/server_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // storeTape creates and saves a minimal tape to the store, returning the saved tape.
@@ -605,5 +606,484 @@ func TestServer_ReplayTruncatedBody(t *testing.T) {
 	}
 	if !bytes.Equal(rec.Body.Bytes(), truncatedBody) {
 		t.Errorf("truncated body not replayed correctly, got %q", rec.Body.String())
+	}
+}
+
+// --- ADR-24: CORS support tests ---
+
+func TestServer_CORS_HeadersPresent(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	srv := NewServer(store, WithCORS())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{"Access-Control-Allow-Origin", "*"},
+		{"Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD"},
+		{"Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With, Accept"},
+		{"Access-Control-Max-Age", "86400"},
+	}
+	for _, tt := range tests {
+		if got := rec.Header().Get(tt.header); got != tt.want {
+			t.Errorf("%s = %q, want %q", tt.header, got, tt.want)
+		}
+	}
+}
+
+func TestServer_CORS_Disabled_NoHeaders(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	srv := NewServer(store) // no WithCORS
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin should be absent, got %q", got)
+	}
+}
+
+func TestServer_CORS_OptionsPreflight(t *testing.T) {
+	store := NewMemoryStore()
+	srv := NewServer(store, WithCORS())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("OPTIONS", "/api/data", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "*")
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body should be empty for OPTIONS, got %d bytes", rec.Body.Len())
+	}
+}
+
+func TestServer_CORS_OptionsWithoutCORS(t *testing.T) {
+	store := NewMemoryStore()
+	srv := NewServer(store) // no WithCORS
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("OPTIONS", "/api/data", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	// Without CORS enabled, OPTIONS is treated as a normal request (no match -> 404).
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestServer_CORS_WithVariousMethods(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "POST", "/api/data", 201, "created", nil)
+	storeTape(t, store, "DELETE", "/api/data", 204, "", nil)
+
+	srv := NewServer(store, WithCORS())
+
+	methods := []struct {
+		method string
+		want   int
+	}{
+		{"POST", 201},
+		{"DELETE", 204},
+	}
+	for _, tt := range methods {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(tt.method, "/api/data", nil)
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != tt.want {
+			t.Errorf("%s status = %d, want %d", tt.method, rec.Code, tt.want)
+		}
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("%s CORS header missing", tt.method)
+		}
+	}
+}
+
+// --- ADR-24: Latency simulation tests ---
+
+func TestServer_Delay_GlobalDelay(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	srv := NewServer(store, WithDelay(50*time.Millisecond))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+
+	start := time.Now()
+	srv.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("elapsed = %v, want >= 40ms", elapsed)
+	}
+}
+
+func TestServer_Delay_ZeroDelay(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	srv := NewServer(store, WithDelay(0))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+
+	start := time.Now()
+	srv.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	// Should be near-instant.
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("zero delay took %v, expected near-instant", elapsed)
+	}
+}
+
+func TestServer_Delay_PerFixtureOverride(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/slow",
+	}, RecordedResp{
+		StatusCode: 200,
+		Body:       []byte("slow response"),
+	})
+	tape.Metadata = map[string]any{"delay": "50ms"}
+	if err := store.Save(context.Background(), tape); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := NewServer(store, WithDelay(1*time.Millisecond)) // global is 1ms
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/slow", nil)
+
+	start := time.Now()
+	srv.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	// Per-fixture delay of 50ms should override the 1ms global.
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("per-fixture delay elapsed = %v, want >= 40ms", elapsed)
+	}
+}
+
+func TestServer_Delay_ContextCancellation(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	srv := NewServer(store, WithDelay(5*time.Second)) // very long delay
+
+	rec := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/api/data", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		srv.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Cancel after a short time.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Good, returned quickly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeHTTP did not return after context cancellation")
+	}
+}
+
+func TestServer_Delay_NoDelayOnNoMatch(t *testing.T) {
+	store := NewMemoryStore() // empty store, no tapes
+
+	srv := NewServer(store, WithDelay(5*time.Second))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/nonexistent", nil)
+
+	start := time.Now()
+	srv.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+	// No-match should not be delayed.
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("no-match took %v, expected near-instant", elapsed)
+	}
+}
+
+// --- ADR-24: Error simulation tests ---
+
+func TestServer_ErrorRate_Zero_NoErrors(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	// randFloat always returns 0.5, but errorRate is 0 so it should never trigger.
+	srv := NewServer(store, withRandFloat(func() float64 { return 0.5 }))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestServer_ErrorRate_One_AllErrors(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	// randFloat returns 0.5, errorRate is 1.0 so all requests fail.
+	srv := NewServer(store,
+		WithErrorRate(1.0),
+		withRandFloat(func() float64 { return 0.5 }),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if got := rec.Header().Get("X-Httptape-Error"); got != "simulated" {
+		t.Errorf("X-Httptape-Error = %q, want %q", got, "simulated")
+	}
+	if !strings.Contains(rec.Body.String(), "simulated error") {
+		t.Errorf("body = %q, want it to contain 'simulated error'", rec.Body.String())
+	}
+}
+
+func TestServer_ErrorRate_Deterministic(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	// Error rate 0.5: randFloat < 0.5 -> error, randFloat >= 0.5 -> success.
+	callCount := 0
+	srv := NewServer(store,
+		WithErrorRate(0.5),
+		withRandFloat(func() float64 {
+			callCount++
+			if callCount%2 == 1 {
+				return 0.1 // below rate -> error
+			}
+			return 0.9 // above rate -> success
+		}),
+	)
+
+	// First request: error.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusInternalServerError {
+		t.Errorf("req1 status = %d, want 500", rec1.Code)
+	}
+
+	// Second request: success.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec2, req2)
+	if rec2.Code != 200 {
+		t.Errorf("req2 status = %d, want 200", rec2.Code)
+	}
+}
+
+func TestServer_ErrorRate_WithCORS(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
+
+	srv := NewServer(store,
+		WithCORS(),
+		WithErrorRate(1.0),
+		withRandFloat(func() float64 { return 0.0 }),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec, req)
+
+	// Even on error, CORS headers must be present.
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("CORS header missing on error response: %q", got)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestServer_ErrorRate_InvalidPanics(t *testing.T) {
+	tests := []struct {
+		name string
+		rate float64
+	}{
+		{"negative", -0.1},
+		{"above one", 1.1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatal("expected panic, got none")
+				}
+				msg, ok := r.(string)
+				if !ok {
+					t.Fatalf("expected string panic, got %T", r)
+				}
+				if !strings.Contains(msg, "between 0.0 and 1.0") {
+					t.Errorf("panic message = %q, want it to contain 'between 0.0 and 1.0'", msg)
+				}
+			}()
+			WithErrorRate(tt.rate)(&Server{})
+		})
+	}
+}
+
+func TestServer_PerFixtureError(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/broken",
+	}, RecordedResp{
+		StatusCode: 200,
+		Body:       []byte("should not see this"),
+	})
+	tape.Metadata = map[string]any{
+		"error": map[string]any{
+			"status": float64(503),
+			"body":   "service unavailable",
+		},
+	}
+	if err := store.Save(context.Background(), tape); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/broken", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 503 {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "service unavailable") {
+		t.Errorf("body = %q, want it to contain 'service unavailable'", rec.Body.String())
+	}
+	if got := rec.Header().Get("X-Httptape-Error"); got != "simulated" {
+		t.Errorf("X-Httptape-Error = %q, want %q", got, "simulated")
+	}
+}
+
+func TestServer_PerFixtureError_DefaultStatus(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/err",
+	}, RecordedResp{
+		StatusCode: 200,
+		Body:       []byte("normal"),
+	})
+	// error with no status field -> default 500
+	tape.Metadata = map[string]any{
+		"error": map[string]any{},
+	}
+	if err := store.Save(context.Background(), tape); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/err", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestServer_PerFixtureError_WithCORS(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/broken",
+	}, RecordedResp{
+		StatusCode: 200,
+		Body:       []byte("ok"),
+	})
+	tape.Metadata = map[string]any{
+		"error": map[string]any{
+			"status": float64(429),
+			"body":   "rate limited",
+		},
+	}
+	if err := store.Save(context.Background(), tape); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := NewServer(store, WithCORS())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/broken", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 429 {
+		t.Errorf("status = %d, want 429", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("CORS header missing on per-fixture error: %q", got)
+	}
+}
+
+// --- ADR-24: Metadata field on Tape ---
+
+func TestTape_MetadataOmitEmpty(t *testing.T) {
+	tape := NewTape("route", RecordedReq{Method: "GET", URL: "/test"}, RecordedResp{StatusCode: 200})
+	if tape.Metadata != nil {
+		t.Errorf("new tape Metadata should be nil, got %v", tape.Metadata)
+	}
+}
+
+func TestTape_MetadataRoundTrip(t *testing.T) {
+	tape := NewTape("route", RecordedReq{Method: "GET", URL: "/test"}, RecordedResp{StatusCode: 200})
+	tape.Metadata = map[string]any{
+		"delay": "500ms",
+		"error": map[string]any{"status": float64(503)},
+	}
+
+	if tape.Metadata["delay"] != "500ms" {
+		t.Errorf("delay = %v, want 500ms", tape.Metadata["delay"])
 	}
 }

--- a/tape.go
+++ b/tape.go
@@ -43,6 +43,11 @@ type Tape struct {
 
 	// Response is the recorded HTTP response.
 	Response RecordedResp `json:"response"`
+
+	// Metadata holds optional key-value pairs for fixture-level
+	// configuration (e.g., delay, error simulation). Not used for
+	// matching. Values are preserved through JSON round-trip.
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // RecordedReq captures the essential parts of an HTTP request for matching and replay.


### PR DESCRIPTION
## Summary

- **CORS support (#94)**: `WithCORS()` ServerOption adds permissive CORS headers (`Access-Control-Allow-Origin: *`) to all responses and handles OPTIONS preflight requests with 204 No Content. `--cors` CLI flag added to both `serve` and `record` commands.
- **Latency simulation (#95)**: `WithDelay(d)` ServerOption adds a fixed delay before responses, respecting context cancellation. Per-fixture delay override via `Tape.Metadata["delay"]` (Go duration string). `--delay` CLI flag on `serve`.
- **Error simulation (#96)**: `WithErrorRate(rate)` ServerOption causes a fraction of requests to return 500 with `X-Httptape-Error: simulated` header. Per-fixture error override via `Tape.Metadata["error"]`. Injectable `randFloat` for deterministic testing. `--error-rate` CLI flag on `serve`.
- **Tape.Metadata field**: Added `map[string]any` field with `omitempty` JSON tag to support per-fixture configuration.

Implements ADR-24. Middleware execution order: CORS -> Error simulation -> Match -> Per-fixture error -> Delay -> Write response.

Closes #94, closes #95, closes #96

## Test plan

- [x] CORS headers present when enabled, absent when disabled
- [x] OPTIONS preflight returns 204 with CORS headers
- [x] CORS headers present on error responses
- [x] Global delay applied before response
- [x] Zero delay is a no-op
- [x] Per-fixture delay overrides global delay
- [x] Context cancellation during delay returns immediately
- [x] No delay on no-match fallback
- [x] Error rate 0 produces no errors
- [x] Error rate 1 produces all errors
- [x] Deterministic error simulation via injected randFloat
- [x] Per-fixture error override with custom status and body
- [x] Invalid error rate panics
- [x] `X-Httptape-Error: simulated` header on all simulated errors
- [x] All tests pass with `-race` flag
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
