### PR TITLE
feat(#116): add pluggable Faker interface with 11 built-in adapters

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,12 +44,17 @@ type Config struct {
 //
 //   - "redact_headers": Headers (optional; defaults to DefaultSensitiveHeaders)
 //   - "redact_body":    Paths (required, non-empty)
-//   - "fake":           Seed (required, non-empty) and Paths (required, non-empty)
+//   - "fake":           Seed (required, non-empty) and either Paths or Fields (mutually exclusive)
+//
+// For "fake" rules, Fields maps JSONPath-like paths to faker specifications.
+// A faker spec is either a string shorthand (e.g., "email", "phone") or an
+// object with a "type" field and type-specific parameters.
 type Rule struct {
-	Action  string   `json:"action"`
-	Headers []string `json:"headers,omitempty"`
-	Paths   []string `json:"paths,omitempty"`
-	Seed    string   `json:"seed,omitempty"`
+	Action  string         `json:"action"`
+	Headers []string       `json:"headers,omitempty"`
+	Paths   []string       `json:"paths,omitempty"`
+	Seed    string         `json:"seed,omitempty"`
+	Fields  map[string]any `json:"fields,omitempty"`
 }
 
 // LoadConfig reads a JSON sanitization config from r, validates it, and
@@ -145,12 +150,25 @@ func (c *Config) Validate() error {
 			if rule.Seed == "" {
 				errs = append(errs, fmt.Sprintf("%s: %q requires non-empty \"seed\"", prefix, rule.Action))
 			}
-			if len(rule.Paths) == 0 {
-				errs = append(errs, fmt.Sprintf("%s: %q requires non-empty \"paths\"", prefix, rule.Action))
+			hasPaths := len(rule.Paths) > 0
+			hasFields := len(rule.Fields) > 0
+			if hasPaths && hasFields {
+				errs = append(errs, fmt.Sprintf("%s: %q cannot use both \"paths\" and \"fields\"", prefix, rule.Action))
+			}
+			if !hasPaths && !hasFields {
+				errs = append(errs, fmt.Sprintf("%s: %q requires non-empty \"paths\" or \"fields\"", prefix, rule.Action))
 			}
 			for _, p := range rule.Paths {
 				if _, ok := parsePath(p); !ok {
 					errs = append(errs, fmt.Sprintf("%s: %q invalid path syntax: %q", prefix, rule.Action, p))
+				}
+			}
+			for path, spec := range rule.Fields {
+				if _, ok := parsePath(path); !ok {
+					errs = append(errs, fmt.Sprintf("%s: %q invalid path syntax: %q", prefix, rule.Action, path))
+				}
+				if _, err := parseFakerSpec(spec); err != nil {
+					errs = append(errs, fmt.Sprintf("%s: %q field %q: %v", prefix, rule.Action, path, err))
 				}
 			}
 			if len(rule.Headers) > 0 {
@@ -181,10 +199,94 @@ func (c *Config) BuildPipeline() *Pipeline {
 		case ActionRedactBody:
 			funcs = append(funcs, RedactBodyPaths(rule.Paths...))
 		case ActionFake:
-			funcs = append(funcs, FakeFields(rule.Seed, rule.Paths...))
+			if len(rule.Fields) > 0 {
+				fakers := make(map[string]Faker, len(rule.Fields))
+				for path, spec := range rule.Fields {
+					f, _ := parseFakerSpec(spec) // already validated
+					fakers[path] = f
+				}
+				funcs = append(funcs, FakeFieldsWith(rule.Seed, fakers))
+			} else {
+				funcs = append(funcs, FakeFields(rule.Seed, rule.Paths...))
+			}
 		}
 	}
 
 	return NewPipeline(funcs...)
+}
+
+// validShorthands maps string shorthand names to zero-value faker constructors.
+var validShorthands = map[string]func() Faker{
+	"redacted":    func() Faker { return RedactedFaker{} },
+	"hmac":        func() Faker { return HMACFaker{} },
+	"email":       func() Faker { return EmailFaker{} },
+	"phone":       func() Faker { return PhoneFaker{} },
+	"credit_card": func() Faker { return CreditCardFaker{} },
+	"address":     func() Faker { return AddressFaker{} },
+}
+
+// parseFakerSpec parses a faker specification from a config value.
+// The spec can be a string shorthand (e.g., "email") or an object with
+// a "type" field and type-specific parameters.
+func parseFakerSpec(spec any) (Faker, error) {
+	switch v := spec.(type) {
+	case string:
+		ctor, ok := validShorthands[v]
+		if !ok {
+			return nil, fmt.Errorf("unknown faker shorthand %q", v)
+		}
+		return ctor(), nil
+
+	case map[string]any:
+		typeName, ok := v["type"].(string)
+		if !ok || typeName == "" {
+			return nil, fmt.Errorf("faker object requires a \"type\" string field")
+		}
+
+		// Check if it's a shorthand name used in object form (no extra params).
+		if ctor, ok := validShorthands[typeName]; ok {
+			return ctor(), nil
+		}
+
+		switch typeName {
+		case "numeric":
+			length, ok := v["length"].(float64)
+			if !ok || length <= 0 {
+				return nil, fmt.Errorf("\"numeric\" faker requires \"length\" > 0")
+			}
+			return NumericFaker{Length: int(length)}, nil
+
+		case "date":
+			format, _ := v["format"].(string)
+			return DateFaker{Format: format}, nil
+
+		case "pattern":
+			pattern, ok := v["pattern"].(string)
+			if !ok || pattern == "" {
+				return nil, fmt.Errorf("\"pattern\" faker requires non-empty \"pattern\" field")
+			}
+			return PatternFaker{Pattern: pattern}, nil
+
+		case "prefix":
+			prefix, ok := v["prefix"].(string)
+			if !ok || prefix == "" {
+				return nil, fmt.Errorf("\"prefix\" faker requires non-empty \"prefix\" field")
+			}
+			return PrefixFaker{Prefix: prefix}, nil
+
+		case "fixed":
+			val, ok := v["value"]
+			if !ok {
+				return nil, fmt.Errorf("\"fixed\" faker requires a \"value\" field")
+			}
+			return FixedFaker{Value: val}, nil
+
+		default:
+			return nil, fmt.Errorf("unknown faker type %q", typeName)
+		}
+
+	default:
+		return nil, fmt.Errorf("faker spec must be a string or object, got %T", spec)
+	}
 }
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -74,10 +74,71 @@
                   "minLength": 3
                 },
                 "minItems": 1,
-                "description": "JSONPath-like paths to fake in request/response bodies."
+                "description": "JSONPath-like paths to fake in request/response bodies (auto-detection mode)."
+              },
+              "fields": {
+                "type": "object",
+                "minProperties": 1,
+                "description": "Map of JSONPath-like paths to faker specifications (explicit faker mode). Mutually exclusive with 'paths'.",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": ["redacted", "hmac", "email", "phone", "credit_card", "address"],
+                      "description": "Faker shorthand name."
+                    },
+                    {
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "Faker type name."
+                        },
+                        "length": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Length for 'numeric' faker."
+                        },
+                        "format": {
+                          "type": "string",
+                          "description": "Go time format for 'date' faker."
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Pattern for 'pattern' faker. '#' = digit, '?' = letter."
+                        },
+                        "prefix": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Prefix for 'prefix' faker."
+                        },
+                        "value": {
+                          "description": "Fixed value for 'fixed' faker."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                }
               }
             },
