### PR TITLE
ci: simplify release workflow for Go library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+# .github/workflows/release.yml
+#
+# Build multi-platform binaries and publish a GitHub Release.
+# Triggers: semver tags (v*).
+
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test -race -count=1 ./...
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          EXT=""
+          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
+          OUTPUT="httptape-${GOOS}-${GOARCH}${EXT}"
+          CGO_ENABLED=0 go build -trimpath \
+            -ldflags="-s -w -X main.version=${{ github.ref_name }}" \
+            -o "${OUTPUT}" ./cmd/httptape
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: httptape-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: httptape-*
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 # .github/workflows/release.yml
 #
-# Build multi-platform binaries and publish a GitHub Release.
+# Run tests and publish a GitHub Release with auto-generated notes.
+# httptape is a Go library — no binaries needed.
 # Triggers: semver tags (v*).
 
 name: Release
@@ -13,7 +14,7 @@ permissions:
   contents: write
 
 jobs:
-  test:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,61 +28,7 @@ jobs:
       - name: Run tests
         run: go test -race -count=1 ./...
 
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Build binary
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-        run: |
-          EXT=""
-          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
-          OUTPUT="httptape-${GOOS}-${GOARCH}${EXT}"
-          CGO_ENABLED=0 go build -trimpath \
-            -ldflags="-s -w -X main.version=${{ github.ref_name }}" \
-            -o "${OUTPUT}" ./cmd/httptape
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: httptape-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: httptape-*
-
-  publish:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          merge-multiple: true
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: artifacts/*


### PR DESCRIPTION
## Summary

Closes #118

httptape is a Go library consumed via `go get` — there are no binaries to distribute. This simplifies the release workflow to the essentials:

- Triggers on `v*` tag pushes
- Runs the full test suite (`go test -race`)
- Creates a GitHub Release with auto-generated notes via `softprops/action-gh-release`

Removed the multi-platform binary build matrix, artifact upload/download, and the separate publish job. The entire workflow is now a single job with 4 steps.

## Test plan

- [ ] Push a `v0.0.0-test` tag to verify the workflow triggers
- [ ] Confirm tests run successfully
- [ ] Confirm the GitHub Release is created with auto-generated notes
