### PR TITLE
docs: add MkDocs Material site and deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Deploy docs to vibewarden.dev
+
+on:
+  push:
+    branches: [main]
+    paths: ["docs/**", "mkdocs.yml", ".github/workflows/docs.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material==9.5.* mkdocs-minify-plugin pymdown-extensions
+      - run: mkdocs build --strict --site-dir _site/docs
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          external_repository: vibewarden/vibewarden.dev
+          publish_branch: main
+          publish_dir: ./_site/docs
+          destination_dir: docs/httptape
+          keep_files: true
+          commit_message: "docs: sync from vibewarden/httptape@${{ github.sha }}"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,85 @@
+site_name: httptape
+site_description: HTTP traffic recording, sanitization, and replay for Go.
+site_url: https://vibewarden.dev/docs/httptape
+repo_url: https://github.com/VibeWarden/httptape
+repo_name: VibeWarden/httptape
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: cyan
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: cyan
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - toc.follow
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Core Concepts:
+      - Recording: recording.md
+      - Replay: replay.md
+      - Sanitization: sanitization.md
+      - Matching: matching.md
+      - Storage: storage.md
+  - Guides:
+      - Fixture Authoring: fixtures-authoring.md
+      - Import/Export: import-export.md
+      - UI-First Development: ui-first-dev.md
+      - Other Languages: other-languages.md
+  - Operations:
+      - Configuration: config.md
+      - CLI: cli.md
+      - Docker: docker.md
+      - Testcontainers: testcontainers.md
+  - API Reference: api-reference.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/VibeWarden/httptape


### PR DESCRIPTION
## Summary

- Add `docs/fixtures-authoring.md` (#93): comprehensive guide for hand-writing Tape JSON fixture files, covering the full JSON structure with field descriptions, working examples for GET/POST/204/paginated responses, metadata-based delay and error simulation, FileStore directory layout, and base64 encoding tips.
- Add `docs/ui-first-dev.md` (#97): practical guide for using httptape as a mock backend during frontend development, covering two workflows (hand-write vs record from staging), Docker Compose setup with a frontend service, CORS configuration (`--cors` flag), hot-reload behavior (edit fixture files without restarting), latency simulation for loading states, error simulation for error UI testing, and a comparison table with json-server and Mockoon.

Closes #93, closes #97

## Test plan

- [ ] Verify all JSON examples in fixtures-authoring.md are valid JSON
- [ ] Verify base64-encoded bodies decode to the documented JSON payloads
- [ ] Verify Docker Compose example in ui-first-dev.md is valid YAML
- [ ] Verify cross-references between the two new docs and existing docs resolve correctly
- [ ] Verify the docs render correctly on GitHub (markdown tables, code blocks, links)

Generated with [Claude Code](https://claude.com/claude-code)
