### PR TITLE
docs: add fixture authoring guide and UI-first dev guide

### DIFF
--- a/docs/fixtures-authoring.md
+++ b/docs/fixtures-authoring.md
@@ -1,0 +1,386 @@
+# Fixture Authoring Guide
+
+Hand-write Tape JSON files for static mocking without recording from a live API.
+
+## When to author fixtures by hand
+
+- The upstream API does not exist yet (contract-first development)
+- You need specific edge cases (empty arrays, 204 No Content, error responses)
+- You want deterministic test data without a recording step
+- You are building a mock backend for frontend development (see [UI-First Dev](ui-first-dev.md))
+
+## Tape JSON structure
+
+Every fixture file is a single JSON object with these fields:
+
+```json
+{
+  "id": "get-users-list",
+  "route": "users-api",
+  "recorded_at": "2025-01-15T10:00:00Z",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/api/users",
+    "headers": {
+      "Accept": ["application/json"]
+    },
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": "eyJ1c2VycyI6W3siaWQiOjEsIm5hbWUiOiJBbGljZSJ9XX0="
+  },
+  "metadata": {}
+}
+```
+
+### Field reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Unique identifier. Used as the filename (`<id>.json`). Must not contain `/`, `\`, or `..`. |
+| `route` | string | No | Logical grouping label (e.g., `"users-api"`). Used by `Filter.Route` and `MatchRoute`. |
+| `recorded_at` | string (RFC 3339) | No | UTC timestamp. Informational only -- not used for matching. |
+| `request.method` | string | Yes | HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`). |
+| `request.url` | string | Yes | Full URL. The path component is used for matching (e.g., `http://mock/api/users`). |
+| `request.headers` | object | No | Request headers. Each key maps to an array of strings. |
+| `request.body` | string/null | No | Base64-encoded request body, or `null` for bodiless requests. |
+| `request.body_hash` | string | No | Hex-encoded SHA-256 hash of the original request body. Required for `MatchBodyHash`. |
+| `request.body_encoding` | string | No | `"identity"` for UTF-8 text, `"base64"` for binary. Defaults to identity if omitted. |
+| `response.status_code` | int | Yes | HTTP status code (200, 201, 204, 404, 500, etc.). |
+| `response.headers` | object | No | Response headers. Each key maps to an array of strings. |
+| `response.body` | string/null | No | Base64-encoded response body. |
+| `response.body_encoding` | string | No | Same as request body encoding. |
+| `metadata` | object | No | Key-value pairs for delay/error simulation. Not used for matching. |
+
+### Body encoding
+
+Go's `encoding/json` handles `[]byte` fields as base64 automatically. When authoring by hand:
+
+- **JSON response bodies**: base64-encode the JSON string and set the body field
+- **Text responses**: base64-encode the text
+- **No body** (e.g., 204): set body to `null`
+
+To base64-encode on the command line:
+
+```bash
+echo -n '{"users":[{"id":1,"name":"Alice"}]}' | base64
+# eyJ1c2VycyI6W3siaWQiOjEsIm5hbWUiOiJBbGljZSJ9XX0=
+```
+
+### URL format and matching
+
+The `request.url` field stores a full URL, but the `DefaultMatcher` (used by the Server) only compares the **path** component. This means:
+
+- `http://mock/api/users` and `https://production.example.com/api/users` match the same `GET /api/users` request
+- Use `http://mock` as the host for hand-written fixtures -- it is a convention, not a requirement
+- Query parameters are ignored by the default matcher. Use `MatchQueryParams` in a `CompositeMatcher` if you need them.
+
+## Example fixtures
+
+### GET returning JSON (200)
+
+**File:** `fixtures/get-users.json`
+
+```json
+{
+  "id": "get-users",
+  "route": "users-api",
+  "recorded_at": "2025-01-15T10:00:00Z",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/api/users",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"],
+      "X-Total-Count": ["42"]
+    },
+    "body": "eyJ1c2VycyI6W3siaWQiOjEsIm5hbWUiOiJBbGljZSJ9LHsiaWQiOjIsIm5hbWUiOiJCb2IifV19"
+  }
+}
+```
+
+The response body decodes to:
+
+```json
+{"users":[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]}
+```
+
+### POST returning created resource (201)
+
+**File:** `fixtures/create-user.json`
+
+```json
+{
+  "id": "create-user",
+  "route": "users-api",
+  "recorded_at": "2025-01-15T10:00:00Z",
+  "request": {
+    "method": "POST",
+    "url": "http://mock/api/users",
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 201,
+    "headers": {
+      "Content-Type": ["application/json"],
+      "Location": ["/api/users/3"]
+    },
+    "body": "eyJpZCI6MywibmFtZSI6IkNoYXJsaWUiLCJjcmVhdGVkX2F0IjoiMjAyNS0wMS0xNVQxMDowMDowMFoifQ=="
+  }
+}
+```
+
+The response body decodes to:
+
+```json
+{"id":3,"name":"Charlie","created_at":"2025-01-15T10:00:00Z"}
+```
+
+### DELETE returning 204 No Content
+
+**File:** `fixtures/delete-user.json`
+
+```json
+{
+  "id": "delete-user",
+  "route": "users-api",
+  "recorded_at": "2025-01-15T10:00:00Z",
+  "request": {
+    "method": "DELETE",
+    "url": "http://mock/api/users/1",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 204,
+    "headers": {},
+    "body": null
+  }
+}
+```
+
+### GET with custom headers (paginated response)
+
+**File:** `fixtures/get-users-page2.json`
+
+```json
+{
+  "id": "get-users-page2",
+  "route": "users-api",
+  "recorded_at": "2025-01-15T10:00:00Z",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/api/users?page=2&per_page=10",
+    "headers": {
+      "Accept": ["application/json"],
+      "Authorization": ["Bearer [REDACTED]"]
+    },
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"],
+      "X-Total-Count": ["42"],
+      "X-Page": ["2"],
+      "X-Per-Page": ["10"],
+      "Link": ["<http://mock/api/users?page=3&per_page=10>; rel=\"next\""]
+    },
+    "body": "eyJ1c2VycyI6W3siaWQiOjExLCJuYW1lIjoiS2FyZW4ifV19"
+  }
+}
+```
+
+## Metadata: delay and error simulation
+
+The `metadata` field holds per-fixture configuration that the Server reads at replay time. It is not used for matching.
+
+### Simulating latency
+
+Add a `delay` key with a Go duration string:
+
+```json
+{
+  "id": "slow-endpoint",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/api/reports",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": "eyJzdGF0dXMiOiJjb21wbGV0ZSJ9"
+  },
+  "metadata": {
+    "delay": "2s"
+  }
+}
+```
+
+Supported duration formats: `100ms`, `1.5s`, `2s`, `500ms`. The server sleeps for the specified duration before writing the response. If the client disconnects during the delay, the server returns immediately.
+
+The per-fixture delay overrides the global `WithDelay` server option.
+
+### Simulating errors
+
+Add an `error` key with a `status` code and optional `body`:
+
+```json
+{
+  "id": "failing-endpoint",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/api/flaky",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": "eyJvayI6dHJ1ZX0="
+  },
+  "metadata": {
+    "error": {
+      "status": 503,
+      "body": "Service Unavailable"
+    }
+  }
+}
+```
+
+When the Server matches this fixture, it returns a `503` with the body `"Service Unavailable"` and sets the header `X-Httptape-Error: simulated`. The `response` section is ignored when `metadata.error` is present.
+
+### Combining delay and error
+
+```json
+{
+  "metadata": {
+    "delay": "3s",
+    "error": {
+      "status": 504,
+      "body": "Gateway Timeout"
+    }
+  }
+}
+```
+
+The error check runs before the delay, so in practice the error response is returned immediately (the delay applies only to successful responses).
+
+## FileStore directory structure
+
+`FileStore` stores all fixture files in a single flat directory. Each file is named `<id>.json`:
+
+```
+fixtures/
+  get-users.json
+  create-user.json
+  delete-user.json
+  get-users-page2.json
+  slow-endpoint.json
+  failing-endpoint.json
+```
+
+Rules:
+- The filename is derived from the `id` field: `id + ".json"`
+- IDs must not contain path separators (`/`, `\`) or traversal components (`..`)
+- Only `.json` files are loaded -- other files are ignored
+- There is no subdirectory nesting. Use the `route` field for logical grouping instead.
+- The default directory is `fixtures/` relative to the working directory. Override with `WithDirectory`:
+
+```go
+store, err := httptape.NewFileStore(httptape.WithDirectory("./testdata/api-fixtures"))
+```
+
+## Tips for hand-authored fixtures
+
+**Use descriptive IDs.** The ID is the filename, so `get-users` is easier to find than a UUID. Recorded tapes use UUIDs, but hand-authored ones can use any valid string.
+
+**Keep the `route` consistent.** If you plan to filter fixtures by route (e.g., to run tests against a subset), use the same route string across related fixtures.
+
+**Omit optional fields.** Fields like `body_hash`, `body_encoding`, `recorded_at`, and `metadata` can be omitted entirely:
+
+```json
+{
+  "id": "minimal-fixture",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/api/health",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": "eyJzdGF0dXMiOiJvayJ9"
+  }
+}
+```
+
+**Base64 helper script.** Create a shell alias for encoding response bodies:
+
+```bash
+alias b64='python3 -c "import sys,base64; print(base64.b64encode(sys.stdin.buffer.read()).decode())"'
+
+# Usage:
+echo -n '{"status":"ok"}' | b64
+# eyJzdGF0dXMiOiJvayJ9
+```
+
+**Validate your fixtures.** Load fixtures with `FileStore` and check for JSON parse errors:
+
+```go
+store, err := httptape.NewFileStore(httptape.WithDirectory("./fixtures"))
+if err != nil {
+    log.Fatal(err)
+}
+tapes, err := store.List(context.Background(), httptape.Filter{})
+if err != nil {
+    log.Fatal("fixture load error:", err)
+}
+fmt.Printf("Loaded %d fixtures\n", len(tapes))
+```
+
+## Reference: sanitization config
+
+If your fixtures were recorded with sanitization enabled, the values in headers and body fields will already be redacted or faked. When authoring fixtures by hand, you can use the same redacted placeholders for consistency:
+
+- Redacted header: `"[REDACTED]"`
+- Redacted body field: `"[REDACTED]"`
+- Faked field: deterministic HMAC-based value (varies by seed)
+
+See [Declarative Configuration](config.md) for the config file format and [Sanitization](sanitization.md) for the programmatic API.
+
+## See also
+
+- [Storage](storage.md) -- FileStore and MemoryStore details
+- [Replay](replay.md) -- how the Server matches and serves fixtures
+- [Matching](matching.md) -- customizing request-to-tape matching
+- [UI-First Dev](ui-first-dev.md) -- using hand-authored fixtures for frontend development
+- [Config](config.md) -- sanitization configuration reference

--- a/docs/ui-first-dev.md
+++ b/docs/ui-first-dev.md
@@ -1,0 +1,397 @@
+# UI-First Development Guide
+
+Use httptape as a mock backend for frontend development. Build your UI against fixture data without waiting for the real API to be ready, stable, or accessible.
+
+## Why use httptape for frontend dev
+
+- **No backend dependency.** Start building UI before the API exists (contract-first).
+- **Deterministic data.** Same fixtures, same responses, every time.
+- **Offline development.** No network access needed once fixtures are written.
+- **Edge case testing.** Simulate errors, slow responses, and empty states with fixture metadata.
+- **Team sharing.** Commit fixtures to version control. Every developer gets the same mock data.
+
+## Workflow overview
+
+There are two paths to get fixtures:
+
+### Path A: Write fixtures by hand
+
+Best when the API does not exist yet or you want full control over the mock data.
+
+1. Define the API contract (endpoints, request/response shapes)
+2. Author fixture JSON files -- see [Fixture Authoring Guide](fixtures-authoring.md)
+3. Start httptape in serve mode
+4. Point your frontend at httptape
+
+### Path B: Record from a real or staging API
+
+Best when the API already exists and you want realistic data.
+
+1. Start httptape in record mode, pointing at the upstream API
+2. Exercise the API endpoints your frontend needs (manually or via a script)
+3. Stop the recorder -- fixtures are now on disk
+4. Start httptape in serve mode
+5. Point your frontend at httptape
+
+Record mode with the CLI:
+
+```bash
+# Record from staging
+httptape record \
+  --upstream https://staging-api.example.com \
+  --fixtures ./fixtures \
+  --config sanitize.json \
+  --port 3001
+
+# Exercise your endpoints
+curl http://localhost:3001/api/users
+curl http://localhost:3001/api/users/1
+curl -X POST http://localhost:3001/api/users -d '{"name":"Alice"}'
+
+# Stop with Ctrl+C, then serve the recorded fixtures
+httptape serve --fixtures ./fixtures --port 3001
+```
+
+## Docker Compose: frontend + httptape
+
+A typical setup with a React/Vue/Svelte dev server calling httptape as the API backend:
+
+```yaml
+# docker-compose.yml
+services:
+  mock-api:
+    image: ghcr.io/vibewarden/httptape:latest
+    command: ["serve", "--fixtures", "/fixtures", "--port", "3001", "--cors"]
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./fixtures:/fixtures:ro
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3000:3000"
+    environment:
+      VITE_API_URL: http://localhost:3001
+    depends_on:
+      - mock-api
+```
+
+Start everything with:
+
+```bash
+docker compose up
+```
+
+Your frontend at `http://localhost:3000` calls the mock API at `http://localhost:3001`. Fixtures are read from the `./fixtures` directory on the host.
+
+### Without Docker
+
+Run httptape directly:
+
+```bash
+httptape serve --fixtures ./fixtures --port 3001 --cors
+```
+
+In another terminal, start your frontend dev server:
+
+```bash
+cd frontend && npm run dev
+# Vite/Next/CRA dev server on localhost:3000
+```
+
+Configure your frontend to use `http://localhost:3001` as the API base URL.
+
+## CORS setup
+
+When the frontend dev server (e.g., `localhost:3000`) calls the mock backend (e.g., `localhost:3001`), the browser enforces the same-origin policy. httptape has built-in CORS support.
+
+### CLI flag
+
+```bash
+httptape serve --fixtures ./fixtures --port 3001 --cors
+```
+
+### Go API
+
+```go
+srv := httptape.NewServer(store, httptape.WithCORS())
+```
+
+When CORS is enabled, the server:
+
+- Adds `Access-Control-Allow-Origin: *` to all responses
+- Adds `Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD`
+- Adds `Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, Accept`
+- Adds `Access-Control-Max-Age: 86400` (24 hours)
+- Handles `OPTIONS` preflight requests automatically with `204 No Content`
+
+This is a permissive CORS configuration intended for local development only.
+
+## Hot-reload: edit fixtures, see changes immediately
+
+`FileStore` reads fixture files from disk on every request. There is no in-memory cache. This means:
+
+- Edit a fixture JSON file, save it, and the next request picks up the change
+- Add a new fixture file to the directory, and it is immediately available
+- Delete a fixture file, and the next request to that endpoint returns the fallback (404 by default)
+
+No server restart is needed. This makes the edit-refresh cycle fast:
+
+1. Frontend shows wrong data or you need a new endpoint
+2. Edit or create a fixture file in `./fixtures/`
+3. Refresh the browser
+4. New response is served
+
+### Example: adding an endpoint on the fly
+
+Your frontend needs `GET /api/notifications`, which does not have a fixture yet. Create the file:
+
+**File:** `fixtures/get-notifications.json`
+
+```json
+{
+  "id": "get-notifications",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/api/notifications",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": "W3siaWQiOjEsIm1lc3NhZ2UiOiJXZWxjb21lISIsInJlYWQiOmZhbHNlfV0="
+  }
+}
+```
+
+The body decodes to:
+
+```json
+[{"id":1,"message":"Welcome!","read":false}]
+```
+
+Save the file. Refresh the frontend. The notification badge appears.
+
+## Latency simulation for loading states
+
+Frontend loading states (spinners, skeletons, progress bars) are hard to test against a local mock that responds instantly. Use the `metadata.delay` field to slow specific endpoints:
+
+```json
+{
+  "id": "slow-dashboard",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/api/dashboard",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": "eyJ3aWRnZXRzIjpbXX0="
+  },
+  "metadata": {
+    "delay": "2s"
+  }
+}
+```
+
+The server waits 2 seconds before sending the response. Your frontend loading spinner is now visible during development.
+
+### Global delay
+
+Apply a delay to every endpoint via the Go API:
+
+```go
+srv := httptape.NewServer(store,
+    httptape.WithCORS(),
+    httptape.WithDelay(500 * time.Millisecond),
+)
+```
+
+Per-fixture delays in `metadata.delay` override the global delay for that specific endpoint.
+
+### Supported duration values
+
+| Value | Duration |
+|-------|----------|
+| `"100ms"` | 100 milliseconds |
+| `"500ms"` | Half a second |
+| `"1s"` | One second |
+| `"1.5s"` | 1.5 seconds |
+| `"2s"` | Two seconds |
+| `"5s"` | Five seconds |
+
+## Error simulation for error handling in UI
+
+Test your error boundaries, retry logic, toast notifications, and fallback UI by simulating server errors.
+
+### Per-fixture errors
+
+Return a specific error for a specific endpoint:
+
+```json
+{
+  "id": "payment-failure",
+  "request": {
+    "method": "POST",
+    "url": "http://mock/api/payments",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 201,
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": "eyJpZCI6MX0="
+  },
+  "metadata": {
+    "error": {
+      "status": 422,
+      "body": "{\"errors\":{\"card_number\":[\"is invalid\"]}}"
+    }
+  }
+}
+```
+
+The server returns 422 with the validation error body. The `response` section is ignored when `metadata.error` is present. To switch back to the success response, remove the `metadata.error` block and save the file.
+
+### Random error rate
+
+Simulate flaky APIs where some percentage of requests fail with 500:
+
+```go
+srv := httptape.NewServer(store,
+    httptape.WithCORS(),
+    httptape.WithErrorRate(0.3), // 30% of requests return 500
+)
+```
+
+Failed responses include the header `X-Httptape-Error: simulated` so you can distinguish simulated errors from real ones in your frontend code or browser dev tools.
+
+### Common error scenarios for frontend testing
+
+| Scenario | Fixture setup |
+|----------|--------------|
+| Validation error (422) | `metadata.error.status: 422`, body with field errors |
+| Unauthorized (401) | `metadata.error.status: 401`, body with auth error message |
+| Not found (404) | `metadata.error.status: 404` |
+| Rate limited (429) | `metadata.error.status: 429`, body with retry-after info |
+| Server error (500) | `metadata.error.status: 500` |
+| Service unavailable (503) | `metadata.error.status: 503` |
+| Gateway timeout (504) | `metadata.error.status: 504` combined with `metadata.delay: "30s"` |
+
+### Toggle between success and error
+
+A practical workflow for testing both happy and error paths:
+
+1. Start with the fixture returning the success response (no `metadata.error`)
+2. Test the happy path in the UI
+3. Add `metadata.error` to the fixture file and save
+4. Refresh the browser -- error UI is now shown
+5. Remove `metadata.error` and save to go back to the happy path
+
+No server restart needed. Hot-reload picks up changes immediately.
+
+## Full example: e-commerce frontend
+
+A complete fixture set for a simple e-commerce frontend:
+
+```
+fixtures/
+  get-products.json          # GET /api/products -> 200, product list
+  get-product-detail.json    # GET /api/products/1 -> 200, single product
+  get-cart.json              # GET /api/cart -> 200, cart contents
+  add-to-cart.json           # POST /api/cart/items -> 201, added item
+  checkout.json              # POST /api/checkout -> 201, order confirmation
+  checkout-error.json        # POST /api/checkout -> 422, validation error (via metadata.error)
+  slow-search.json           # GET /api/search -> 200, delayed 1.5s (via metadata.delay)
+```
+
+Note: since the default matcher uses method + path, having both `checkout.json` and `checkout-error.json` match the same `POST /api/checkout` means the first file loaded wins. To toggle between them, use a single fixture and swap the `metadata.error` block in and out, or delete one file and keep the other.
+
+Docker Compose for this setup:
+
+```yaml
+services:
+  mock-api:
+    image: ghcr.io/vibewarden/httptape:latest
+    command: ["serve", "--fixtures", "/fixtures", "--port", "3001", "--cors"]
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./fixtures:/fixtures:ro
+
+  frontend:
+    image: node:20-alpine
+    working_dir: /app
+    command: ["npm", "run", "dev"]
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+    environment:
+      VITE_API_URL: http://localhost:3001
+    depends_on:
+      - mock-api
+```
+
+## Comparison with alternatives
+
+### json-server
+
+[json-server](https://github.com/typicode/json-server) generates REST endpoints from a single JSON file with a database-like structure.
+
+| Aspect | httptape | json-server |
+|--------|----------|-------------|
+| Data model | One JSON file per endpoint (request + response pair) | Single `db.json` file with resource collections |
+| CRUD support | Read-only replay (records exact responses) | Full CRUD with auto-generated routes |
+| Response fidelity | Exact headers, status codes, body from fixtures | Generated responses with limited header control |
+| Recording | Built-in -- record from a real API | None -- hand-author only |
+| Sanitization | Built-in redaction and deterministic faking | None |
+| Error simulation | Per-fixture `metadata.error` and global `WithErrorRate` | Custom middleware required |
+| Latency simulation | Per-fixture `metadata.delay` and global `WithDelay` | `--delay` flag (global only) |
+| Language | Go (single binary, Docker image) | Node.js |
+
+**Choose httptape when** you need exact replay of recorded API interactions, per-endpoint error/delay simulation, or sanitized fixtures safe for version control.
+
+**Choose json-server when** you need full CRUD semantics with auto-generated routes and a database-like data model.
+
+### Mockoon
+
+[Mockoon](https://mockoon.com/) is a desktop application and CLI for creating mock APIs with a GUI.
+
+| Aspect | httptape | Mockoon |
+|--------|----------|---------|
+| Configuration | JSON fixture files (text editor) | GUI application or JSON environment files |
+| Version control | Individual fixture files, easy diffs | Single large environment JSON file |
+| Recording | Built-in proxy recording with sanitization | Built-in proxy recording |
+| Error simulation | `metadata.error` per fixture, `WithErrorRate` global | Per-route rules in GUI |
+| Latency simulation | `metadata.delay` per fixture, `WithDelay` global | Per-route latency in GUI |
+| Go integration | Native -- embeddable in Go tests | None (separate process) |
+| Docker | Minimal scratch image (~10 MB) | Node.js-based image |
+| CORS | `--cors` flag | Built-in toggle |
+
+**Choose httptape when** you want text-file-based fixtures, Git-friendly diffs, Go test integration, or sanitization.
+
+**Choose Mockoon when** you prefer a GUI for designing mock APIs or need features like response templating and dynamic generation.
+
+## See also
+
+- [Fixture Authoring Guide](fixtures-authoring.md) -- JSON fixture format and field reference
+- [CLI](cli.md) -- `serve` and `record` commands
+- [Docker](docker.md) -- container setup and Docker Compose examples
+- [Replay](replay.md) -- how the Server matches requests to fixtures
+- [Matching](matching.md) -- customizing request-to-tape matching


### PR DESCRIPTION
## Summary

- Add `docs/fixtures-authoring.md` (#93): comprehensive guide for hand-writing Tape JSON fixture files, covering the full JSON structure with field descriptions, working examples for GET/POST/204/paginated responses, metadata-based delay and error simulation, FileStore directory layout, and base64 encoding tips.
- Add `docs/ui-first-dev.md` (#97): practical guide for using httptape as a mock backend during frontend development, covering two workflows (hand-write vs record from staging), Docker Compose setup with a frontend service, CORS configuration (`--cors` flag), hot-reload behavior (edit fixture files without restarting), latency simulation for loading states, error simulation for error UI testing, and a comparison table with json-server and Mockoon.

Closes #93, closes #97

## Test plan

- [ ] Verify all JSON examples in fixtures-authoring.md are valid JSON
- [ ] Verify base64-encoded bodies decode to the documented JSON payloads
- [ ] Verify Docker Compose example in ui-first-dev.md is valid YAML
- [ ] Verify cross-references between the two new docs and existing docs resolve correctly
- [ ] Verify the docs render correctly on GitHub (markdown tables, code blocks, links)

Generated with [Claude Code](https://claude.com/claude-code)
