### PR TITLE
feat: add NameFaker for deterministic fake names

### DIFF
--- a/config.go
+++ b/config.go
@@ -223,6 +223,7 @@ var validShorthands = map[string]func() Faker{
 	"phone":       func() Faker { return PhoneFaker{} },
 	"credit_card": func() Faker { return CreditCardFaker{} },
 	"address":     func() Faker { return AddressFaker{} },
+	"name":        func() Faker { return NameFaker{} },
 }
 
 // parseFakerSpec parses a faker specification from a config value.

--- a/faker.go
+++ b/faker.go
@@ -288,6 +288,39 @@ func (f PrefixFaker) Fake(seed string, original any) any {
 	return f.Prefix + hex.EncodeToString(h[:8])
 }
 
+// NameFaker generates a deterministic full name from HMAC.
+// Picks a first name and last name from fixed lists using HMAC bytes.
+// Non-string values are returned unchanged.
+type NameFaker struct{}
+
+// Fake implements Faker.
+func (f NameFaker) Fake(seed string, original any) any {
+	s, ok := original.(string)
+	if !ok {
+		return original
+	}
+	h := computeHMAC(seed, s)
+	first := firstNames[h[0]%byte(len(firstNames))]
+	last := lastNames[h[1]%byte(len(lastNames))]
+	return first + " " + last
+}
+
+// firstNames is a fixed list of first names for NameFaker.
+var firstNames = []string{
+	"James", "Emma", "Liam", "Olivia", "Noah",
+	"Ava", "Lucas", "Sophia", "Mason", "Isabella",
+	"Ethan", "Mia", "Logan", "Charlotte", "Aiden",
+	"Amelia", "Jackson", "Harper", "Sebastian", "Evelyn",
+}
+
+// lastNames is a fixed list of last names for NameFaker.
+var lastNames = []string{
+	"Smith", "Johnson", "Williams", "Brown", "Jones",
+	"Garcia", "Miller", "Davis", "Rodriguez", "Martinez",
+	"Anderson", "Taylor", "Thomas", "Moore", "Jackson",
+	"Martin", "Lee", "Thompson", "White", "Harris",
+}
+
 // streetNames is a fixed list of street names for AddressFaker.
 var streetNames = []string{
 	"Oak", "Maple", "Cedar", "Elm", "Pine",

--- a/faker_test.go
+++ b/faker_test.go
@@ -690,3 +690,41 @@ func TestFakeFieldsWith_Deterministic(t *testing.T) {
 		t.Errorf("non-deterministic:\n  first:  %s\n  second: %s", r1.Request.Body, r2.Request.Body)
 	}
 }
+
+func TestNameFaker(t *testing.T) {
+	f := NameFaker{}
+
+	// Deterministic: same input = same output.
+	r1 := f.Fake("seed", "Alice Johnson")
+	r2 := f.Fake("seed", "Alice Johnson")
+	if r1 != r2 {
+		t.Errorf("not deterministic: %v vs %v", r1, r2)
+	}
+
+	// Produces a "First Last" format.
+	name, ok := r1.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", r1)
+	}
+	parts := strings.Fields(name)
+	if len(parts) != 2 {
+		t.Errorf("expected 'First Last', got %q", name)
+	}
+
+	// Different input = different output.
+	r3 := f.Fake("seed", "Bob Smith")
+	if r1 == r3 {
+		t.Errorf("different inputs produced same name: %v", r1)
+	}
+
+	// Different seed = different output.
+	r4 := f.Fake("other-seed", "Alice Johnson")
+	if r1 == r4 {
+		t.Errorf("different seeds produced same name: %v", r1)
+	}
+
+	// Non-string passthrough.
+	if f.Fake("seed", 42.0) != 42.0 {
+		t.Error("non-string should pass through")
+	}
+}


### PR DESCRIPTION
## Summary
- Add NameFaker: picks first + last name from fixed lists using HMAC bytes
- Registered as "name" shorthand in JSON config
- 20 first names, 20 last names = 400 combinations

## Test plan
- [x] TestNameFaker: determinism, format, different inputs, different seeds, non-string passthrough
- [x] `go test ./... -race` passes