-            "required": ["action", "seed", "paths"],
+            "required": ["action", "seed"],
+            "oneOf": [
+              {
+                "required": ["paths"],
+                "properties": {
+                  "fields": false
+                }
+              },
+              {
+                "required": ["fields"],
+                "properties": {
+                  "paths": false
+                }
+              }
+            ],
             "additionalProperties": false
           }
         ]

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package httptape
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"strings"
@@ -372,6 +373,211 @@ func TestConfig_Programmatic(t *testing.T) {
 	}
 	if len(pipeline.funcs) != 2 {
 		t.Errorf("pipeline.funcs len = %d, want 2", len(pipeline.funcs))
+	}
+}
+
+func TestLoadConfig_FieldsMode(t *testing.T) {
+	input := `{
+		"version": "1",
+		"rules": [
+			{
+				"action": "fake",
+				"seed": "my-seed",
+				"fields": {
+					"$.email": "email",
+					"$.phone": "phone",
+					"$.card": "credit_card",
+					"$.addr": "address",
+					"$.token": "hmac",
+					"$.secret": "redacted",
+					"$.cvv": {"type": "numeric", "length": 3},
+					"$.ssn": {"type": "pattern", "pattern": "###-##-####"},
+					"$.dob": {"type": "date", "format": "2006-01-02"},
+					"$.ref": {"type": "prefix", "prefix": "ref_"},
+					"$.status": {"type": "fixed", "value": "active"}
+				}
+			}
+		]
+	}`
+
+	cfg, err := LoadConfig(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Rules) != 1 {
+		t.Fatalf("len(rules) = %d, want 1", len(cfg.Rules))
+	}
+	if cfg.Rules[0].Action != ActionFake {
+		t.Errorf("action = %q, want %q", cfg.Rules[0].Action, ActionFake)
+	}
+	if len(cfg.Rules[0].Fields) != 11 {
+		t.Errorf("len(fields) = %d, want 11", len(cfg.Rules[0].Fields))
+	}
+}
+
+func TestLoadConfig_FieldsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "paths and fields mutually exclusive",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","paths":["$.x"],"fields":{"$.y":"email"}}]}`,
+			wantErr: "cannot use both",
+		},
+		{
+			name:    "neither paths nor fields",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s"}]}`,
+			wantErr: "requires non-empty",
+		},
+		{
+			name:    "invalid path in fields key",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","fields":{"badpath":"email"}}]}`,
+			wantErr: "invalid path syntax",
+		},
+		{
+			name:    "unknown faker shorthand",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","fields":{"$.x":"unknown_faker"}}]}`,
+			wantErr: "unknown faker shorthand",
+		},
+		{
+			name:    "numeric missing length",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","fields":{"$.x":{"type":"numeric"}}}]}`,
+			wantErr: "requires \"length\" > 0",
+		},
+		{
+			name:    "pattern missing pattern",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","fields":{"$.x":{"type":"pattern"}}}]}`,
+			wantErr: "requires non-empty \"pattern\"",
+		},
+		{
+			name:    "prefix missing prefix",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","fields":{"$.x":{"type":"prefix"}}}]}`,
+			wantErr: "requires non-empty \"prefix\"",
+		},
+		{
+			name:    "fixed missing value",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","fields":{"$.x":{"type":"fixed"}}}]}`,
+			wantErr: "requires a \"value\"",
+		},
+		{
+			name:    "unknown faker type in object",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","fields":{"$.x":{"type":"bogus"}}}]}`,
+			wantErr: "unknown faker type",
+		},
+		{
+			name:    "invalid spec type",
+			input:   `{"version":"1","rules":[{"action":"fake","seed":"s","fields":{"$.x":42}}]}`,
+			wantErr: "must be a string or object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadConfig(strings.NewReader(tt.input))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConfig_BuildPipeline_Fields(t *testing.T) {
+	cfg := &Config{
+		Version: "1",
+		Rules: []Rule{
+			{
+				Action: ActionFake,
+				Seed:   "test-seed",
+				Fields: map[string]any{
+					"$.email": "email",
+					"$.phone": "phone",
+				},
+			},
+		},
+	}
+
+	pipeline := cfg.BuildPipeline()
+	if pipeline == nil {
+		t.Fatal("BuildPipeline returned nil")
+	}
+	if len(pipeline.funcs) != 1 {
+		t.Errorf("pipeline.funcs len = %d, want 1", len(pipeline.funcs))
+	}
+
+	// Apply to a tape and verify transformation.
+	tape := Tape{
+		Request: RecordedReq{
+			Body:    []byte(`{"email":"alice@corp.com","phone":"555-1234","name":"Alice"}`),
+			Headers: make(map[string][]string),
+		},
+		Response: RecordedResp{
+			Body:    []byte(`{"email":"bob@corp.com","phone":"555-5678"}`),
+			Headers: make(map[string][]string),
+		},
+	}
+
+	result := pipeline.Sanitize(tape)
+
+	// Check request body.
+	var reqData map[string]any
+	if err := json.Unmarshal(result.Request.Body, &reqData); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	email := reqData["email"].(string)
+	if !strings.HasSuffix(email, "@example.com") {
+		t.Errorf("email = %q, want *@example.com", email)
+	}
+	if reqData["name"] != "Alice" {
+		t.Errorf("name = %v, want \"Alice\"", reqData["name"])
+	}
+}
+
+func TestParseFakerSpec_ObjectShorthand(t *testing.T) {
+	// Object form with a shorthand type name (no extra params).
+	spec := map[string]any{"type": "email"}
+	f, err := parseFakerSpec(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := f.(EmailFaker); !ok {
+		t.Errorf("expected EmailFaker, got %T", f)
+	}
+}
+
+func TestParseFakerSpec_AllShorthands(t *testing.T) {
+	shorthands := []string{"redacted", "hmac", "email", "phone", "credit_card", "address"}
+	for _, s := range shorthands {
+		t.Run(s, func(t *testing.T) {
+			f, err := parseFakerSpec(s)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if f == nil {
+				t.Fatal("got nil faker")
+			}
+		})
+	}
+}
+
+func TestParseFakerSpec_DateDefaultFormat(t *testing.T) {
+	spec := map[string]any{"type": "date"}
+	f, err := parseFakerSpec(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	df, ok := f.(DateFaker)
+	if !ok {
+		t.Fatalf("expected DateFaker, got %T", f)
+	}
+	// Format can be empty; DateFaker defaults to "2006-01-02" internally.
+	if df.Format != "" {
+		t.Errorf("format = %q, want empty (default)", df.Format)
 	}
 }
 

--- a/decisions.md
+++ b/decisions.md
@@ -7059,13 +7059,13 @@ deterministic output from the HMAC hash bytes.
 | `FixedFaker` | Returns a caller-supplied constant value | `Value any` |
 | `HMACFaker` | `fake_<hex8>` for strings, positive int for numbers (current generic behavior) | None |
 | `EmailFaker` | `user_<hex8>@example.com` (current email behavior) | None |
-| `PhoneFaker` | `+<country>-555-<hex7digits>` preserving original country code prefix | None |
+| `PhoneFaker` | Digit-by-digit HMAC replacement preserving original formatting (dashes, spaces, parens, plus signs) | None |
 | `CreditCardFaker` | Preserves issuer prefix (first 6 digits), fills middle with HMAC-derived digits, computes valid Luhn check digit | None |
 | `NumericFaker` | HMAC-derived decimal digits of specified length | `Length int` |
-| `DateFaker` | Valid date in caller-specified Go `time.Format` layout, derived from HMAC bytes mapped to valid year/month/day ranges | `Format string` |
+| `DateFaker` | Deterministic date from epoch offset (2000-01-01 + HMAC-derived days mod ~100 years), formatted with caller-specified Go `time.Format` layout | `Format string` |
 | `PatternFaker` | Fills `#` with digits (0-9), `?` with lowercase letters (a-z), literal chars preserved | `Pattern string` |
 | `PrefixFaker` | `<prefix><hex8>` | `Prefix string` |
-| `AddressFaker` | `<number> <street>, <city>, ST <zip>` with deterministic number/street/city/state/zip drawn from small built-in lists indexed by HMAC bytes | None |
+| `AddressFaker` | `<number> <street> <suffix>, <city>, <state> <zip>` with deterministic components drawn from small built-in lists (10 entries each) indexed by HMAC bytes | None |
 
 **Determinism guarantee**: every faker derives its output solely from
 `computeHMAC(seed, fmt.Sprintf("%v", original))`. No randomness, no
@@ -7076,18 +7076,20 @@ using the standard Luhn mod-10 algorithm over the first 15 digits
 (6-digit issuer prefix from the original + 9 HMAC-derived digits). This
 is a pure arithmetic function -- no external dependencies.
 
-**`PhoneFaker` country code preservation**: The faker parses the leading
-`+<digits>` from the original value. If no country code is detected, it
-defaults to `+1`. The remaining digits are replaced with HMAC-derived
-digits, formatted as `+<cc>-555-<digits>` where the digit count matches
-the original (minus country code and separator chars).
+**`PhoneFaker` digit-by-digit replacement**: Each digit in the original
+string is replaced with an HMAC-derived digit (0-9). All non-digit
+characters (dashes, spaces, parentheses, plus signs) are preserved in
+their original positions, maintaining the phone number's formatting.
+If the HMAC bytes are exhausted, a new HMAC is computed from the
+current output to chain additional bytes.
 
-**`DateFaker` valid date generation**: HMAC bytes are mapped to ranges:
-year [2020-2029], month [1-12], day [1-28] (always valid). The result is
-formatted using the caller-specified Go `time.Format` layout string.
+**`DateFaker` epoch offset generation**: The first 4 HMAC bytes are
+interpreted as a uint32 days offset from 2000-01-01, modulo 36525
+(~100 years). The resulting date is formatted using the caller-specified
+Go `time.Format` layout string (default: "2006-01-02").
 
-**`AddressFaker` built-in data**: A small hardcoded list of 16 street
-names, 16 city names, and 50 US state abbreviations. The HMAC bytes
+**`AddressFaker` built-in data**: A small hardcoded list of 10 street
+names, 10 street suffixes, 10 city names, and 50 US state abbreviations. The HMAC bytes
 select indices into these lists. The house number is derived from the
 first 2 HMAC bytes (range [1-9999]). The zip code is 5 HMAC-derived
 digits.

--- a/decisions.md
+++ b/decisions.md
@@ -6992,3 +6992,307 @@ API needed.
 - `proxy_test.go` -- unit tests for all paths
 - `cmd/httptape/main.go` -- `runProxy` function, `proxy` subcommand routing,
   updated usage text
+
+
+---
+
+### ADR-27: Pluggable Faker interface with format-preserving adapters
+
+**Date**: 2026-03-30
+**Issue**: #116
+**Status**: Accepted
+
+#### Context
+
+ADR-7 introduced `FakeFields` with hardcoded type detection (email, UUID,
+numeric, generic string). While this covers common cases, it falls short
+for format-sensitive fields: phone numbers (`+1-555-867-5309` becomes
+`fake_a1b2c3d4`), credit card numbers (no Luhn validation), SSNs, dates,
+and prefix-bearing API tokens (`sk_test_...`). UI display logic and
+client-side validation break when the faked value does not preserve the
+structural format of the original.
+
+The existing `fakeValue` function is an auto-detecting dispatcher. Rather
+than adding ever more detection heuristics, we need a pluggable system
+where users can explicitly assign a faking strategy per field path.
+
+Key constraints from the project constitution:
+- Hexagonal architecture: the `Faker` interface is a port; each built-in
+  faker is an adapter.
+- stdlib only: all implementations use `crypto/hmac`, `crypto/sha256`,
+  `encoding/hex`, `strconv`, `fmt`, `time` -- no external libraries.
+- Deterministic: same seed + same input = same output, always.
+- Backward compatible: `FakeFields` must continue to work unchanged.
+- `SanitizeFunc` contract: return a copy, never mutate the input.
+- No panics in hot paths.
+
+#### Decision
+
+##### 1. The `Faker` interface (port)
+
+```go
+// Faker is a port that produces deterministic fake values from a seed and
+// an original value. Implementations must be deterministic: the same seed
+// and original value must always produce the same output.
+//
+// The seed is the project-level HMAC key. The original is the JSON value
+// being faked (string, float64, bool, nil, map[string]any, []any).
+// The return value replaces the original in the sanitized output.
+type Faker interface {
+    Fake(seed string, original any) any
+}
+```
+
+This is placed in `faker.go` alongside all built-in adapter types. The
+interface is intentionally minimal (one method) to maximize composability
+and keep the implementation burden low for custom fakers.
+
+##### 2. Built-in faker adapters
+
+All adapters are exported struct types implementing `Faker`. Each uses
+`computeHMAC(seed, stringRepr)` from `sanitizer.go` to derive
+deterministic output from the HMAC hash bytes.
+
+| Type | Behavior | Fields |
+|------|----------|--------|
+| `RedactedFaker` | Returns `[REDACTED]` for strings, `0` for numbers, `false` for bools | None |
+| `FixedFaker` | Returns a caller-supplied constant value | `Value any` |
+| `HMACFaker` | `fake_<hex8>` for strings, positive int for numbers (current generic behavior) | None |
+| `EmailFaker` | `user_<hex8>@example.com` (current email behavior) | None |
+| `PhoneFaker` | `+<country>-555-<hex7digits>` preserving original country code prefix | None |
+| `CreditCardFaker` | Preserves issuer prefix (first 6 digits), fills middle with HMAC-derived digits, computes valid Luhn check digit | None |
+| `NumericFaker` | HMAC-derived decimal digits of specified length | `Length int` |
+| `DateFaker` | Valid date in caller-specified Go `time.Format` layout, derived from HMAC bytes mapped to valid year/month/day ranges | `Format string` |
+| `PatternFaker` | Fills `#` with digits (0-9), `?` with lowercase letters (a-z), literal chars preserved | `Pattern string` |
+| `PrefixFaker` | `<prefix><hex8>` | `Prefix string` |
+| `AddressFaker` | `<number> <street>, <city>, ST <zip>` with deterministic number/street/city/state/zip drawn from small built-in lists indexed by HMAC bytes | None |
+
+**Determinism guarantee**: every faker derives its output solely from
+`computeHMAC(seed, fmt.Sprintf("%v", original))`. No randomness, no
+global state, no time-dependent logic.
+
+**Luhn algorithm for `CreditCardFaker`**: The check digit is computed
+using the standard Luhn mod-10 algorithm over the first 15 digits
+(6-digit issuer prefix from the original + 9 HMAC-derived digits). This
+is a pure arithmetic function -- no external dependencies.
+
+**`PhoneFaker` country code preservation**: The faker parses the leading
+`+<digits>` from the original value. If no country code is detected, it
+defaults to `+1`. The remaining digits are replaced with HMAC-derived
+digits, formatted as `+<cc>-555-<digits>` where the digit count matches
+the original (minus country code and separator chars).
+
+**`DateFaker` valid date generation**: HMAC bytes are mapped to ranges:
+year [2020-2029], month [1-12], day [1-28] (always valid). The result is
+formatted using the caller-specified Go `time.Format` layout string.
+
+**`AddressFaker` built-in data**: A small hardcoded list of 16 street
+names, 16 city names, and 50 US state abbreviations. The HMAC bytes
+select indices into these lists. The house number is derived from the
+first 2 HMAC bytes (range [1-9999]). The zip code is 5 HMAC-derived
+digits.
+
+##### 3. `FakeFieldsWith` constructor
+
+```go
+// FakeFieldsWith returns a SanitizeFunc that replaces field values in JSON
+// request and response bodies with deterministic fakes using explicitly
+// assigned Faker implementations per path.
+//
+// The seed is a project-level secret used as the HMAC key. The fields map
+// associates JSONPath-like paths with specific Faker implementations.
+//
+// This gives callers explicit control over the faking strategy for each
+// field, unlike FakeFields which auto-detects the strategy from the value.
+func FakeFieldsWith(seed string, fields map[string]Faker) SanitizeFunc
+```
+
+Internally, `FakeFieldsWith` parses all map keys as paths at construction
+time (same as `FakeFields`), then at execution time traverses the JSON
+body and calls `faker.Fake(seed, originalValue)` for each matched leaf.
+
+The traversal logic (`fakeAtPathWith`) mirrors `fakeAtPath` but accepts
+a `Faker` instead of calling `fakeValue`. This avoids modifying the
+existing `fakeAtPath` function, preserving backward compatibility.
+
+##### 4. Backward compatibility
+
+`FakeFields(seed, paths...)` remains unchanged. Internally it continues
+to call `fakeValue`, which is the existing auto-detecting dispatcher.
+`fakeValue` is **not** refactored to use the `Faker` interface -- this
+avoids any risk of behavioral change for existing users.
+
+A future ADR may refactor `fakeValue` to delegate to the built-in fakers,
+but that is out of scope here.
+
+##### 5. JSON config changes
+
+The `Rule` struct gains a new `Fields` field:
+
+```go
+type Rule struct {
+    Action  string            `json:"action"`
+    Headers []string          `json:"headers,omitempty"`
+    Paths   []string          `json:"paths,omitempty"`
+    Seed    string            `json:"seed,omitempty"`
+    Fields  map[string]any    `json:"fields,omitempty"`
+}
+```
+
+For the `"fake"` action, the config now supports two mutually exclusive
+modes:
+
+1. **`paths` mode** (existing): array of paths, auto-detection.
+   ```json
+   {"action": "fake", "seed": "s", "paths": ["$.email", "$.phone"]}
+   ```
+
+2. **`fields` mode** (new): map of path -> faker spec.
+   ```json
+   {"action": "fake", "seed": "s", "fields": {
+     "$.email": "email",
+     "$.phone": "phone",
+     "$.card.number": "credit_card",
+     "$.card.cvv": {"type": "numeric", "length": 3},
+     "$.ssn": {"type": "pattern", "pattern": "###-##-####"}
+   }}
+   ```
+
+**Parsing rules for faker specs**:
+
+- **String shorthand**: maps to a zero-value faker by name.
+  | String | Faker |
+  |--------|-------|
+  | `"redacted"` | `RedactedFaker{}` |
+  | `"hmac"` | `HMACFaker{}` |
+  | `"email"` | `EmailFaker{}` |
+  | `"phone"` | `PhoneFaker{}` |
+  | `"credit_card"` | `CreditCardFaker{}` |
+  | `"address"` | `AddressFaker{}` |
+
+- **Object form**: `{"type": "<name>", ...params}`. The `type` field
+  selects the faker; remaining fields are type-specific parameters.
+  | Type | Extra fields | Faker |
+  |------|-------------|-------|
+  | `"numeric"` | `"length": int` | `NumericFaker{Length: n}` |
+  | `"date"` | `"format": string` | `DateFaker{Format: f}` |
+  | `"pattern"` | `"pattern": string` | `PatternFaker{Pattern: p}` |
+  | `"prefix"` | `"prefix": string` | `PrefixFaker{Prefix: p}` |
+  | `"fixed"` | `"value": any` | `FixedFaker{Value: v}` |
+  | All shorthands | (none) | Corresponding zero-value faker |
+
+**Validation**: `Validate()` checks:
+- `paths` and `fields` are mutually exclusive for a `"fake"` rule.
+- At least one of `paths` or `fields` must be present.
+- All keys in `fields` must be valid paths (via `parsePath`).
+- All faker specs must resolve to known types.
+- Required parameters must be present (e.g., `"pattern"` requires
+  `"pattern"` field, `"numeric"` requires `"length"` > 0).
+
+**`BuildPipeline`**: when `fields` is present, the rule maps to
+`FakeFieldsWith(seed, parsedFakers)` instead of `FakeFields(seed, paths...)`.
+
+##### 6. `config.schema.json` update
+
+The JSON Schema is updated to reflect the new `fields` property on
+`"fake"` rules, with `oneOf` constraining the mutual exclusivity of
+`paths` vs `fields`. The faker spec schema uses `oneOf` for string
+shorthand vs object form.
+
+##### 7. File placement
+
+- **`faker.go`** (new file): `Faker` interface, all built-in faker
+  struct types and their `Fake` methods, `FakeFieldsWith` constructor,
+  `fakeAtPathWith` traversal, `fakeBodyFieldsWith` body processor, Luhn
+  helper. Rationale: `sanitizer.go` is already 579 lines; adding ~400
+  lines of faker types would push it past maintainable size. A dedicated
+  file keeps the faker port/adapter boundary clean.
+- **`faker_test.go`** (new file): unit tests for every faker, including
+  Luhn validation for `CreditCardFaker`, format validation for
+  `PhoneFaker` and `DateFaker`, determinism tests (same seed+input =
+  same output), and `FakeFieldsWith` integration tests.
+- **`sanitizer.go`**: no changes. `fakeValue` and `FakeFields` remain
+  as-is.
+- **`config.go`**: updated `Rule` struct, updated `Validate()` for
+  `fields` support, updated `BuildPipeline()` to emit `FakeFieldsWith`
+  when `fields` is present, new `parseFakerSpec` helper.
+- **`config_test.go`**: new test cases for `fields` mode parsing,
+  validation, and pipeline building.
+- **`config.schema.json`**: updated schema.
+
+##### 8. Implementation details for key fakers
+
+**`CreditCardFaker.Fake`**:
+```
+1. Extract issuer prefix (first 6 digits) from original string
+   (stripping non-digit chars). If fewer than 6 digits, use "400000".
+2. Compute HMAC of the original value.
+3. Generate 9 digits from HMAC bytes (each byte mod 10).
+4. Concatenate: prefix (6) + generated (9) = 15 digits.
+5. Compute Luhn check digit over the 15 digits.
+6. Return 16-digit string formatted as "XXXX-XXXX-XXXX-XXXX".
+```
+
+**`luhnCheckDigit(digits string) byte`** (unexported helper):
+```
+Standard Luhn algorithm: iterate digits right-to-left, double every
+second digit, subtract 9 if > 9, sum all, check digit = (10 - sum%10) % 10.
+```
+
+**`PatternFaker.Fake`**:
+```
+1. Compute HMAC of the original value.
+2. Walk the pattern string char by char:
+   - '#' -> next HMAC byte mod 10, rendered as digit char
+   - '?' -> next HMAC byte mod 26, rendered as lowercase letter
+   - anything else -> literal copy
+3. If HMAC bytes exhausted, re-HMAC with the current output as message
+   (chaining). In practice, 32 HMAC bytes cover patterns up to 32
+   placeholders; longer patterns are extremely rare.
+```
+
+**`AddressFaker.Fake`**:
+```
+1. Compute HMAC of the original value.
+2. House number: bytes[0:2] as uint16, mod 9999 + 1.
+3. Street: streetNames[bytes[2] % len(streetNames)] + " " +
+   streetSuffixes[bytes[3] % len(streetSuffixes)]
+4. City: cityNames[bytes[4] % len(cityNames)]
+5. State: stateAbbrs[bytes[5] % len(stateAbbrs)]
+6. Zip: 5 digits from bytes[6:11], each mod 10.
+7. Return "<number> <street>, <city>, <state> <zip>"
+```
+
+#### Consequences
+
+##### Positive
+- Users gain explicit, fine-grained control over faking strategies per
+  field without losing the convenience of auto-detection.
+- Format-preserving fakers (phone, credit card, date, pattern) prevent
+  client-side validation breakage in recorded fixtures.
+- The `Faker` interface enables users to implement custom fakers for
+  domain-specific formats.
+- Full backward compatibility: `FakeFields` behavior is untouched.
+- JSON config gains expressive power without breaking existing configs.
+
+##### Negative
+- New file (`faker.go`) adds ~400 lines of code. This is acceptable
+  given the number of distinct faker types.
+- `AddressFaker` hardcodes US-format addresses. Locale-aware faking is
+  explicitly out of scope (per issue #116) and can be addressed in a
+  future ADR.
+- The `Rule.Fields` field uses `map[string]any` for JSON flexibility,
+  requiring runtime type assertions in `parseFakerSpec`. This is a
+  pragmatic trade-off for supporting both string shorthand and object
+  form in JSON.
+
+##### Risks
+- Luhn implementation must be correct. Mitigated by table-driven tests
+  with known-good card numbers.
+- `PatternFaker` HMAC chaining (for patterns > 32 placeholders) adds
+  complexity. Mitigated by the fact that such long patterns are
+  exceedingly rare in practice.
+
+##### Migration
+- No migration needed. Existing configs using `"paths"` continue to work
+  unchanged. New `"fields"` syntax is opt-in.

--- a/faker.go
+++ b/faker.go
@@ -391,11 +391,12 @@ func FakeFieldsWith(seed string, fields map[string]Faker) SanitizeFunc {
 	return func(t Tape) Tape {
 		newReqBody := fakeBodyFieldsWith(t.Request.Body, pfs, seed)
 		if !bytes.Equal(newReqBody, t.Request.Body) {
-			t.Request.Body = newReqBody
 			t.Request.BodyHash = BodyHashFromBytes(newReqBody)
-		} else {
-			t.Request.Body = newReqBody
 		}
+		t.Request.Body = newReqBody
+		// Note: BodyHash is updated for the request but not for the response
+		// because RecordedResp does not have a BodyHash field. If a BodyHash
+		// field is ever added to RecordedResp, it must be updated here too.
 		t.Response.Body = fakeBodyFieldsWith(t.Response.Body, pfs, seed)
 		return t
 	}

--- a/faker.go
+++ b/faker.go
@@ -1,0 +1,481 @@
+package httptape
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Faker is the interface for pluggable deterministic faking strategies.
+// Implementations produce a fake value from a seed (HMAC key) and the
+// original JSON value. The result must be deterministic: same seed and
+// original must always produce the same fake.
+type Faker interface {
+	Fake(seed string, original any) any
+}
+
+// RedactedFaker replaces values with type-aware redacted placeholders:
+// strings become "[REDACTED]", numbers become 0, booleans become false.
+// Other types (nil, objects, arrays) are returned unchanged.
+type RedactedFaker struct{}
+
+// Fake implements Faker.
+func (f RedactedFaker) Fake(_ string, original any) any {
+	switch original.(type) {
+	case string:
+		return Redacted
+	case float64:
+		return float64(0)
+	case bool:
+		return false
+	default:
+		return original
+	}
+}
+
+// FixedFaker always returns its Value field, regardless of the original.
+type FixedFaker struct {
+	Value any
+}
+
+// Fake implements Faker.
+func (f FixedFaker) Fake(_ string, _ any) any {
+	return f.Value
+}
+
+// HMACFaker replaces string values with "fake_<hash>", numbers with a
+// deterministic positive integer, and booleans/nil unchanged. This mirrors
+// the behavior of the existing fakeValue auto-detection for generic strings.
+type HMACFaker struct{}
+
+// Fake implements Faker.
+func (f HMACFaker) Fake(seed string, original any) any {
+	switch val := original.(type) {
+	case string:
+		h := computeHMAC(seed, val)
+		return fakeString(h)
+	case float64:
+		h := computeHMAC(seed, strconv.FormatFloat(val, 'f', -1, 64))
+		return fakeNumericID(h)
+	default:
+		return original
+	}
+}
+
+// EmailFaker replaces string values with "user_<hash>@example.com".
+// Non-string values are returned unchanged.
+type EmailFaker struct{}
+
+// Fake implements Faker.
+func (f EmailFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+	h := computeHMAC(seed, s)
+	return fakeEmail(h)
+}
+
+// PhoneFaker replaces digits in a string with HMAC-derived digits while
+// preserving the original formatting (dashes, spaces, parentheses, plus
+// signs). Non-string values are returned unchanged.
+type PhoneFaker struct{}
+
+// Fake implements Faker.
+func (f PhoneFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+	h := computeHMAC(seed, s)
+	hi := 0
+	var buf strings.Builder
+	buf.Grow(len(s))
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			if hi >= len(h) {
+				// Chain: re-HMAC with current output.
+				h = computeHMAC(seed, buf.String())
+				hi = 0
+			}
+			digit := h[hi] % 10
+			hi++
+			buf.WriteByte('0' + digit)
+		} else {
+			buf.WriteRune(c)
+		}
+	}
+	return buf.String()
+}
+
+// CreditCardFaker generates a fake credit card number that preserves the
+// issuer prefix (first 6 digits), uses HMAC-derived digits for the middle,
+// and appends a valid Luhn check digit. The result is formatted as
+// "XXXX-XXXX-XXXX-XXXX". Non-string values are returned unchanged.
+type CreditCardFaker struct{}
+
+// Fake implements Faker.
+func (f CreditCardFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+
+	// Extract digits from original.
+	var digits []byte
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			digits = append(digits, byte(c))
+		}
+	}
+
+	// Use first 6 digits as issuer prefix; fall back to "400000".
+	prefix := "400000"
+	if len(digits) >= 6 {
+		prefix = string(digits[:6])
+	}
+
+	// Generate 9 middle digits from HMAC.
+	h := computeHMAC(seed, s)
+	var mid strings.Builder
+	for i := 0; i < 9; i++ {
+		mid.WriteByte('0' + h[i]%10)
+	}
+
+	// 15 digits = prefix(6) + mid(9), then compute Luhn check digit.
+	base := prefix + mid.String()
+	check := luhnCheckDigit(base)
+
+	full := base + string(rune('0'+check))
+
+	// Format as XXXX-XXXX-XXXX-XXXX.
+	return fmt.Sprintf("%s-%s-%s-%s", full[0:4], full[4:8], full[8:12], full[12:16])
+}
+
+// luhnCheckDigit computes the Luhn check digit for the given string of
+// digits. It returns a value 0-9.
+func luhnCheckDigit(digits string) byte {
+	sum := 0
+	// Process from rightmost digit, doubling every second digit.
+	for i := len(digits) - 1; i >= 0; i-- {
+		d := int(digits[i] - '0')
+		// Digits at odd positions from the right (0-indexed from right: 0,1,2,...)
+		// Position 0 is rightmost. We double positions 0, 2, 4, ... (even from right).
+		pos := len(digits) - 1 - i // position from right
+		if pos%2 == 0 {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+	}
+	return byte((10 - sum%10) % 10)
+}
+
+// NumericFaker generates a string of N HMAC-derived digits.
+// Non-string values are returned unchanged.
+type NumericFaker struct {
+	Length int
+}
+
+// Fake implements Faker.
+func (f NumericFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+	h := computeHMAC(seed, s)
+	var buf strings.Builder
+	buf.Grow(f.Length)
+	hi := 0
+	for i := 0; i < f.Length; i++ {
+		if hi >= len(h) {
+			h = computeHMAC(seed, buf.String())
+			hi = 0
+		}
+		buf.WriteByte('0' + h[hi]%10)
+		hi++
+	}
+	return buf.String()
+}
+
+// DateFaker generates a deterministic date string from HMAC in the given
+// Go time format (e.g., "2006-01-02"). Non-string values are returned
+// unchanged.
+type DateFaker struct {
+	Format string
+}
+
+// Fake implements Faker.
+func (f DateFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+	h := computeHMAC(seed, s)
+	// Use first 4 bytes as days offset from epoch (2000-01-01).
+	n := uint32(h[0])<<24 | uint32(h[1])<<16 | uint32(h[2])<<8 | uint32(h[3])
+	// Restrict to ~100 years range: mod 36525 days ≈ 100 years.
+	days := int(n % 36525)
+	epoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	t := epoch.AddDate(0, 0, days)
+	format := f.Format
+	if format == "" {
+		format = "2006-01-02"
+	}
+	return t.Format(format)
+}
+
+// PatternFaker fills a pattern string where '#' is replaced with a digit
+// and '?' is replaced with a lowercase letter, both derived from HMAC.
+// All other characters are copied literally. Non-string values are returned
+// unchanged.
+type PatternFaker struct {
+	Pattern string
+}
+
+// Fake implements Faker.
+func (f PatternFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+	h := computeHMAC(seed, s)
+	hi := 0
+	var buf strings.Builder
+	buf.Grow(len(f.Pattern))
+	for _, c := range f.Pattern {
+		switch c {
+		case '#':
+			if hi >= len(h) {
+				h = computeHMAC(seed, buf.String())
+				hi = 0
+			}
+			buf.WriteByte('0' + h[hi]%10)
+			hi++
+		case '?':
+			if hi >= len(h) {
+				h = computeHMAC(seed, buf.String())
+				hi = 0
+			}
+			buf.WriteByte('a' + h[hi]%26)
+			hi++
+		default:
+			buf.WriteRune(c)
+		}
+	}
+	return buf.String()
+}
+
+// PrefixFaker generates a string of the form "<prefix><hex_hash>".
+// Non-string values are returned unchanged.
+type PrefixFaker struct {
+	Prefix string
+}
+
+// Fake implements Faker.
+func (f PrefixFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+	h := computeHMAC(seed, s)
+	return f.Prefix + hex.EncodeToString(h[:8])
+}
+
+// streetNames is a fixed list of street names for AddressFaker.
+var streetNames = []string{
+	"Oak", "Maple", "Cedar", "Elm", "Pine",
+	"Birch", "Walnut", "Cherry", "Willow", "Spruce",
+}
+
+// streetSuffixes is a fixed list of street suffixes for AddressFaker.
+var streetSuffixes = []string{
+	"Street", "Avenue", "Boulevard", "Drive", "Lane",
+	"Court", "Place", "Road", "Way", "Circle",
+}
+
+// cityNames is a fixed list of city names for AddressFaker.
+var cityNames = []string{
+	"Springfield", "Riverside", "Fairview", "Madison", "Georgetown",
+	"Clinton", "Arlington", "Salem", "Franklin", "Bristol",
+}
+
+// stateAbbrs is a fixed list of US state abbreviations for AddressFaker.
+var stateAbbrs = []string{
+	"AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+	"HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+	"MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+	"NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+	"SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+}
+
+// AddressFaker generates a deterministic US-style address from HMAC.
+// Format: "<number> <street> <suffix>, <city>, <state> <zip>".
+// Non-string values are returned unchanged.
+type AddressFaker struct{}
+
+// Fake implements Faker.
+func (f AddressFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+	h := computeHMAC(seed, s)
+
+	// House number: bytes[0:2] as uint16, mod 9999 + 1.
+	num := (uint16(h[0])<<8 | uint16(h[1])) % 9999
+	num++ // 1-9999
+
+	street := streetNames[h[2]%byte(len(streetNames))]
+	suffix := streetSuffixes[h[3]%byte(len(streetSuffixes))]
+	city := cityNames[h[4]%byte(len(cityNames))]
+	state := stateAbbrs[h[5]%byte(len(stateAbbrs))]
+
+	// Zip: 5 digits from bytes[6:11].
+	var zip strings.Builder
+	for i := 6; i < 11; i++ {
+		zip.WriteByte('0' + h[i]%10)
+	}
+
+	return fmt.Sprintf("%d %s %s, %s, %s %s", num, street, suffix, city, state, zip.String())
+}
+
+// FakeFieldsWith returns a SanitizeFunc that replaces field values in JSON
+// request and response bodies with deterministic fakes using explicitly
+// assigned Faker implementations per path.
+//
+// The seed is a project-level secret used as the HMAC key. The fields map
+// associates JSONPath-like paths with specific Faker implementations.
+//
+// This gives callers explicit control over the faking strategy for each
+// field, unlike FakeFields which auto-detects the strategy from the value.
+//
+// Paths use the same JSONPath-like syntax as RedactBodyPaths:
+//   - $.field             -- top-level field
+//   - $.nested.field      -- nested field access
+//   - $.array[*].field    -- field within each element of an array
+//
+// If the body is not valid JSON, it is left unchanged (no error).
+// If a path does not match any field in the body, it is silently skipped.
+// Invalid or unsupported paths are silently ignored.
+//
+// The returned function does not mutate the input Tape -- it copies the
+// body byte slices before modification.
+//
+// Example:
+//
+//	sanitizer := NewPipeline(
+//	    RedactHeaders(),
+//	    FakeFieldsWith("my-seed", map[string]Faker{
+//	        "$.user.email": EmailFaker{},
+//	        "$.user.phone": PhoneFaker{},
+//	        "$.card.number": CreditCardFaker{},
+//	        "$.card.cvv": NumericFaker{Length: 3},
+//	    }),
+//	)
+func FakeFieldsWith(seed string, fields map[string]Faker) SanitizeFunc {
+	// Parse all paths at construction time.
+	var pfs []pathFaker
+	for p, f := range fields {
+		if pp, ok := parsePath(p); ok {
+			pfs = append(pfs, pathFaker{path: pp, faker: f})
+		}
+	}
+
+	return func(t Tape) Tape {
+		newReqBody := fakeBodyFieldsWith(t.Request.Body, pfs, seed)
+		if !bytes.Equal(newReqBody, t.Request.Body) {
+			t.Request.Body = newReqBody
+			t.Request.BodyHash = BodyHashFromBytes(newReqBody)
+		} else {
+			t.Request.Body = newReqBody
+		}
+		t.Response.Body = fakeBodyFieldsWith(t.Response.Body, pfs, seed)
+		return t
+	}
+}
+
+// pathFaker pairs a parsed path with its Faker. It is used internally by
+// FakeFieldsWith.
+type pathFaker struct {
+	path  parsedPath
+	faker Faker
+}
+
+// fakeBodyFieldsWith unmarshals the body as JSON, applies all path-based
+// faking with explicit Faker implementations, and re-marshals the result.
+// If the body is nil, empty, or not valid JSON, it is returned unchanged.
+func fakeBodyFieldsWith(body []byte, pfs []pathFaker, seed string) []byte {
+	if len(body) == 0 {
+		return body
+	}
+
+	var data any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return body
+	}
+
+	for _, pf := range pfs {
+		fakeAtPathWith(data, pf.path.segments, seed, pf.faker)
+	}
+
+	result, err := json.Marshal(data)
+	if err != nil {
+		return body
+	}
+	return result
+}
+
+// fakeAtPathWith recursively traverses the JSON structure following the
+// given segments and replaces the leaf value using the provided Faker.
+// It modifies the data in-place (caller must ensure data is a fresh
+// copy from json.Unmarshal).
+func fakeAtPathWith(data any, segments []segment, seed string, faker Faker) {
+	if len(segments) == 0 {
+		return
+	}
+
+	seg := segments[0]
+	rest := segments[1:]
+
+	obj, ok := data.(map[string]any)
+	if !ok {
+		return
+	}
+
+	val, exists := obj[seg.key]
+	if !exists {
+		return
+	}
+
+	if seg.wildcard {
+		arr, ok := val.([]any)
+		if !ok {
+			return
+		}
+		if len(rest) == 0 {
+			// Wildcard at leaf targets array elements (containers) -- skip.
+			return
+		}
+		for _, elem := range arr {
+			fakeAtPathWith(elem, rest, seed, faker)
+		}
+		return
+	}
+
+	// Not a wildcard segment.
+	if len(rest) == 0 {
+		// Leaf: apply the Faker.
+		obj[seg.key] = faker.Fake(seed, val)
+		return
+	}
+
+	// Intermediate: recurse deeper.
+	fakeAtPathWith(val, rest, seed, faker)
+}

--- a/faker_test.go
+++ b/faker_test.go
@@ -1,0 +1,692 @@
+package httptape
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRedactedFaker_String(t *testing.T) {
+	f := RedactedFaker{}
+	got := f.Fake("seed", "secret-value")
+	if got != Redacted {
+		t.Errorf("got %q, want %q", got, Redacted)
+	}
+}
+
+func TestRedactedFaker_Number(t *testing.T) {
+	f := RedactedFaker{}
+	got := f.Fake("seed", float64(42))
+	if got != float64(0) {
+		t.Errorf("got %v, want 0", got)
+	}
+}
+
+func TestRedactedFaker_Bool(t *testing.T) {
+	f := RedactedFaker{}
+	got := f.Fake("seed", true)
+	if got != false {
+		t.Errorf("got %v, want false", got)
+	}
+}
+
+func TestRedactedFaker_Nil(t *testing.T) {
+	f := RedactedFaker{}
+	got := f.Fake("seed", nil)
+	if got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+func TestFixedFaker(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{"string", "fixed-value"},
+		{"number", float64(99)},
+		{"bool", true},
+		{"nil", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := FixedFaker{Value: tt.value}
+			got := f.Fake("seed", "anything")
+			if got != tt.value {
+				t.Errorf("got %v, want %v", got, tt.value)
+			}
+		})
+	}
+}
+
+func TestHMACFaker_String(t *testing.T) {
+	f := HMACFaker{}
+	got := f.Fake("seed", "hello")
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if !strings.HasPrefix(s, "fake_") {
+		t.Errorf("got %q, want prefix \"fake_\"", s)
+	}
+}
+
+func TestHMACFaker_Number(t *testing.T) {
+	f := HMACFaker{}
+	got := f.Fake("seed", float64(42))
+	n, ok := got.(float64)
+	if !ok {
+		t.Fatalf("expected float64, got %T", got)
+	}
+	if n <= 0 {
+		t.Errorf("got %v, want positive number", n)
+	}
+}
+
+func TestHMACFaker_Deterministic(t *testing.T) {
+	f := HMACFaker{}
+	a := f.Fake("seed", "value")
+	b := f.Fake("seed", "value")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestHMACFaker_DifferentSeed(t *testing.T) {
+	f := HMACFaker{}
+	a := f.Fake("seed1", "value")
+	b := f.Fake("seed2", "value")
+	if a == b {
+		t.Errorf("different seeds produced same result: %v", a)
+	}
+}
+
+func TestHMACFaker_Bool(t *testing.T) {
+	f := HMACFaker{}
+	got := f.Fake("seed", true)
+	if got != true {
+		t.Errorf("bool should be unchanged, got %v", got)
+	}
+}
+
+func TestEmailFaker(t *testing.T) {
+	f := EmailFaker{}
+	got := f.Fake("seed", "alice@corp.com")
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if !strings.HasPrefix(s, "user_") || !strings.HasSuffix(s, "@example.com") {
+		t.Errorf("got %q, want user_<hash>@example.com", s)
+	}
+}
+
+func TestEmailFaker_Deterministic(t *testing.T) {
+	f := EmailFaker{}
+	a := f.Fake("seed", "alice@corp.com")
+	b := f.Fake("seed", "alice@corp.com")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestEmailFaker_NonString(t *testing.T) {
+	f := EmailFaker{}
+	got := f.Fake("seed", float64(42))
+	if got != float64(42) {
+		t.Errorf("non-string should be unchanged, got %v", got)
+	}
+}
+
+func TestPhoneFaker_PreservesFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		format string // regex-like description of expected format
+	}{
+		{"US format", "+1 (555) 123-4567", "+# (###) ###-####"},
+		{"simple", "1234567890", "##########"},
+		{"dashes", "123-456-7890", "###-###-####"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := PhoneFaker{}
+			got := f.Fake("seed", tt.input)
+			s, ok := got.(string)
+			if !ok {
+				t.Fatalf("expected string, got %T", got)
+			}
+			if len(s) != len(tt.input) {
+				t.Errorf("length mismatch: got %d, want %d", len(s), len(tt.input))
+			}
+			// Verify non-digit characters preserved.
+			for i, c := range tt.input {
+				if c < '0' || c > '9' {
+					if rune(s[i]) != c {
+						t.Errorf("format char at %d: got %c, want %c", i, s[i], c)
+					}
+				} else {
+					if s[i] < '0' || s[i] > '9' {
+						t.Errorf("expected digit at %d, got %c", i, s[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestPhoneFaker_Deterministic(t *testing.T) {
+	f := PhoneFaker{}
+	a := f.Fake("seed", "555-1234")
+	b := f.Fake("seed", "555-1234")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestPhoneFaker_NonString(t *testing.T) {
+	f := PhoneFaker{}
+	got := f.Fake("seed", float64(42))
+	if got != float64(42) {
+		t.Errorf("non-string should be unchanged, got %v", got)
+	}
+}
+
+func TestCreditCardFaker_Format(t *testing.T) {
+	f := CreditCardFaker{}
+	got := f.Fake("seed", "4532-1234-5678-9012")
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	// Should be XXXX-XXXX-XXXX-XXXX format.
+	parts := strings.Split(s, "-")
+	if len(parts) != 4 {
+		t.Fatalf("expected 4 parts, got %d: %q", len(parts), s)
+	}
+	for i, part := range parts {
+		if len(part) != 4 {
+			t.Errorf("part[%d] length = %d, want 4", i, len(part))
+		}
+	}
+}
+
+func TestCreditCardFaker_PreservesIssuerPrefix(t *testing.T) {
+	f := CreditCardFaker{}
+	got := f.Fake("seed", "4532-1234-5678-9012")
+	s := got.(string)
+	// First 4 chars should be the first 4 of the prefix "453212".
+	digits := strings.ReplaceAll(s, "-", "")
+	if !strings.HasPrefix(digits, "4532") {
+		t.Errorf("expected issuer prefix 4532, got %q", digits[:4])
+	}
+}
+
+func TestCreditCardFaker_ValidLuhn(t *testing.T) {
+	f := CreditCardFaker{}
+	inputs := []string{
+		"4532-1234-5678-9012",
+		"5500-0000-0000-0004",
+		"3782-8224-6310-005",
+	}
+	for _, input := range inputs {
+		got := f.Fake("seed", input)
+		s := got.(string)
+		digits := strings.ReplaceAll(s, "-", "")
+		if !isValidLuhn(digits) {
+			t.Errorf("invalid Luhn for input %q -> %q (digits: %s)", input, s, digits)
+		}
+	}
+}
+
+// isValidLuhn checks the Luhn checksum of a digit string.
+func isValidLuhn(digits string) bool {
+	sum := 0
+	nDigits := len(digits)
+	parity := nDigits % 2
+	for i := 0; i < nDigits; i++ {
+		d := int(digits[i] - '0')
+		if i%2 == parity {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+	}
+	return sum%10 == 0
+}
+
+func TestCreditCardFaker_Deterministic(t *testing.T) {
+	f := CreditCardFaker{}
+	a := f.Fake("seed", "4532-1234-5678-9012")
+	b := f.Fake("seed", "4532-1234-5678-9012")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestCreditCardFaker_NonString(t *testing.T) {
+	f := CreditCardFaker{}
+	got := f.Fake("seed", float64(42))
+	if got != float64(42) {
+		t.Errorf("non-string should be unchanged, got %v", got)
+	}
+}
+
+func TestCreditCardFaker_ShortInput(t *testing.T) {
+	// Fewer than 6 digits should fall back to "400000" prefix.
+	f := CreditCardFaker{}
+	got := f.Fake("seed", "12")
+	s := got.(string)
+	digits := strings.ReplaceAll(s, "-", "")
+	if !strings.HasPrefix(digits, "4000") {
+		t.Errorf("expected fallback prefix 4000, got %q", digits[:4])
+	}
+	if !isValidLuhn(digits) {
+		t.Errorf("invalid Luhn for short input: %s", digits)
+	}
+}
+
+func TestNumericFaker(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{"3 digits", 3},
+		{"10 digits", 10},
+		{"40 digits (exceeds HMAC length)", 40},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NumericFaker{Length: tt.length}
+			got := f.Fake("seed", "input")
+			s, ok := got.(string)
+			if !ok {
+				t.Fatalf("expected string, got %T", got)
+			}
+			if len(s) != tt.length {
+				t.Errorf("length = %d, want %d", len(s), tt.length)
+			}
+			for i, c := range s {
+				if c < '0' || c > '9' {
+					t.Errorf("non-digit at %d: %c", i, c)
+				}
+			}
+		})
+	}
+}
+
+func TestNumericFaker_Deterministic(t *testing.T) {
+	f := NumericFaker{Length: 5}
+	a := f.Fake("seed", "value")
+	b := f.Fake("seed", "value")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestNumericFaker_NonString(t *testing.T) {
+	f := NumericFaker{Length: 5}
+	got := f.Fake("seed", float64(42))
+	if got != float64(42) {
+		t.Errorf("non-string should be unchanged, got %v", got)
+	}
+}
+
+func TestDateFaker(t *testing.T) {
+	f := DateFaker{Format: "2006-01-02"}
+	got := f.Fake("seed", "2023-01-15")
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	_, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Errorf("invalid date format: %q, err: %v", s, err)
+	}
+}
+
+func TestDateFaker_DefaultFormat(t *testing.T) {
+	f := DateFaker{}
+	got := f.Fake("seed", "some date")
+	s := got.(string)
+	_, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Errorf("invalid date with default format: %q, err: %v", s, err)
+	}
+}
+
+func TestDateFaker_Deterministic(t *testing.T) {
+	f := DateFaker{Format: "2006-01-02"}
+	a := f.Fake("seed", "2023-01-15")
+	b := f.Fake("seed", "2023-01-15")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestDateFaker_NonString(t *testing.T) {
+	f := DateFaker{Format: "2006-01-02"}
+	got := f.Fake("seed", float64(42))
+	if got != float64(42) {
+		t.Errorf("non-string should be unchanged, got %v", got)
+	}
+}
+
+func TestPatternFaker(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		check   func(string) bool
+	}{
+		{
+			"SSN",
+			"###-##-####",
+			func(s string) bool {
+				if len(s) != 11 {
+					return false
+				}
+				return s[3] == '-' && s[6] == '-'
+			},
+		},
+		{
+			"alphanumeric",
+			"??-###",
+			func(s string) bool {
+				if len(s) != 6 {
+					return false
+				}
+				return s[0] >= 'a' && s[0] <= 'z' &&
+					s[1] >= 'a' && s[1] <= 'z' &&
+					s[2] == '-' &&
+					s[3] >= '0' && s[3] <= '9'
+			},
+		},
+		{
+			"literal only",
+			"ABC-123",
+			func(s string) bool { return s == "ABC-123" },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := PatternFaker{Pattern: tt.pattern}
+			got := f.Fake("seed", "input")
+			s, ok := got.(string)
+			if !ok {
+				t.Fatalf("expected string, got %T", got)
+			}
+			if !tt.check(s) {
+				t.Errorf("pattern %q produced invalid output: %q", tt.pattern, s)
+			}
+		})
+	}
+}
+
+func TestPatternFaker_Deterministic(t *testing.T) {
+	f := PatternFaker{Pattern: "###-##-####"}
+	a := f.Fake("seed", "value")
+	b := f.Fake("seed", "value")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestPatternFaker_NonString(t *testing.T) {
+	f := PatternFaker{Pattern: "###"}
+	got := f.Fake("seed", float64(42))
+	if got != float64(42) {
+		t.Errorf("non-string should be unchanged, got %v", got)
+	}
+}
+
+func TestPrefixFaker(t *testing.T) {
+	f := PrefixFaker{Prefix: "cust_"}
+	got := f.Fake("seed", "original-id")
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if !strings.HasPrefix(s, "cust_") {
+		t.Errorf("got %q, want prefix \"cust_\"", s)
+	}
+	// Prefix + 16 hex chars.
+	if len(s) != 5+16 {
+		t.Errorf("length = %d, want %d", len(s), 5+16)
+	}
+}
+
+func TestPrefixFaker_Deterministic(t *testing.T) {
+	f := PrefixFaker{Prefix: "id_"}
+	a := f.Fake("seed", "value")
+	b := f.Fake("seed", "value")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestPrefixFaker_NonString(t *testing.T) {
+	f := PrefixFaker{Prefix: "x_"}
+	got := f.Fake("seed", float64(42))
+	if got != float64(42) {
+		t.Errorf("non-string should be unchanged, got %v", got)
+	}
+}
+
+func TestAddressFaker(t *testing.T) {
+	f := AddressFaker{}
+	got := f.Fake("seed", "123 Main St, Anytown, CA 90210")
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	// Should contain a comma (city separator).
+	if !strings.Contains(s, ",") {
+		t.Errorf("address missing comma: %q", s)
+	}
+	// Should have a 5-digit zip.
+	parts := strings.Split(s, " ")
+	zip := parts[len(parts)-1]
+	if len(zip) != 5 {
+		t.Errorf("zip length = %d, want 5: %q", len(zip), zip)
+	}
+	for _, c := range zip {
+		if c < '0' || c > '9' {
+			t.Errorf("non-digit in zip: %c", c)
+		}
+	}
+}
+
+func TestAddressFaker_Deterministic(t *testing.T) {
+	f := AddressFaker{}
+	a := f.Fake("seed", "some address")
+	b := f.Fake("seed", "some address")
+	if a != b {
+		t.Errorf("non-deterministic: %v != %v", a, b)
+	}
+}
+
+func TestAddressFaker_NonString(t *testing.T) {
+	f := AddressFaker{}
+	got := f.Fake("seed", float64(42))
+	if got != float64(42) {
+		t.Errorf("non-string should be unchanged, got %v", got)
+	}
+}
+
+func TestLuhnCheckDigit(t *testing.T) {
+	// Known card numbers with valid Luhn checksums.
+	tests := []struct {
+		base string
+		want byte
+	}{
+		// Visa test card: 4111111111111111 -> base=411111111111111, check=1
+		{"411111111111111", 1},
+		// Mastercard test: 5500000000000004 -> base=550000000000000, check=4
+		{"550000000000000", 4},
+	}
+	for _, tt := range tests {
+		got := luhnCheckDigit(tt.base)
+		if got != tt.want {
+			t.Errorf("luhnCheckDigit(%q) = %d, want %d", tt.base, got, tt.want)
+		}
+	}
+}
+
+func TestFakeFieldsWith_Basic(t *testing.T) {
+	body := []byte(`{"email":"alice@corp.com","phone":"555-1234","name":"Alice"}`)
+	tape := Tape{
+		Request: RecordedReq{
+			Method:  "POST",
+			URL:     "https://example.com/api",
+			Body:    body,
+			Headers: make(map[string][]string),
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Body:       body,
+			Headers:    make(map[string][]string),
+		},
+	}
+
+	fn := FakeFieldsWith("test-seed", map[string]Faker{
+		"$.email": EmailFaker{},
+		"$.phone": PhoneFaker{},
+	})
+
+	result := fn(tape)
+
+	// Parse result bodies.
+	var reqData map[string]any
+	if err := json.Unmarshal(result.Request.Body, &reqData); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+
+	email, ok := reqData["email"].(string)
+	if !ok {
+		t.Fatal("email not a string")
+	}
+	if !strings.HasSuffix(email, "@example.com") {
+		t.Errorf("email = %q, want *@example.com", email)
+	}
+
+	phone, ok := reqData["phone"].(string)
+	if !ok {
+		t.Fatal("phone not a string")
+	}
+	if len(phone) != len("555-1234") {
+		t.Errorf("phone length = %d, want %d", len(phone), len("555-1234"))
+	}
+	if phone[3] != '-' {
+		t.Errorf("phone format broken: %q", phone)
+	}
+
+	// Name should be unchanged.
+	name, ok := reqData["name"].(string)
+	if !ok || name != "Alice" {
+		t.Errorf("name = %q, want \"Alice\"", name)
+	}
+}
+
+func TestFakeFieldsWith_NestedAndWildcard(t *testing.T) {
+	body := []byte(`{"users":[{"email":"a@b.com"},{"email":"c@d.com"}],"meta":{"key":"val"}}`)
+	tape := Tape{
+		Request: RecordedReq{
+			Body:    body,
+			Headers: make(map[string][]string),
+		},
+		Response: RecordedResp{
+			Body:    body,
+			Headers: make(map[string][]string),
+		},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.users[*].email": EmailFaker{},
+		"$.meta.key":       RedactedFaker{},
+	})
+
+	result := fn(tape)
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Request.Body, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	users := data["users"].([]any)
+	for i, u := range users {
+		m := u.(map[string]any)
+		email := m["email"].(string)
+		if !strings.HasSuffix(email, "@example.com") {
+			t.Errorf("users[%d].email = %q, want *@example.com", i, email)
+		}
+	}
+
+	meta := data["meta"].(map[string]any)
+	if meta["key"] != Redacted {
+		t.Errorf("meta.key = %v, want %q", meta["key"], Redacted)
+	}
+}
+
+func TestFakeFieldsWith_InvalidJSON(t *testing.T) {
+	body := []byte("not json")
+	tape := Tape{
+		Request: RecordedReq{
+			Body:    body,
+			Headers: make(map[string][]string),
+		},
+		Response: RecordedResp{
+			Body:    body,
+			Headers: make(map[string][]string),
+		},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.email": EmailFaker{},
+	})
+
+	result := fn(tape)
+	if string(result.Request.Body) != "not json" {
+		t.Errorf("non-JSON body should be unchanged, got %q", result.Request.Body)
+	}
+}
+
+func TestFakeFieldsWith_EmptyBody(t *testing.T) {
+	tape := Tape{
+		Request: RecordedReq{
+			Headers: make(map[string][]string),
+		},
+		Response: RecordedResp{
+			Headers: make(map[string][]string),
+		},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.email": EmailFaker{},
+	})
+
+	result := fn(tape)
+	if result.Request.Body != nil {
+		t.Errorf("nil body should remain nil, got %v", result.Request.Body)
+	}
+}
+
+func TestFakeFieldsWith_Deterministic(t *testing.T) {
+	body := []byte(`{"email":"test@test.com"}`)
+	tape := Tape{
+		Request:  RecordedReq{Body: body, Headers: make(map[string][]string)},
+		Response: RecordedResp{Body: body, Headers: make(map[string][]string)},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.email": EmailFaker{},
+	})
+
+	r1 := fn(tape)
+	r2 := fn(tape)
+	if string(r1.Request.Body) != string(r2.Request.Body) {
+		t.Errorf("non-deterministic:\n  first:  %s\n  second: %s", r1.Request.Body, r2.Request.Body)
+	}
+}

--- a/sanitizer.go
+++ b/sanitizer.go
@@ -234,11 +234,9 @@ func RedactBodyPaths(paths ...string) SanitizeFunc {
 	return func(t Tape) Tape {
 		newReqBody := redactBodyFields(t.Request.Body, parsed)
 		if !bytes.Equal(newReqBody, t.Request.Body) {
-			t.Request.Body = newReqBody
 			t.Request.BodyHash = BodyHashFromBytes(newReqBody)
-		} else {
-			t.Request.Body = newReqBody
 		}
+		t.Request.Body = newReqBody
 		// Note: BodyHash is updated for the request but not for the response
 		// because RecordedResp does not have a BodyHash field. If a BodyHash
 		// field is ever added to RecordedResp, it must be updated here too.
@@ -386,11 +384,9 @@ func FakeFields(seed string, paths ...string) SanitizeFunc {
 	return func(t Tape) Tape {
 		newReqBody := fakeBodyFields(t.Request.Body, parsed, seed)
 		if !bytes.Equal(newReqBody, t.Request.Body) {
-			t.Request.Body = newReqBody
 			t.Request.BodyHash = BodyHashFromBytes(newReqBody)
-		} else {
-			t.Request.Body = newReqBody
 		}
+		t.Request.Body = newReqBody
 		// Note: BodyHash is updated for the request but not for the response
 		// because RecordedResp does not have a BodyHash field. If a BodyHash
 		// field is ever added to RecordedResp, it must be updated here too.


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul rebranding httptape around the **3 Rs: Record, Redact, Replay**.

- Rewrite README.md with universal framing (not Go-only), proxy/fallback section, and updated comparison table
- Create docs/proxy.md: full guide for proxy mode with L1/L2 caching, CLI, Go API, and Docker usage
- Rebrand sanitize to redact in all user-facing prose (Go API type names kept as-is)
- Update CLI, Docker, index, getting-started, sanitization, and API reference docs
- Create llms.txt (~100 lines) and llms-full.txt (all docs concatenated) for LLM context
- Add Proxy Mode to mkdocs nav under Core Concepts

Closes #102
Closes #107

## Test plan

- [ ] Verify all internal doc links resolve correctly
- [ ] Check that mkdocs builds without errors
- [ ] Review proxy.md for accuracy against proxy.go implementation
- [ ] Verify llms.txt is concise and covers key APIs
- [ ] Confirm Go API type names (Sanitizer, Pipeline, SanitizeFunc) are preserved in code references

Generated with [Claude Code](https://claude.com/claude-code)
