### PR TITLE
fix(#114): strip Content-Length from Proxy L2 fallback responses

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -311,6 +311,9 @@ func (p *Proxy) tapeToResponse(tape Tape, source string) *http.Response {
 		header = tape.Response.Headers.Clone()
 	}
 	header.Set("X-Httptape-Source", source)
+	// Remove stale Content-Length — the body may differ from the original
+	// due to sanitization. Let the HTTP stack set it from actual body size.
+	header.Del("Content-Length")
 
 	body := tape.Response.Body
 	if body == nil {


### PR DESCRIPTION
Closes #114

## Summary
Strip Content-Length header in Proxy.tapeToResponse() before returning cached responses. The stored header reflects the original body size, which differs after sanitization.

## Test plan
- [x] `go test ./... -race` passes
- [x] Manual test: L2 fallback now returns correct Content-Length matching actual body
