### PR TITLE
feat: replay-time header injection and multi-language docs

### DIFF
--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -45,6 +45,15 @@ const (
 
 var logger = log.New(os.Stderr, "httptape: ", 0)
 
+// repeatableFlag is a flag.Value that accumulates repeated flag uses into a slice.
+type repeatableFlag []string
+
+func (r *repeatableFlag) String() string { return strings.Join(*r, ", ") }
+func (r *repeatableFlag) Set(value string) error {
+	*r = append(*r, value)
+	return nil
+}
+
 const usageText = `httptape — HTTP traffic recording, sanitization, and replay
 
 Usage:
@@ -117,6 +126,8 @@ func runServe(args []string) error {
 	cors := fs.Bool("cors", false, "Enable CORS headers (Access-Control-Allow-Origin: *)")
 	delay := fs.Duration("delay", 0, "Fixed delay before every response (e.g., 200ms, 1s)")
 	errorRate := fs.Float64("error-rate", 0, "Fraction of requests that return 500 (0.0-1.0)")
+	var replayHeaders repeatableFlag
+	fs.Var(&replayHeaders, "replay-header", "Header to inject into responses (Key=Value, repeatable)")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -142,6 +153,13 @@ func runServe(args []string) error {
 	}
 	if *errorRate > 0 {
 		serverOpts = append(serverOpts, httptape.WithErrorRate(*errorRate))
+	}
+	for _, rh := range replayHeaders {
+		eqIdx := strings.Index(rh, "=")
+		if eqIdx < 1 {
+			return &usageError{fmt.Errorf("invalid --replay-header %q: expected Key=Value", rh)}
+		}
+		serverOpts = append(serverOpts, httptape.WithReplayHeaders(rh[:eqIdx], rh[eqIdx+1:]))
 	}
 
 	server := httptape.NewServer(store, serverOpts...)

--- a/decisions.md
+++ b/decisions.md
@@ -6449,3 +6449,106 @@ import (
 - **Per-fixture features require manual JSON editing**: there is no DSL
   or CLI for setting per-fixture metadata. This is acceptable for v1 --
   users edit fixture JSON directly.
+
+---
+
+### ADR-25: Replay header injection (WithReplayHeaders)
+
+**Date**: 2026-03-30
+**Issue**: #105
+**Status**: Accepted
+
+#### Context
+
+When replaying recorded fixtures as a mock server, certain HTTP response
+headers may need to differ from what was originally recorded. Common
+scenarios include:
+
+- Injecting fresh `Authorization` tokens so downstream clients pass
+  validation.
+- Adding correlation or trace headers (`X-Request-Id`, `X-Trace-Id`)
+  for observability in test environments.
+- Overriding `Cache-Control` or `Set-Cookie` headers that are
+  environment-specific.
+
+Currently, the only way to achieve this is to edit every fixture file
+manually, which is error-prone and pollutes diffs.
+
+#### Decision
+
+Add a new `ServerOption`:
+
+```go
+func WithReplayHeaders(key, value string) ServerOption
+```
+
+**Library side** (`server.go`):
+
+- A `replayHeaders map[string]string` field is added to the `Server`
+  struct.
+- Each call to `WithReplayHeaders` inserts (or overwrites) an entry in
+  the map.
+- In `ServeHTTP`, after copying the matched tape's response headers and
+  before removing `Content-Length`, every entry in `replayHeaders` is
+  applied via `w.Header().Set(key, value)`. This means replay headers
+  override tape headers with the same key.
+
+**CLI side** (`cmd/httptape/main.go`):
+
+- A repeatable `--replay-header` flag is added to the `serve` command.
+- Format: `--replay-header "Key=Value"`.
+- Multiple flags are allowed:
+  `--replay-header "Authorization=Bearer tok" --replay-header "X-Req-Id=123"`.
+- The flag is split on the first `=` sign; keys without `=` are rejected
+  as a usage error.
+
+##### Design choices
+
+1. **`map[string]string` (single value per key)**: HTTP allows multiple
+   values per header key, but the override use case is almost always
+   "replace the value". A map keeps the API simple. Users who need
+   multi-valued headers can call `WithReplayHeaders` with the
+   canonical comma-separated form.
+
+2. **Applied after tape headers, before Content-Length removal**: this
+   ensures replay headers always win over recorded values, and
+   Content-Length is still recalculated by `net/http` from the actual
+   body.
+
+3. **No effect on fallback/error responses**: replay headers are only
+   injected on successful tape matches. Fallback (no-match) and
+   simulated error responses are not modified — they are synthetic
+   responses from httptape itself, not from recorded tapes.
+
+4. **Repeatable CLI flag via `flag.Value` interface**: Go's `flag`
+   package supports custom value types. A `repeatableFlag` (string
+   slice) collects multiple `--replay-header` invocations.
+
+##### File placement
+
+- `server.go` -- `WithReplayHeaders` option, `replayHeaders` field,
+  injection in `ServeHTTP`
+- `server_test.go` -- new test cases
+- `cmd/httptape/main.go` -- `--replay-header` flag, `repeatableFlag` type
+
+##### Test plan
+
+- Header override: tape has `Authorization: original`, replay header
+  sets `Authorization: injected` — response has injected value.
+- Multiple overrides: three different replay headers all appear in
+  response.
+- No override when not set: default server leaves tape headers untouched.
+
+#### Consequences
+
+- **Non-breaking**: `WithReplayHeaders` is a new opt-in option. Existing
+  behavior is unchanged when no replay headers are configured.
+- **Environment-portable fixtures**: fixtures can be recorded once and
+  replayed in different environments by injecting environment-specific
+  headers at serve time, without editing fixture files.
+- **stdlib only**: no new dependencies.
+- **Single-value limitation**: the `map[string]string` design means only
+  one value per header key. This is acceptable for the target use cases.
+  If multi-value support is needed later, the API can be extended with a
+  `WithReplayHeaderValues(key string, values ...string)` option without
+  breaking the existing API.

--- a/docs/other-languages.md
+++ b/docs/other-languages.md
@@ -1,0 +1,345 @@
+# Using httptape with Other Languages
+
+httptape ships as a Docker image (`ghcr.io/vibewarden/httptape:latest`), so any language with Docker or Testcontainers support can use it as a mock server. This guide shows how to start an httptape container, mount fixture files, make requests, and clean up in several popular languages.
+
+All examples assume you have a directory of recorded fixtures at `./testdata/fixtures` relative to the project root. The container exposes port **8081** by default.
+
+---
+
+## Java (Testcontainers)
+
+```java
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttptapeTest {
+
+    static GenericContainer<?> httptape;
+    static String baseUrl;
+
+    @BeforeAll
+    static void startContainer() {
+        httptape = new GenericContainer<>("ghcr.io/vibewarden/httptape:latest")
+            .withCommand("serve", "--fixtures", "/fixtures")
+            .withExposedPorts(8081)
+            .withFileSystemBind("./testdata/fixtures", "/fixtures")
+            .waitingFor(Wait.forHttp("/").forStatusCode(404));
+        httptape.start();
+
+        baseUrl = "http://" + httptape.getHost()
+            + ":" + httptape.getMappedPort(8081);
+    }
+
+    @AfterAll
+    static void stopContainer() {
+        if (httptape != null) {
+            httptape.stop();
+        }
+    }
+
+    @Test
+    void replayFixture() throws Exception {
+        var client = HttpClient.newHttpClient();
+        var request = HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl + "/api/users"))
+            .GET()
+            .build();
+
+        var response = client.send(request,
+            HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+    }
+}
+```
+
+---
+
+## Kotlin (Testcontainers)
+
+```kotlin
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import kotlin.test.assertEquals
+
+class HttptapeTest {
+
+    companion object {
+        private lateinit var httptape: GenericContainer<*>
+        lateinit var baseUrl: String
+
+        @BeforeAll
+        @JvmStatic
+        fun startContainer() {
+            httptape = GenericContainer("ghcr.io/vibewarden/httptape:latest")
+                .withCommand("serve", "--fixtures", "/fixtures")
+                .withExposedPorts(8081)
+                .withFileSystemBind("./testdata/fixtures", "/fixtures")
+                .waitingFor(Wait.forHttp("/").forStatusCode(404))
+            httptape.start()
+
+            baseUrl = "http://${httptape.host}:${httptape.getMappedPort(8081)}"
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stopContainer() {
+            httptape.stop()
+        }
+    }
+
+    @Test
+    fun `replay fixture`() {
+        val client = HttpClient.newHttpClient()
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("$baseUrl/api/users"))
+            .GET()
+            .build()
+
+        val response = client.send(request,
+            HttpResponse.BodyHandlers.ofString())
+
+        assertEquals(200, response.statusCode())
+    }
+}
+```
+
+---
+
+## Python (testcontainers-python)
+
+```python
+import requests
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+
+def test_replay_fixture():
+    with DockerContainer("ghcr.io/vibewarden/httptape:latest") \
+        .with_command("serve --fixtures /fixtures") \
+        .with_exposed_ports(8081) \
+        .with_volume_mapping("./testdata/fixtures", "/fixtures") as container:
+
+        wait_for_logs(container, "listening on")
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(8081)
+        base_url = f"http://{host}:{port}"
+
+        resp = requests.get(f"{base_url}/api/users")
+
+        assert resp.status_code == 200
+```
+
+You can also use `pytest` fixtures for shared setup:
+
+```python
+import pytest
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+
+@pytest.fixture(scope="module")
+def httptape_url():
+    container = DockerContainer("ghcr.io/vibewarden/httptape:latest") \
+        .with_command("serve --fixtures /fixtures") \
+        .with_exposed_ports(8081) \
+        .with_volume_mapping("./testdata/fixtures", "/fixtures")
+    container.start()
+    wait_for_logs(container, "listening on")
+
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(8081)
+    yield f"http://{host}:{port}"
+
+    container.stop()
+
+
+def test_users(httptape_url):
+    resp = requests.get(f"{httptape_url}/api/users")
+    assert resp.status_code == 200
+
+
+def test_health(httptape_url):
+    resp = requests.get(f"{httptape_url}/health")
+    assert resp.status_code == 404  # no fixture recorded for /health
+```
+
+---
+
+## Node.js (testcontainers-node)
+
+```javascript
+const { GenericContainer, Wait } = require("testcontainers");
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert");
+
+describe("httptape replay", () => {
+  let container;
+  let baseUrl;
+
+  before(async () => {
+    container = await new GenericContainer(
+      "ghcr.io/vibewarden/httptape:latest"
+    )
+      .withCommand(["serve", "--fixtures", "/fixtures"])
+      .withExposedPorts(8081)
+      .withBindMounts([
+        { source: "./testdata/fixtures", target: "/fixtures" },
+      ])
+      .withWaitStrategy(Wait.forLogMessage("listening on"))
+      .start();
+
+    const host = container.getHost();
+    const port = container.getMappedPort(8081);
+    baseUrl = `http://${host}:${port}`;
+  });
+
+  after(async () => {
+    if (container) {
+      await container.stop();
+    }
+  });
+
+  it("replays a recorded fixture", async () => {
+    const response = await fetch(`${baseUrl}/api/users`);
+    assert.strictEqual(response.status, 200);
+  });
+});
+```
+
+Or with ES modules and a test framework like Vitest:
+
+```typescript
+import { GenericContainer, Wait } from "testcontainers";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+
+describe("httptape replay", () => {
+  let container: any;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    container = await new GenericContainer(
+      "ghcr.io/vibewarden/httptape:latest"
+    )
+      .withCommand(["serve", "--fixtures", "/fixtures"])
+      .withExposedPorts(8081)
+      .withBindMounts([
+        { source: "./testdata/fixtures", target: "/fixtures" },
+      ])
+      .withWaitStrategy(Wait.forLogMessage("listening on"))
+      .start();
+
+    const host = container.getHost();
+    const port = container.getMappedPort(8081);
+    baseUrl = `http://${host}:${port}`;
+  });
+
+  afterAll(async () => {
+    await container?.stop();
+  });
+
+  it("replays a recorded fixture", async () => {
+    const response = await fetch(`${baseUrl}/api/users`);
+    expect(response.status).toBe(200);
+  });
+});
+```
+
+---
+
+## Generic Docker CLI
+
+If your language or test framework does not have a Testcontainers library, you can use the Docker CLI directly. This works from any language via shell commands or a Docker SDK.
+
+### Start the container
+
+```bash
+docker run -d \
+  --name httptape-mock \
+  -p 8081:8081 \
+  -v "$PWD/testdata/fixtures:/fixtures" \
+  ghcr.io/vibewarden/httptape:latest \
+  serve --fixtures /fixtures
+```
+
+### Verify it is running
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/api/users
+# 200 (if a fixture exists for GET /api/users)
+```
+
+### Use replay headers
+
+```bash
+docker run -d \
+  --name httptape-mock \
+  -p 8081:8081 \
+  -v "$PWD/testdata/fixtures:/fixtures" \
+  ghcr.io/vibewarden/httptape:latest \
+  serve --fixtures /fixtures \
+  --replay-header "Authorization=Bearer test-token" \
+  --replay-header "X-Request-Id=integration-test-001"
+```
+
+### Stop and remove
+
+```bash
+docker stop httptape-mock && docker rm httptape-mock
+```
+
+### Docker Compose
+
+```yaml
+# docker-compose.test.yml
+services:
+  httptape:
+    image: ghcr.io/vibewarden/httptape:latest
+    command: ["serve", "--fixtures", "/fixtures"]
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./testdata/fixtures:/fixtures:ro
+```
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+# run your tests against http://localhost:8081
+docker compose -f docker-compose.test.yml down
+```
+
+---
+
+## Tips
+
+- **Fixture directory**: always mount it read-only (`:ro`) in serve mode to prevent accidental writes.
+- **Port conflicts**: use `--port` inside the container and map to a random host port (`-p 0:8081`) to avoid conflicts in CI.
+- **Wait strategies**: prefer waiting for the `"listening on"` log line rather than a fixed sleep.
+- **Replay headers**: use `--replay-header` to inject environment-specific headers (tokens, trace IDs) without editing fixtures.
+- **CORS**: pass `--cors` if your frontend tests make requests from a browser context.
+
+## See also
+
+- [Docker](docker.md) -- Dockerfile reference and Docker Compose examples
+- [Testcontainers (Go)](testcontainers.md) -- native Go Testcontainers module
+- [CLI](cli.md) -- full CLI flag reference
+- [Replay](replay.md) -- server options and replay behavior

--- a/server.go
+++ b/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	delay          time.Duration    // fixed delay before every response; zero means no delay
 	errorRate      float64          // fraction of requests that return 500 (0.0-1.0)
 	randFloat      func() float64   // random number generator (injectable for testing)
+	replayHeaders  map[string]string // headers injected into every replayed response
 }
 
 // ServerOption configures a Server.
@@ -92,6 +93,22 @@ func WithErrorRate(rate float64) ServerOption {
 	}
 }
 
+// WithReplayHeaders adds a header that will be injected into every replayed
+// response. It is applied after tape matching and overrides any header with the
+// same key that was present in the recorded tape. WithReplayHeaders may be
+// called multiple times to set multiple headers.
+//
+// Common use cases include injecting authorization tokens, correlation IDs,
+// or cache-control headers that differ between environments.
+func WithReplayHeaders(key, value string) ServerOption {
+	return func(s *Server) {
+		if s.replayHeaders == nil {
+			s.replayHeaders = make(map[string]string)
+		}
+		s.replayHeaders[key] = value
+	}
+}
+
 // withRandFloat overrides the random number generator for testing.
 // This is unexported -- only used in tests to make error simulation
 // deterministic.
@@ -145,7 +162,8 @@ func NewServer(store Store, opts ...ServerOption) *Server {
 //  3. Normal replay -- existing match-and-respond logic
 //  4. Per-fixture error override -- after matching, before writing
 //  5. Delay -- sleep before writing the real response
-//  6. Write response
+//  6. Replay header injection -- override/add headers from WithReplayHeaders
+//  7. Write response
 //
 // Performance note: ServeHTTP calls Store.List with an empty filter on every
 // request, resulting in an O(n) scan over all tapes. This is acceptable for
@@ -243,11 +261,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for key, values := range tape.Response.Headers {
 		w.Header()[key] = append([]string(nil), values...)
 	}
-	// 8b: remove Content-Length — the recorded value may be stale if the body
+	// 8b: apply replay header overrides (if any).
+	for key, value := range s.replayHeaders {
+		w.Header().Set(key, value)
+	}
+	// 8c: remove Content-Length — the recorded value may be stale if the body
 	// was modified by sanitization. Let net/http set it from the actual body.
 	w.Header().Del("Content-Length")
-	// 8c: write status code.
+	// 8d: write status code.
 	w.WriteHeader(tape.Response.StatusCode)
-	// 8d: write body.
+	// 8e: write body.
 	w.Write(tape.Response.Body) //nolint:errcheck // response write failure is not actionable
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1087,3 +1087,73 @@ func TestTape_MetadataRoundTrip(t *testing.T) {
 		t.Errorf("delay = %v, want 500ms", tape.Metadata["delay"])
 	}
 }
+
+func TestServer_ReplayHeaders_Override(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/api/data", 200, `{"ok":true}`, http.Header{
+		"Authorization": {"Bearer original-token"},
+		"Content-Type":  {"application/json"},
+	})
+
+	srv := NewServer(store,
+		WithReplayHeaders("Authorization", "Bearer injected-token"),
+	)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Authorization"); got != "Bearer injected-token" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer injected-token")
+	}
+	// Original header that was NOT overridden should still be present.
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+}
+
+func TestServer_ReplayHeaders_Multiple(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/multi", 200, "ok", http.Header{})
+
+	srv := NewServer(store,
+		WithReplayHeaders("X-Request-Id", "req-123"),
+		WithReplayHeaders("X-Trace-Id", "trace-456"),
+		WithReplayHeaders("Cache-Control", "no-store"),
+	)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/multi", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	tests := map[string]string{
+		"X-Request-Id":  "req-123",
+		"X-Trace-Id":    "trace-456",
+		"Cache-Control":  "no-store",
+	}
+	for key, want := range tests {
+		if got := rec.Header().Get(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestServer_ReplayHeaders_NotSetByDefault(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/default", 200, "ok", http.Header{
+		"X-Original": {"value"},
+	})
+
+	srv := NewServer(store) // no WithReplayHeaders
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/default", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Original"); got != "value" {
+		t.Errorf("X-Original = %q, want %q", got, "value")
+	}
+}


### PR DESCRIPTION
Closes #104, Closes #105

## Summary
- Add `WithReplayHeaders(key, value)` ServerOption for replay-time header injection
- Add `--replay-header` repeatable CLI flag on serve command
- Add `docs/other-languages.md` with testcontainers examples for Java, Kotlin, Python, Node.js
- Add ADR-25 documenting the replay headers design

## Test plan
- [x] `go test ./... -race` passes
- [x] Replay header override tests
- [x] Multiple header overrides
