### PR TITLE
feat: add TLS/mTLS support for upstream connections

### DIFF
--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -204,6 +204,10 @@ func runRecord(args []string) error {
 	configPath := fs.String("config", "", "Path to sanitization config JSON")
 	port := fs.Int("port", 8081, "Listen port")
 	cors := fs.Bool("cors", false, "Enable CORS headers (Access-Control-Allow-Origin: *)")
+	tlsCert := fs.String("tls-cert", "", "Path to PEM client certificate for mTLS")
+	tlsKey := fs.String("tls-key", "", "Path to PEM client private key for mTLS")
+	tlsCA := fs.String("tls-ca", "", "Path to PEM CA certificate(s) for upstream verification")
+	tlsInsecure := fs.Bool("tls-insecure", false, "Skip TLS verification (dev only)")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -231,11 +235,24 @@ func runRecord(args []string) error {
 		return fmt.Errorf("create store: %w", err)
 	}
 
+	if *tlsInsecure {
+		logger.Println("WARNING: --tls-insecure disables TLS verification. Do not use in production.")
+	}
+
+	tlsCfg, err := httptape.BuildTLSConfig(*tlsCert, *tlsKey, *tlsCA, *tlsInsecure)
+	if err != nil {
+		return &usageError{err}
+	}
+
 	var recorderOpts []httptape.RecorderOption
 	recorderOpts = append(recorderOpts, httptape.WithAsync(true))
 	recorderOpts = append(recorderOpts, httptape.WithOnError(func(err error) {
 		logger.Printf("recorder error: %v", err)
 	}))
+
+	if tlsCfg != nil {
+		recorderOpts = append(recorderOpts, httptape.WithRecorderTLSConfig(tlsCfg))
+	}
 
 	if *configPath != "" {
 		cfg, err := httptape.LoadConfigFile(*configPath)
@@ -313,6 +330,10 @@ func runProxy(args []string) error {
 	port := fs.Int("port", 8081, "Listen port")
 	cors := fs.Bool("cors", false, "Enable CORS headers (Access-Control-Allow-Origin: *)")
 	fallbackOn5xx := fs.Bool("fallback-on-5xx", false, "Also fall back on 5xx responses from upstream")
+	tlsCert := fs.String("tls-cert", "", "Path to PEM client certificate for mTLS")
+	tlsKey := fs.String("tls-key", "", "Path to PEM client private key for mTLS")
+	tlsCA := fs.String("tls-ca", "", "Path to PEM CA certificate(s) for upstream verification")
+	tlsInsecure := fs.Bool("tls-insecure", false, "Skip TLS verification (dev only)")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -341,10 +362,23 @@ func runProxy(args []string) error {
 		return fmt.Errorf("create L2 store: %w", err)
 	}
 
+	if *tlsInsecure {
+		logger.Println("WARNING: --tls-insecure disables TLS verification. Do not use in production.")
+	}
+
+	tlsCfg, err := httptape.BuildTLSConfig(*tlsCert, *tlsKey, *tlsCA, *tlsInsecure)
+	if err != nil {
+		return &usageError{err}
+	}
+
 	var proxyOpts []httptape.ProxyOption
 	proxyOpts = append(proxyOpts, httptape.WithProxyOnError(func(err error) {
 		logger.Printf("proxy error: %v", err)
 	}))
+
+	if tlsCfg != nil {
+		proxyOpts = append(proxyOpts, httptape.WithProxyTLSConfig(tlsCfg))
+	}
 
 	if *configPath != "" {
 		cfg, err := httptape.LoadConfigFile(*configPath)

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,0 +1,157 @@
+# TLS / mTLS Configuration
+
+httptape supports custom TLS configuration for **outbound** connections
+(httptape to upstream). This enables recording and proxying through backends
+that use self-signed certificates, internal CAs, or mutual TLS (mTLS).
+
+!!! note "Inbound connections are not affected"
+    The TLS flags configure only the connection **from httptape to the upstream**.
+    httptape itself listens on plain HTTP. Place a reverse proxy (nginx, Caddy)
+    in front of httptape if you need TLS on the inbound side.
+
+## Four levels of TLS
+
+| Level | Use case | Configuration |
+|-------|----------|---------------|
+| **Basic TLS** | Upstream uses HTTPS with a publicly trusted certificate | None -- works out of the box |
+| **Custom CA** | Upstream uses a self-signed or internal CA certificate | `--tls-ca` |
+| **mTLS** | Upstream requires a client certificate | `--tls-cert` + `--tls-key` (+ optional `--tls-ca`) |
+| **Skip verify** | Dev shortcut when certs are broken or self-signed | `--tls-insecure` |
+
+## CLI usage
+
+### Custom CA
+
+```bash
+httptape record \
+  --upstream https://internal-api.corp:8443 \
+  --fixtures ./fixtures \
+  --tls-ca /path/to/internal-ca.pem
+```
+
+### Mutual TLS (mTLS)
+
+```bash
+httptape proxy \
+  --upstream https://secure-api.corp:8443 \
+  --fixtures ./fixtures \
+  --tls-cert /path/to/client.crt \
+  --tls-key  /path/to/client.key \
+  --tls-ca   /path/to/internal-ca.pem
+```
+
+### Skip TLS verification (dev only)
+
+```bash
+httptape record \
+  --upstream https://localhost:8443 \
+  --fixtures ./fixtures \
+  --tls-insecure
+```
+
+!!! warning
+    `--tls-insecure` disables all certificate verification. **Never use this in
+    production.** A warning is printed to stderr when this flag is active.
+
+## Go library usage
+
+### BuildTLSConfig helper
+
+The `BuildTLSConfig` function converts file paths into a `*tls.Config`:
+
+```go
+import "github.com/VibeWarden/httptape"
+
+// Custom CA only
+tlsCfg, err := httptape.BuildTLSConfig("", "", "/path/to/ca.pem", false)
+
+// mTLS with custom CA
+tlsCfg, err := httptape.BuildTLSConfig(
+    "/path/to/client.crt",
+    "/path/to/client.key",
+    "/path/to/ca.pem",
+    false,
+)
+
+// Skip verification (dev only)
+tlsCfg, err := httptape.BuildTLSConfig("", "", "", true)
+```
+
+When all arguments are zero-valued, `BuildTLSConfig` returns `nil, nil` (use Go
+defaults).
+
+### Recorder with TLS
+
+```go
+tlsCfg, err := httptape.BuildTLSConfig("", "", "ca.pem", false)
+if err != nil {
+    log.Fatal(err)
+}
+
+store, _ := httptape.NewFileStore(httptape.WithDirectory("fixtures"))
+rec := httptape.NewRecorder(store, httptape.WithRecorderTLSConfig(tlsCfg))
+defer rec.Close()
+
+client := &http.Client{Transport: rec}
+resp, err := client.Get("https://internal-api.corp:8443/v1/data")
+```
+
+### Proxy with TLS
+
+```go
+tlsCfg, err := httptape.BuildTLSConfig("client.crt", "client.key", "ca.pem", false)
+if err != nil {
+    log.Fatal(err)
+}
+
+l1 := httptape.NewMemoryStore()
+l2, _ := httptape.NewFileStore(httptape.WithDirectory("fixtures"))
+proxy := httptape.NewProxy(l1, l2, httptape.WithProxyTLSConfig(tlsCfg))
+
+client := &http.Client{Transport: proxy}
+```
+
+## Docker
+
+When running httptape in Docker, mount your certificate files into the
+container:
+
+```bash
+docker run -v /host/certs:/certs:ro \
+  httptape record \
+  --upstream https://backend:8443 \
+  --fixtures /data/fixtures \
+  --tls-cert /certs/client.crt \
+  --tls-key  /certs/client.key \
+  --tls-ca   /certs/ca.pem
+```
+
+## Troubleshooting
+
+### "x509: certificate signed by unknown authority"
+
+The upstream certificate is not trusted. Provide the CA certificate with
+`--tls-ca`, or use `--tls-insecure` as a temporary workaround.
+
+### "x509: certificate has expired or is not yet valid"
+
+The upstream (or client) certificate is outside its validity window. Check the
+`NotBefore` and `NotAfter` fields with:
+
+```bash
+openssl x509 -in cert.pem -noout -dates
+```
+
+### "tls: private key does not match public key"
+
+The `--tls-cert` and `--tls-key` files do not form a valid pair. Verify with:
+
+```bash
+openssl x509 -in client.crt -noout -modulus | md5
+openssl ec    -in client.key -noout         -modulus 2>/dev/null | md5
+# (Use openssl rsa for RSA keys)
+```
+
+### "--tls-cert requires --tls-key" (or vice versa)
+
+Client certificate and key must be provided together. Supply both or neither.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
   - Operations:
       - Configuration: config.md
       - CLI: cli.md
+      - TLS / mTLS: tls.md
       - Docker: docker.md
       - Testcontainers: testcontainers.md
   - API Reference: api-reference.md

--- a/proxy.go
+++ b/proxy.go
@@ -3,6 +3,7 @@ package httptape
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -91,6 +92,25 @@ func WithProxyOnError(fn func(error)) ProxyOption {
 func WithProxyFallbackOn(fn func(err error, resp *http.Response) bool) ProxyOption {
 	return func(p *Proxy) {
 		p.isFallback = fn
+	}
+}
+
+// WithProxyTLSConfig sets the TLS configuration for outbound connections.
+// The provided config is applied to the inner http.Transport's TLSClientConfig.
+// If the current transport is not an *http.Transport, a new *http.Transport is
+// created with the TLS config set.
+//
+// If cfg is nil, this option is a no-op.
+func WithProxyTLSConfig(cfg *tls.Config) ProxyOption {
+	return func(p *Proxy) {
+		if cfg == nil {
+			return
+		}
+		if t, ok := p.transport.(*http.Transport); ok {
+			t.TLSClientConfig = cfg
+			return
+		}
+		p.transport = &http.Transport{TLSClientConfig: cfg}
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -107,6 +107,10 @@ func WithProxyTLSConfig(cfg *tls.Config) ProxyOption {
 			return
 		}
 		if t, ok := p.transport.(*http.Transport); ok {
+			if t == http.DefaultTransport.(*http.Transport) {
+				p.transport = &http.Transport{TLSClientConfig: cfg}
+				return
+			}
 			t.TLSClientConfig = cfg
 			return
 		}

--- a/recorder.go
+++ b/recorder.go
@@ -3,6 +3,7 @@ package httptape
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -151,6 +152,25 @@ func WithMaxBodySize(n int) RecorderOption {
 func WithSkipRedirects(skip bool) RecorderOption {
 	return func(r *Recorder) {
 		r.skipRedirects = skip
+	}
+}
+
+// WithRecorderTLSConfig sets the TLS configuration for outbound connections.
+// The provided config is applied to the inner http.Transport's TLSClientConfig.
+// If the current transport is not an *http.Transport, a new *http.Transport is
+// created with the TLS config set.
+//
+// If cfg is nil, this option is a no-op.
+func WithRecorderTLSConfig(cfg *tls.Config) RecorderOption {
+	return func(r *Recorder) {
+		if cfg == nil {
+			return
+		}
+		if t, ok := r.transport.(*http.Transport); ok {
+			t.TLSClientConfig = cfg
+			return
+		}
+		r.transport = &http.Transport{TLSClientConfig: cfg}
 	}
 }
 

--- a/recorder.go
+++ b/recorder.go
@@ -167,6 +167,10 @@ func WithRecorderTLSConfig(cfg *tls.Config) RecorderOption {
 			return
 		}
 		if t, ok := r.transport.(*http.Transport); ok {
+			if t == http.DefaultTransport.(*http.Transport) {
+				r.transport = &http.Transport{TLSClientConfig: cfg}
+				return
+			}
 			t.TLSClientConfig = cfg
 			return
 		}

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,67 @@
+package httptape
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// BuildTLSConfig constructs a *tls.Config from optional PEM file paths and an
+// insecure flag. All parameters are optional; an all-zero call returns nil
+// (meaning "use Go defaults").
+//
+// Parameters:
+//   - certFile, keyFile: PEM-encoded client certificate and private key for
+//     mTLS. Both must be provided together; providing one without the other
+//     returns an error.
+//   - caFile: PEM-encoded CA certificate(s) to use as the root CA pool for
+//     verifying the upstream server. When empty, the system root CAs are used.
+//   - insecure: when true, sets InsecureSkipVerify on the returned config.
+//
+// Returns nil, nil when all parameters are zero-valued (no custom TLS needed).
+func BuildTLSConfig(certFile, keyFile, caFile string, insecure bool) (*tls.Config, error) {
+	// Validate cert/key pairing: both or neither.
+	if certFile != "" && keyFile == "" {
+		return nil, fmt.Errorf("httptape: --tls-cert requires --tls-key")
+	}
+	if keyFile != "" && certFile == "" {
+		return nil, fmt.Errorf("httptape: --tls-key requires --tls-cert")
+	}
+
+	// If nothing is configured, return nil (use Go defaults).
+	if certFile == "" && keyFile == "" && caFile == "" && !insecure {
+		return nil, nil
+	}
+
+	cfg := &tls.Config{}
+
+	// Load client certificate for mTLS.
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("httptape: load client certificate: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+
+	// Load custom CA.
+	if caFile != "" {
+		caPEM, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("httptape: read CA file: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("httptape: no valid certificates found in CA file %q", caFile)
+		}
+		cfg.RootCAs = pool
+	}
+
+	// Insecure skip verify.
+	if insecure {
+		cfg.InsecureSkipVerify = true
+	}
+
+	return cfg, nil
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,461 @@
+package httptape
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// testCert holds PEM-encoded certificate and key bytes generated for testing.
+type testCert struct {
+	CertPEM []byte
+	KeyPEM  []byte
+	Cert    *x509.Certificate
+	Key     *ecdsa.PrivateKey
+}
+
+// generateTestCA creates a self-signed CA certificate for testing.
+func generateTestCA(t *testing.T) testCert {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("parse CA certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal CA key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return testCert{CertPEM: certPEM, KeyPEM: keyPEM, Cert: cert, Key: key}
+}
+
+// generateTestLeaf creates a leaf certificate signed by the given CA.
+func generateTestLeaf(t *testing.T, ca testCert) testCert {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca.Cert, &key.PublicKey, ca.Key)
+	if err != nil {
+		t.Fatalf("create leaf certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("parse leaf certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return testCert{CertPEM: certPEM, KeyPEM: keyPEM, Cert: cert, Key: key}
+}
+
+// writePEM writes PEM data to a temp file and returns the path.
+func writePEM(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+func TestBuildTLSConfig_NoArgs(t *testing.T) {
+	cfg, err := BuildTLSConfig("", "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatal("expected nil config when no args provided")
+	}
+}
+
+func TestBuildTLSConfig_CertWithoutKey(t *testing.T) {
+	_, err := BuildTLSConfig("cert.pem", "", "", false)
+	if err == nil {
+		t.Fatal("expected error when cert provided without key")
+	}
+}
+
+func TestBuildTLSConfig_KeyWithoutCert(t *testing.T) {
+	_, err := BuildTLSConfig("", "key.pem", "", false)
+	if err == nil {
+		t.Fatal("expected error when key provided without cert")
+	}
+}
+
+func TestBuildTLSConfig_InsecureOnly(t *testing.T) {
+	cfg, err := BuildTLSConfig("", "", "", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config with insecure=true")
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=true")
+	}
+}
+
+func TestBuildTLSConfig_CertAndKey(t *testing.T) {
+	ca := generateTestCA(t)
+	leaf := generateTestLeaf(t, ca)
+
+	dir := t.TempDir()
+	certPath := writePEM(t, dir, "client.crt", leaf.CertPEM)
+	keyPath := writePEM(t, dir, "client.key", leaf.KeyPEM)
+
+	cfg, err := BuildTLSConfig(certPath, keyPath, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(cfg.Certificates))
+	}
+}
+
+func TestBuildTLSConfig_CAOnly(t *testing.T) {
+	ca := generateTestCA(t)
+
+	dir := t.TempDir()
+	caPath := writePEM(t, dir, "ca.crt", ca.CertPEM)
+
+	cfg, err := BuildTLSConfig("", "", caPath, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("expected non-nil RootCAs")
+	}
+}
+
+func TestBuildTLSConfig_AllOptions(t *testing.T) {
+	ca := generateTestCA(t)
+	leaf := generateTestLeaf(t, ca)
+
+	dir := t.TempDir()
+	certPath := writePEM(t, dir, "client.crt", leaf.CertPEM)
+	keyPath := writePEM(t, dir, "client.key", leaf.KeyPEM)
+	caPath := writePEM(t, dir, "ca.crt", ca.CertPEM)
+
+	cfg, err := BuildTLSConfig(certPath, keyPath, caPath, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(cfg.Certificates))
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("expected non-nil RootCAs")
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=true")
+	}
+}
+
+func TestBuildTLSConfig_NonExistentCertFile(t *testing.T) {
+	_, err := BuildTLSConfig("/nonexistent/cert.pem", "/nonexistent/key.pem", "", false)
+	if err == nil {
+		t.Fatal("expected error for non-existent cert file")
+	}
+}
+
+func TestBuildTLSConfig_NonExistentCAFile(t *testing.T) {
+	_, err := BuildTLSConfig("", "", "/nonexistent/ca.pem", false)
+	if err == nil {
+		t.Fatal("expected error for non-existent CA file")
+	}
+}
+
+func TestBuildTLSConfig_InvalidPEMCA(t *testing.T) {
+	dir := t.TempDir()
+	badCA := filepath.Join(dir, "bad-ca.pem")
+	if err := os.WriteFile(badCA, []byte("not valid PEM"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := BuildTLSConfig("", "", badCA, false)
+	if err == nil {
+		t.Fatal("expected error for invalid PEM in CA file")
+	}
+}
+
+// TestRecorderTLSIntegration verifies that a Recorder can record from an
+// HTTPS server when configured with the server's CA certificate.
+func TestRecorderTLSIntegration(t *testing.T) {
+	// Start a TLS test server.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello tls"))
+	}))
+	defer ts.Close()
+
+	// Extract the server's CA certificate and write it to a temp file.
+	serverCert := ts.TLS.Certificates[0]
+	parsed, err := x509.ParseCertificate(serverCert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse server cert: %v", err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: parsed.Raw})
+
+	dir := t.TempDir()
+	caPath := writePEM(t, dir, "server-ca.crt", caPEM)
+
+	tlsCfg, err := BuildTLSConfig("", "", caPath, false)
+	if err != nil {
+		t.Fatalf("BuildTLSConfig: %v", err)
+	}
+
+	store := NewMemoryStore()
+	recorder := NewRecorder(store,
+		WithAsync(false),
+		WithRecorderTLSConfig(tlsCfg),
+	)
+	defer recorder.Close()
+
+	client := &http.Client{Transport: recorder}
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if string(body) != "hello tls" {
+		t.Fatalf("expected 'hello tls', got %q", string(body))
+	}
+
+	// Verify tape was recorded.
+	tapes, err := store.List(t.Context(), Filter{})
+	if err != nil {
+		t.Fatalf("store.List: %v", err)
+	}
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+}
+
+// TestProxyTLSIntegration verifies that a Proxy can forward to an HTTPS
+// server when configured with the server's CA certificate.
+func TestProxyTLSIntegration(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello proxy tls"))
+	}))
+	defer ts.Close()
+
+	serverCert := ts.TLS.Certificates[0]
+	parsed, err := x509.ParseCertificate(serverCert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse server cert: %v", err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: parsed.Raw})
+
+	dir := t.TempDir()
+	caPath := writePEM(t, dir, "server-ca.crt", caPEM)
+
+	tlsCfg, err := BuildTLSConfig("", "", caPath, false)
+	if err != nil {
+		t.Fatalf("BuildTLSConfig: %v", err)
+	}
+
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+	proxy := NewProxy(l1, l2, WithProxyTLSConfig(tlsCfg))
+
+	client := &http.Client{Transport: proxy}
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if string(body) != "hello proxy tls" {
+		t.Fatalf("expected 'hello proxy tls', got %q", string(body))
+	}
+
+	// Verify tapes were saved.
+	tapes, err := l1.List(t.Context(), Filter{})
+	if err != nil {
+		t.Fatalf("l1.List: %v", err)
+	}
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape in L1, got %d", len(tapes))
+	}
+}
+
+// TestWithRecorderTLSConfig_InsecureSkipVerify verifies the insecure shortcut.
+func TestWithRecorderTLSConfig_InsecureSkipVerify(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("insecure ok"))
+	}))
+	defer ts.Close()
+
+	tlsCfg, err := BuildTLSConfig("", "", "", true)
+	if err != nil {
+		t.Fatalf("BuildTLSConfig: %v", err)
+	}
+
+	store := NewMemoryStore()
+	recorder := NewRecorder(store,
+		WithAsync(false),
+		WithRecorderTLSConfig(tlsCfg),
+	)
+	defer recorder.Close()
+
+	client := &http.Client{Transport: recorder}
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestWithProxyTLSConfig_NilConfig verifies that passing nil is a no-op.
+func TestWithProxyTLSConfig_NilConfig(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	// Should not panic or change transport.
+	proxy := NewProxy(l1, l2, WithProxyTLSConfig(nil))
+	if proxy.transport != http.DefaultTransport {
+		t.Fatal("expected default transport when TLS config is nil")
+	}
+}
+
+// TestWithRecorderTLSConfig_NilConfig verifies that passing nil is a no-op.
+func TestWithRecorderTLSConfig_NilConfig(t *testing.T) {
+	store := NewMemoryStore()
+	recorder := NewRecorder(store, WithRecorderTLSConfig(nil))
+	defer recorder.Close()
+
+	if recorder.transport != http.DefaultTransport {
+		t.Fatal("expected default transport when TLS config is nil")
+	}
+}
+
+// TestWithProxyTLSConfig_CustomTransport verifies that TLS config is applied
+// to an existing *http.Transport.
+func TestWithProxyTLSConfig_CustomTransport(t *testing.T) {
+	tlsCfg := &tls.Config{InsecureSkipVerify: true}
+	existing := &http.Transport{MaxIdleConns: 42}
+
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(existing),
+		WithProxyTLSConfig(tlsCfg),
+	)
+
+	transport, ok := proxy.transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if transport.TLSClientConfig != tlsCfg {
+		t.Fatal("expected TLS config to be set on existing transport")
+	}
+	if transport.MaxIdleConns != 42 {
+		t.Fatal("expected existing transport settings to be preserved")
+	}
+}
+
+// TestWithRecorderTLSConfig_CustomTransport verifies that TLS config is
+// applied to an existing *http.Transport.
+func TestWithRecorderTLSConfig_CustomTransport(t *testing.T) {
+	tlsCfg := &tls.Config{InsecureSkipVerify: true}
+	existing := &http.Transport{MaxIdleConns: 42}
+
+	store := NewMemoryStore()
+	recorder := NewRecorder(store,
+		WithTransport(existing),
+		WithRecorderTLSConfig(tlsCfg),
+	)
+	defer recorder.Close()
+
+	transport, ok := recorder.transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if transport.TLSClientConfig != tlsCfg {
+		t.Fatal("expected TLS config to be set on existing transport")
+	}
+	if transport.MaxIdleConns != 42 {
+		t.Fatal("expected existing transport settings to be preserved")
+	}
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -435,6 +435,55 @@ func TestWithProxyTLSConfig_CustomTransport(t *testing.T) {
 	}
 }
 
+// TestWithProxyTLSConfig_DoesNotMutateDefaultTransport verifies that using
+// WithProxyTLSConfig without a custom transport does not mutate
+// http.DefaultTransport.
+func TestWithProxyTLSConfig_DoesNotMutateDefaultTransport(t *testing.T) {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	originalTLS := defaultTransport.TLSClientConfig
+
+	tlsCfg := &tls.Config{InsecureSkipVerify: true}
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+	proxy := NewProxy(l1, l2, WithProxyTLSConfig(tlsCfg))
+
+	// The proxy must have a new transport, not the default one.
+	if proxy.transport == http.DefaultTransport {
+		t.Fatal("expected proxy transport to differ from http.DefaultTransport")
+	}
+
+	// http.DefaultTransport must not have been mutated.
+	if defaultTransport.TLSClientConfig != originalTLS {
+		t.Fatal("http.DefaultTransport.TLSClientConfig was mutated by WithProxyTLSConfig")
+	}
+}
+
+// TestWithRecorderTLSConfig_DoesNotMutateDefaultTransport verifies that using
+// WithRecorderTLSConfig without a custom transport does not mutate
+// http.DefaultTransport.
+func TestWithRecorderTLSConfig_DoesNotMutateDefaultTransport(t *testing.T) {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	originalTLS := defaultTransport.TLSClientConfig
+
+	tlsCfg := &tls.Config{InsecureSkipVerify: true}
+	store := NewMemoryStore()
+	recorder := NewRecorder(store,
+		WithAsync(false),
+		WithRecorderTLSConfig(tlsCfg),
+	)
+	defer recorder.Close()
+
+	// The recorder must have a new transport, not the default one.
+	if recorder.transport == http.DefaultTransport {
+		t.Fatal("expected recorder transport to differ from http.DefaultTransport")
+	}
+
+	// http.DefaultTransport must not have been mutated.
+	if defaultTransport.TLSClientConfig != originalTLS {
+		t.Fatal("http.DefaultTransport.TLSClientConfig was mutated by WithRecorderTLSConfig")
+	}
+}
+
 // TestWithRecorderTLSConfig_CustomTransport verifies that TLS config is
 // applied to an existing *http.Transport.
 func TestWithRecorderTLSConfig_CustomTransport(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `BuildTLSConfig` helper in `tls.go` that constructs `*tls.Config` from PEM file paths and an insecure flag (stdlib only)
- Add `WithProxyTLSConfig` and `WithRecorderTLSConfig` functional options for the Go library API
- Add `--tls-cert`, `--tls-key`, `--tls-ca`, `--tls-insecure` CLI flags to `proxy` and `record` subcommands
- Add comprehensive unit tests (cert/key validation, CA loading, insecure mode, error cases) and integration tests using `httptest.NewTLSServer`
- Add `docs/tls.md` with CLI examples, Go library examples, Docker guidance, and troubleshooting

Implements ADR-27. Closes #112.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -race` passes (all new and existing tests)
- [ ] Verify `BuildTLSConfig` returns `nil, nil` for zero args
- [ ] Verify cert-without-key and key-without-cert return errors
- [ ] Verify integration tests connect to TLS server with custom CA
- [ ] Verify insecure mode skips verification against TLS test server
- [ ] Verify nil TLS config is a no-op for both Proxy and Recorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
