### PR TITLE
feat: technical health endpoint surface for proxy mode (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,31 @@ client := &http.Client{Transport: proxy}
 // Upstream down: cached response returned transparently
 ```
 
+### Proxy health endpoints (opt-in)
+
+The proxy can expose a small technical surface for operators and downstream UIs to react to upstream state changes in real time. Off by default; opt in with `--health-endpoint` (CLI) or `WithProxyHealthEndpoint()` (library):
+
+```bash
+httptape proxy --upstream https://api.example.com --fixtures ./cache \
+    --health-endpoint --upstream-probe-interval 2s
+```
+
+```bash
+# JSON snapshot
+curl http://localhost:8081/__httptape/health
+# {"state":"live","upstream_url":"https://api.example.com","probe_interval_ms":2000,"since":"2026-04-16T10:00:00Z","last_probed_at":"2026-04-16T10:00:02Z"}
+
+# SSE stream — one event on connect, one per state transition
+curl -N http://localhost:8081/__httptape/health/stream
+# retry: 2000
+#
+# data: {"state":"live", ... }
+#
+# data: {"state":"l1-cache", ... }
+```
+
+`state` mirrors the existing `X-Httptape-Source` header (`live`, `l1-cache`, `l2-cache`). With both flags absent, no endpoints are mounted and no probe goroutine is started — behavior is byte-for-byte unchanged.
+
 ### Import / Export
 
 ```go

--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -335,6 +335,11 @@ func runProxy(args []string) error {
 	tlsKey := fs.String("tls-key", "", "Path to PEM client private key for mTLS")
 	tlsCA := fs.String("tls-ca", "", "Path to PEM CA certificate(s) for upstream verification")
 	tlsInsecure := fs.Bool("tls-insecure", false, "Skip TLS verification (dev only)")
+	healthEndpoint := fs.Bool("health-endpoint", false,
+		"Mount /__httptape/health (JSON snapshot) and /__httptape/health/stream (SSE).")
+	upstreamProbeInterval := fs.Duration("upstream-probe-interval", 0,
+		"Active upstream probe cadence. 0 = disabled. When --health-endpoint is set "+
+			"and this is unset, defaults to 2s.")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -399,6 +404,20 @@ func runProxy(args []string) error {
 		}))
 	}
 
+	if *healthEndpoint {
+		interval := *upstreamProbeInterval
+		if interval == 0 {
+			interval = 2 * time.Second
+		}
+		proxyOpts = append(proxyOpts,
+			httptape.WithProxyUpstreamURL(*upstream),
+			httptape.WithProxyHealthEndpoint(),
+			httptape.WithProxyProbeInterval(interval),
+		)
+	} else if *upstreamProbeInterval > 0 {
+		return &usageError{fmt.Errorf("--upstream-probe-interval requires --health-endpoint")}
+	}
+
 	tapeProxy := httptape.NewProxy(l1, l2, proxyOpts...)
 
 	rp := &httputil.ReverseProxy{
@@ -409,8 +428,17 @@ func runProxy(args []string) error {
 		Transport: tapeProxy,
 	}
 
+	// Compose the listener mux: mount the health surface (if enabled) under
+	// /__httptape/ and forward everything else to the reverse proxy.
 	var handler http.Handler = rp
+	if hh := tapeProxy.HealthHandler(); hh != nil {
+		mux := http.NewServeMux()
+		mux.Handle("/__httptape/", hh)
+		mux.Handle("/", rp)
+		handler = mux
+	}
 	if *cors {
+		inner := handler
 		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD")
@@ -421,7 +449,7 @@ func runProxy(args []string) error {
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
-			rp.ServeHTTP(w, r)
+			inner.ServeHTTP(w, r)
 		})
 	}
 
@@ -434,6 +462,15 @@ func runProxy(args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// Start background workers (currently: the active probe loop). No-op when
+	// the health endpoint is disabled.
+	tapeProxy.Start()
+	defer func() {
+		if err := tapeProxy.Close(); err != nil {
+			logger.Printf("proxy close error: %v", err)
+		}
+	}()
+
 	go func() {
 		<-ctx.Done()
 		logger.Println("shutdown initiated")
@@ -442,6 +479,9 @@ func runProxy(args []string) error {
 		if err := httpServer.Shutdown(shutdownCtx); err != nil {
 			logger.Printf("graceful shutdown failed: %v, forcing close", err)
 			httpServer.Close()
+		}
+		if err := tapeProxy.Close(); err != nil {
+			logger.Printf("proxy close error: %v", err)
 		}
 	}()
 

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -1,11 +1,19 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/VibeWarden/httptape"
 )
@@ -184,4 +192,195 @@ func TestExportImportRoundTrip(t *testing.T) {
 	if string(loaded.Response.Body) != string(tape.Response.Body) {
 		t.Errorf("body = %q, want %q", loaded.Response.Body, tape.Response.Body)
 	}
+}
+
+// TestProxyHelpExposesHealthFlags is a documentation regression: --help on
+// the proxy command lists the new flags so operators discover them.
+func TestProxyHelpExposesHealthFlags(t *testing.T) {
+	// Capture stderr where flag.Usage writes.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	go func() {
+		_ = run([]string{"proxy", "-h"})
+		w.Close()
+	}()
+
+	br := bufio.NewReader(r)
+	var sb strings.Builder
+	for {
+		line, err := br.ReadString('\n')
+		sb.WriteString(line)
+		if err != nil {
+			break
+		}
+	}
+	os.Stderr = origStderr
+
+	got := sb.String()
+	if !strings.Contains(got, "-health-endpoint") {
+		t.Errorf("--health-endpoint missing from proxy help: %s", got)
+	}
+	if !strings.Contains(got, "-upstream-probe-interval") {
+		t.Errorf("--upstream-probe-interval missing from proxy help: %s", got)
+	}
+}
+
+// TestProxyUpstreamProbeIntervalRequiresHealthEndpoint validates the usage
+// guard: --upstream-probe-interval without --health-endpoint is an error.
+func TestProxyUpstreamProbeIntervalRequiresHealthEndpoint(t *testing.T) {
+	tmpDir := t.TempDir()
+	got := run([]string{"proxy",
+		"--upstream", "http://example.com",
+		"--fixtures", tmpDir,
+		"--upstream-probe-interval", "1s",
+	})
+	if got != exitUsage {
+		t.Errorf("got exit %d, want %d (usage)", got, exitUsage)
+	}
+}
+
+// TestProxyHealthEndpointMounted starts the proxy CLI against a fake upstream
+// with --health-endpoint set, then verifies /__httptape/health responds and
+// /__httptape/health/stream emits an initial event.
+func TestProxyHealthEndpointMounted(t *testing.T) {
+	// Fake upstream the proxy will probe.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	// Find a free port for the proxy listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	tmpDir := t.TempDir()
+	args := []string{"proxy",
+		"--upstream", upstream.URL,
+		"--fixtures", tmpDir,
+		"--port", itoa(port),
+		"--health-endpoint",
+		"--upstream-probe-interval", "50ms",
+	}
+
+	// run blocks on ListenAndServe; race a shutdown via SIGINT-like cancel by
+	// closing the os.Stdin/os.Args isn't an option here, so we run in a
+	// goroutine and just kill it after the assertions.
+	done := make(chan int, 1)
+	go func() {
+		done <- run(args)
+	}()
+
+	base := "http://127.0.0.1:" + itoa(port)
+
+	// Wait for the listener to come up.
+	deadline := time.Now().Add(3 * time.Second)
+	var lastErr error
+	for {
+		resp, err := http.Get(base + "/__httptape/health")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				break
+			}
+			lastErr = errors.New("non-200 from health endpoint")
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("health endpoint never came up: %v", lastErr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	resp, err := http.Get(base + "/__httptape/health")
+	if err != nil {
+		t.Fatalf("GET health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var snap httptape.HealthSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snap.UpstreamURL != upstream.URL {
+		t.Errorf("UpstreamURL=%q, want %q", snap.UpstreamURL, upstream.URL)
+	}
+	if snap.ProbeIntervalMS != 50 {
+		t.Errorf("ProbeIntervalMS=%d, want 50", snap.ProbeIntervalMS)
+	}
+
+	// SSE: read the initial event.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", base+"/__httptape/health/stream", nil)
+	streamResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("subscribe SSE: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	br := bufio.NewReader(streamResp.Body)
+	gotEvent := atomic.Bool{}
+	go func() {
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if strings.HasPrefix(strings.TrimSpace(line), "data:") {
+				gotEvent.Store(true)
+				return
+			}
+		}
+	}()
+	deadline = time.Now().Add(2 * time.Second)
+	for !gotEvent.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("SSE initial event not received")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Trigger shutdown by sending SIGINT to ourselves.
+	p, _ := os.FindProcess(os.Getpid())
+	_ = p.Signal(os.Interrupt)
+
+	select {
+	case code := <-done:
+		_ = code
+	case <-time.After(5 * time.Second):
+		t.Fatal("CLI did not exit after SIGINT")
+	}
+}
+
+func itoa(i int) string {
+	const digits = "0123456789"
+	if i == 0 {
+		return "0"
+	}
+	negative := i < 0
+	if negative {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = digits[i%10]
+		i /= 10
+	}
+	if negative {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
 }

--- a/decisions.md
+++ b/decisions.md
@@ -7298,3 +7298,794 @@ second digit, subtract 9 if > 9, sum all, check digit = (10 - sum%10) % 10.
 ##### Migration
 - No migration needed. Existing configs using `"paths"` continue to work
   unchanged. New `"fields"` syntax is opt-in.
+
+---
+
+### ADR-28: Health endpoint surface for proxy mode (snapshot + SSE + active probe)
+
+**Date**: 2026-04-16
+**Issue**: #121
+**Status**: Accepted
+
+#### Context
+
+The `Proxy` (ADR-26) currently signals which tier served a request via the
+`X-Httptape-Source` response header (`l1-cache`, `l2-cache`, or absent for live
+upstream). This is per-request and reactive: a UI built on top of the proxy can
+only learn about an upstream outage (or recovery) by issuing a request and
+inspecting the header. Issue #121 introduces a small technical surface so
+operators and downstream UIs (notably the `ts-frontend-first` demo) can react to
+upstream state changes in real time without polling per-request headers.
+
+The PM has locked in:
+
+- **State model = definition B** ("most-recently-served source"): one state
+  machine fed by both real client traffic and a synthetic probe, with values
+  mirroring the existing `X-Httptape-Source` semantics (`live`, `l1-cache`,
+  `l2-cache`).
+- **Backward compatibility is non-negotiable**: with both new flags at
+  defaults, proxy behavior is byte-for-byte identical to today — no new
+  endpoints mounted, no new goroutines, no new headers, `X-Httptape-Source`
+  unchanged.
+- `X-Httptape-Source` stays as the per-request ground truth. The new surface
+  is additive.
+- Library API is required; CLI flags are a thin wrapper.
+- Out of scope: auth, rate limiting, metrics, k8s readiness conventions, SSE
+  `Last-Event-ID` replay, WebSocket transport, surfacing state in
+  serve/record/mock modes, per-visitor outage simulation.
+
+This ADR resolves the open questions left for the architect and pins down the
+types, file layout, concurrency model, probe lifecycle, SSE multiplex strategy,
+and CLI wiring required to ship.
+
+#### Decision
+
+##### Resolution of open questions
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Flag names | `--health-endpoint` (bool), `--upstream-probe-interval` (duration) | Match the PM proposal — short, explicit, scoped. `health-endpoint` covers both `/__httptape/health` and `/__httptape/health/stream` because they are one capability with two surfaces. |
+| Default probe cadence (when `--health-endpoint` is set and the interval is unset) | **2s** | Trade-off between freshness (UI badges feel real-time) and load (one extra HEAD per 2s is invisible to any real upstream). Matches the PM suggestion. Easy to override per deployment. |
+| Probe HTTP method | **HEAD** with **GET fallback** if HEAD returns 405/501 (cached for the lifetime of the proxy after the first GET fallback) | HEAD is the smallest blast radius — no body transfer, no cache pollution at the upstream. But many real backends do not implement HEAD on `/`; once we observe 405 or 501 we sticky-switch to GET. |
+| Probe path | **`/`** (configurable via library option, not via CLI in v1) | Most upstreams answer `/`. Library exposes `WithProxyProbePath` so embedders with stricter upstreams can target a known liveness path. CLI flag is held back to keep the surface minimal until there is concrete demand. |
+| Probe request shape | Synthetic `*http.Request` constructed with the configured upstream URL, fed through `Proxy.RoundTrip` | Honors the "single state machine" property — the probe takes the exact same code path as a real client request. TLS, sanitizer, fallback, L1/L2 writes all behave identically. |
+| SSE back-pressure | **Bounded per-subscriber buffer (size 8) + drop-and-disconnect on overflow** | Keeps the broadcast loop O(N) and lock-free per send. A subscriber whose buffer overflows is removed and its connection is closed (client sees EOF and reconnects via `EventSource` auto-retry). Initial-on-connect event re-seeds state on reconnect, so dropped intermediate events are recoverable from the application's point of view. Documented as a guarantee of the API. |
+| JSON field names | `state`, `upstream_url`, `last_probed_at`, `probe_interval_ms`, `since` (RFC 3339 timestamp of the last *transition* into the current state) | Snake_case to match common JSON conventions and the issue's own suggestion. `since` is a small addition (PM listed only the first four as "at least"); it costs nothing and lets a UI render "in state X for Y seconds" without storing local timestamps. |
+| SSE event name | **Default (`message`) event, no `event:` line** | EventSource clients receive the same payload either way, but defaulting keeps the payload small (no `event:` line per emit) and avoids a needless tag a frontend would have to listen for explicitly. The architectural value of the named event would be event multiplexing on the same stream — out of scope. |
+
+##### New types
+
+All in a single new file `health.go`:
+
+```go
+// SourceState identifies which tier produced the most recent serve through
+// the proxy. Values mirror the X-Httptape-Source response header semantics
+// established in ADR-26.
+type SourceState string
+
+const (
+    StateLive    SourceState = "live"
+    StateL1Cache SourceState = "l1-cache"
+    StateL2Cache SourceState = "l2-cache"
+)
+
+// HealthSnapshot is the JSON payload returned by GET /__httptape/health and
+// emitted on every SSE event on /__httptape/health/stream. It is the single
+// JSON shape all clients see — snapshot and stream agree byte-for-byte at any
+// instant.
+type HealthSnapshot struct {
+    State           SourceState `json:"state"`
+    UpstreamURL     string      `json:"upstream_url"`
+    LastProbedAt    *time.Time  `json:"last_probed_at,omitempty"` // nil until the first probe completes (or when probing is disabled)
+    ProbeIntervalMS int64       `json:"probe_interval_ms"`        // 0 when probing is disabled
+    Since           time.Time   `json:"since"`                    // when the proxy last transitioned into the current state
+}
+
+// HealthMonitor owns the proxy's "most-recently-served source" state, the SSE
+// subscriber set, and the active probe loop. It is created by the Proxy when
+// WithProxyHealthEndpoint is enabled. With the option absent, the Proxy holds
+// a nil *HealthMonitor and the request path takes a fast no-op branch — this
+// preserves byte-for-byte default behavior.
+//
+// HealthMonitor is safe for concurrent use.
+type HealthMonitor struct {
+    upstreamURL   string
+    interval      time.Duration       // 0 = no probe loop
+    probePath     string
+    probeMethod   string              // dynamically promoted from HEAD to GET on 405/501
+    probeMethodMu sync.Mutex          // guards the HEAD->GET promotion only
+    transport     http.RoundTripper   // used by the probe (= the Proxy itself, so probes hit the same resolution path)
+    onError       func(error)
+    now           func() time.Time    // injectable for tests
+
+    // state machine + subscriber set
+    mu          sync.Mutex
+    state       SourceState
+    since       time.Time
+    lastProbed  *time.Time
+    subscribers map[*healthSubscriber]struct{}
+
+    // lifecycle
+    closeOnce sync.Once
+    done      chan struct{} // closed when Close() is called; signals probe loop + handlers to exit
+    wg        sync.WaitGroup // tracks the probe loop goroutine
+}
+
+// HealthMonitorOption configures a HealthMonitor.
+type HealthMonitorOption func(*HealthMonitor)
+
+// healthSubscriber is one connected SSE client. The buffer is bounded; if a
+// send would block (buffer full) the broadcast routine drops the subscriber,
+// closes the buffer, and the handler goroutine exits and writes EOF to the
+// underlying connection.
+type healthSubscriber struct {
+    ch chan HealthSnapshot // capacity = sseBufferSize (8)
+}
+```
+
+Constants used internally (unexported):
+
+```go
+const (
+    sseBufferSize           = 8                       // per-subscriber bounded buffer
+    defaultProbeInterval    = 2 * time.Second
+    defaultProbePath        = "/"
+    defaultProbeMethod      = http.MethodHead
+    healthEndpointPath      = "/__httptape/health"
+    healthStreamPath        = "/__httptape/health/stream"
+    sseRetryBackoffMS       = 2000                    // hint to client via "retry: " field on initial event
+)
+```
+
+##### New `Proxy` options (in `proxy.go`)
+
+```go
+// WithProxyHealthEndpoint enables the health surface on this Proxy. When set,
+// Proxy.HealthHandler() returns a non-nil http.Handler that serves
+// /__httptape/health and /__httptape/health/stream. The probe loop is started
+// the first time the Proxy is mounted (see Proxy.Start) — never at construction
+// time, so embedders that build a Proxy without ever serving HTTP do not leak
+// goroutines.
+//
+// With this option absent, Proxy.HealthHandler() returns nil and the request
+// path takes a no-op branch when recording state — preserving byte-for-byte
+// default behavior.
+func WithProxyHealthEndpoint(opts ...HealthMonitorOption) ProxyOption
+
+// WithProxyProbeInterval sets the active probe cadence. Zero disables the
+// probe loop (the request path still updates state, but no synthetic probe
+// runs). When WithProxyHealthEndpoint is set and this option is absent, the
+// default is 2s.
+//
+// This option is a no-op unless WithProxyHealthEndpoint is also set.
+func WithProxyProbeInterval(d time.Duration) ProxyOption
+
+// WithProxyProbePath sets the URL path the active probe targets on the upstream
+// (default "/"). No-op unless WithProxyHealthEndpoint is also set.
+func WithProxyProbePath(path string) ProxyOption
+
+// WithProxyHealthErrorHandler sets a callback for non-fatal errors inside the
+// health surface (probe transport errors that are NOT a state transition,
+// SSE write errors, etc.). Defaults to the existing onError callback set by
+// WithProxyOnError; if neither is set, errors are swallowed. No-op unless
+// WithProxyHealthEndpoint is also set.
+func WithProxyHealthErrorHandler(fn func(error)) ProxyOption
+```
+
+Note that `WithProxyProbeInterval`, `WithProxyProbePath`, and
+`WithProxyHealthErrorHandler` are top-level `ProxyOption`s rather than
+`HealthMonitorOption`s passed through `WithProxyHealthEndpoint`. Rationale:
+embedders configure the Proxy as one object; they should not have to import a
+sub-options type for what feel like proxy-level knobs. The
+`HealthMonitorOption` slot inside `WithProxyHealthEndpoint` exists for future
+extension (e.g. injecting a clock for tests) without breaking the proxy
+options surface.
+
+##### New `Proxy` methods
+
+```go
+// HealthHandler returns the http.Handler that serves /__httptape/health and
+// /__httptape/health/stream. Returns nil when WithProxyHealthEndpoint was not
+// set — callers should mount the handler conditionally.
+//
+// The handler routes only the two health paths; any other path returns 404.
+// Callers compose it into their own mux (see CLI wiring below).
+func (p *Proxy) HealthHandler() http.Handler
+
+// Start initializes background workers (currently: the active probe loop).
+// Safe to call zero or more times; subsequent calls are no-ops. Must be called
+// before serving HTTP if WithProxyHealthEndpoint and a non-zero probe interval
+// are set, otherwise the probe loop never runs.
+//
+// The CLI wires Start() into the proxy command's startup. Library users
+// embedding the Proxy choose when (and whether) to call it.
+func (p *Proxy) Start()
+
+// Close stops background workers and closes all open SSE subscribers. Safe to
+// call zero or more times; idempotent. Returns when all goroutines spawned by
+// the Proxy have exited (probe loop drained, broadcast goroutine exited if any).
+//
+// Close does NOT close the L1/L2 stores — they are owned by the caller.
+func (p *Proxy) Close() error
+```
+
+`Proxy.Close` is new; ADR-26 did not give `Proxy` a Close method because there
+were no background workers to drain. This is the first feature that needs one.
+Idempotent + nil-safe so existing embedders that never call it (or call it
+twice) are unaffected.
+
+##### `HealthMonitor` methods (mostly unexported, used by `Proxy`)
+
+```go
+// NewHealthMonitor constructs a HealthMonitor. transport is the http.RoundTripper
+// the active probe will hit — in production this is the Proxy itself, so the
+// probe takes the same resolution path as real client traffic. upstreamURL is
+// reported in the snapshot. opts may inject a clock or additional knobs.
+//
+// upstreamURL must be non-empty and transport must be non-nil.
+func NewHealthMonitor(upstreamURL string, transport http.RoundTripper, opts ...HealthMonitorOption) *HealthMonitor
+
+// observe is called by the Proxy on every served request (including probe-driven
+// ones) with the source the response was served from. It is the only mutator
+// of the state machine and the only emitter of SSE events.
+//
+// observe is a no-op when called on a nil *HealthMonitor — this is the fast
+// path for proxies built without WithProxyHealthEndpoint.
+func (h *HealthMonitor) observe(src SourceState)
+
+// snapshot returns the current state as a HealthSnapshot value. Safe to call
+// concurrently with observe and broadcast.
+func (h *HealthMonitor) snapshot() HealthSnapshot
+
+// subscribe registers a new SSE subscriber and returns its receive channel
+// plus an unsubscribe func. The channel is closed when the subscriber is
+// dropped (either by overflow or by Close).
+func (h *HealthMonitor) subscribe() (<-chan HealthSnapshot, func())
+
+// runProbe is the active probe loop. Started exactly once by Proxy.Start.
+// Exits when h.done is closed.
+func (h *HealthMonitor) runProbe(ctx context.Context)
+
+// ServeHTTP routes /__httptape/health and /__httptape/health/stream; returns
+// 404 for any other path. HealthMonitor implements http.Handler so it can be
+// mounted directly.
+func (h *HealthMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request)
+
+// Close drains the probe loop, closes all subscriber channels, and is
+// idempotent.
+func (h *HealthMonitor) Close() error
+```
+
+Functional option example:
+
+```go
+// WithHealthClock injects a clock for tests. Defaults to time.Now.
+func WithHealthClock(now func() time.Time) HealthMonitorOption
+```
+
+##### File layout
+
+```
+httptape/
+  health.go              # NEW. SourceState, HealthSnapshot, HealthMonitor,
+                         # HealthMonitorOption, NewHealthMonitor, observe,
+                         # snapshot, subscribe, runProbe, ServeHTTP, Close,
+                         # all unexported helpers and the package-private
+                         # constants listed above.
+  health_test.go         # NEW. Unit tests (see Test strategy below).
+  proxy.go               # MODIFIED. Add Proxy.health *HealthMonitor field,
+                         # WithProxyHealthEndpoint / WithProxyProbeInterval /
+                         # WithProxyProbePath / WithProxyHealthErrorHandler
+                         # options, HealthHandler() / Start() / Close() methods,
+                         # and call p.health.observe(src) in RoundTrip /
+                         # fallback. observe on a nil receiver is a no-op so
+                         # the existing happy paths are unchanged.
+  proxy_test.go          # MODIFIED. Add a single "with both flags at default,
+                         # no goroutines started, no endpoints mounted" guard
+                         # test to lock the backward-compat invariant.
+  cmd/httptape/main.go   # MODIFIED. Add --health-endpoint and
+                         # --upstream-probe-interval flags to runProxy. Build
+                         # ProxyOptions accordingly. If --health-endpoint is
+                         # set, mux the health handler under /__httptape/ and
+                         # forward everything else to the existing reverse
+                         # proxy. Call tapeProxy.Start() and tapeProxy.Close().
+  cmd/httptape/main_test.go  # MODIFIED. Smoke test that --health-endpoint
+                         # changes the listener surface as expected.
+  doc.go                 # MODIFIED. Add a short "Health endpoints" subsection
+                         # documenting the surface.
+  README.md              # MODIFIED. Add a brief proxy-mode health subsection
+                         # mirroring the godoc.
+```
+
+No new top-level files beyond `health.go` / `health_test.go`. No `internal/`.
+No new dependencies — `net/http` + `http.Flusher` + `encoding/json` +
+`time` + `sync` + `context` are all stdlib and already in use.
+
+##### State machine and synchronization
+
+State is a tuple `(state SourceState, since time.Time, lastProbed *time.Time)`
+held inside `HealthMonitor` and guarded by a single `sync.Mutex` (`h.mu`).
+
+Single mutator: `HealthMonitor.observe(src)`. Two readers: `snapshot()` (called
+by the JSON endpoint and also from inside `observe` to build the SSE event
+payload) and `subscribe()` (called by the SSE endpoint).
+
+Why a `sync.Mutex` and not `sync.RWMutex` or `atomic.Pointer`:
+
+- Critical section is tiny (3 string/time field updates + a non-blocking send
+  per subscriber).
+- Writes are infrequent (one per served request + one per probe tick), reads
+  are also infrequent (one per snapshot HTTP call + one per subscribe).
+- An `RWMutex` adds memory and complexity for no measurable benefit at this
+  request rate.
+- `atomic.Pointer[snapshot]` would force a copy-on-write per emit and a
+  separate sync mechanism for the subscriber set anyway.
+
+`observe(src)` algorithm:
+
+```
+1. Compute the next snapshot: state, since, lastProbed.
+   - state = src
+   - if src != h.state: since = h.now() (transition); else since = h.since (no-op)
+2. Acquire h.mu.
+3. Detect transition (src != h.state).
+4. Update h.state, h.since.
+5. If this call is from the probe loop (signaled via a separate `observeProbe`
+   variant), also update h.lastProbed = &now.
+6. If a transition occurred, snapshot the subscriber set into a local slice
+   (cheap; pointers only).
+7. Release h.mu.
+8. For each subscriber pointer, attempt a non-blocking send of the snapshot:
+       select {
+       case sub.ch <- snap:
+       default:
+           // Buffer full: drop and disconnect.
+           h.dropSubscriber(sub)
+       }
+9. If no transition occurred, skip step 6–8 entirely. (Acceptance criterion:
+   no event on confirmation of existing state.)
+```
+
+A separate small entrypoint `observeProbe(src)` exists so the request path
+(`Proxy.RoundTrip`/`fallback`) can call `observe(src)` without bumping
+`lastProbed` (only the probe should update that field), while the probe loop
+calls `observeProbe(src)`. Both share the same locking and broadcast logic.
+
+`subscribe()` algorithm:
+
+```
+1. ch := make(chan HealthSnapshot, sseBufferSize)
+2. sub := &healthSubscriber{ch: ch}
+3. Acquire h.mu.
+4. Capture current snapshot for initial seed.
+5. Add sub to h.subscribers.
+6. Release h.mu.
+7. Send the initial snapshot non-blocking. (Buffer is fresh and capacity 8 so
+   this never blocks — but we still use select/default for paranoia.)
+8. Return ch and an unsubscribe closure.
+```
+
+`dropSubscriber(sub)` algorithm:
+
+```
+1. Acquire h.mu.
+2. If sub not in h.subscribers, release lock and return.
+3. delete(h.subscribers, sub).
+4. close(sub.ch).
+5. Release h.mu.
+```
+
+Closing the channel from the broadcaster (rather than from the SSE handler)
+gives a single owner of the close-channel operation, removing the
+"close-of-closed-channel" race entirely. The SSE handler treats `ch` as
+read-only and exits when it sees the channel closed.
+
+##### SSE multiplex / back-pressure design
+
+Per-subscriber bounded buffer of size 8, drop-and-disconnect on overflow.
+
+Why 8:
+
+- SSE state events are tiny (~150 bytes JSON). 8 events is < 2 KB of memory
+  per subscriber.
+- The fastest plausible event rate is one transition per probe interval (~2s).
+  A subscriber that cannot drain 8 events in 16+ seconds is effectively dead;
+  disconnecting it and letting `EventSource` reconnect is the right answer.
+
+Why drop-and-disconnect over drop-event-only:
+
+- Drop-event-only would let a slow client persistently miss state changes,
+  giving them a stale UI badge with no recovery signal.
+- Disconnect forces a client reconnect; the new connection's
+  initial-on-connect event re-seeds the correct state, so no information is
+  lost from the application's perspective.
+
+Why drop-and-disconnect over disconnect-only (no buffer):
+
+- With buffer = 0, the broadcaster would have to do `select { case ch <- snap;
+  default: drop }` *and* hold the mutex during the send, since concurrent
+  observers could otherwise race to a partial subscriber list. The bounded
+  buffer absorbs short pauses (e.g. SSE handler is in the middle of a
+  `Flush()` call) and keeps the mutex critical section short.
+
+The SSE handler goroutine logic:
+
+```
+1. Verify request is GET. Otherwise 405.
+2. Set headers:
+     Content-Type: text/event-stream
+     Cache-Control: no-cache
+     Connection: keep-alive
+     X-Accel-Buffering: no   (defeats nginx buffering; harmless without nginx)
+3. Type-assert the ResponseWriter to http.Flusher; if it doesn't implement
+   Flusher, return 500. (Modern net/http does; httptest does. Defensive.)
+4. ch, unsub := h.subscribe()
+   defer unsub()
+5. Write a "retry: 2000\n\n" line so EventSource clients reconnect quickly.
+   Flush.
+6. Loop:
+     select {
+     case <-r.Context().Done():
+         // client disconnected
+         return
+     case <-h.done:
+         // proxy shutting down
+         return
+     case snap, ok := <-ch:
+         if !ok {
+             // dropped by broadcaster (overflow or Close)
+             return
+         }
+         payload, _ := json.Marshal(snap)
+         fmt.Fprintf(w, "data: %s\n\n", payload)
+         flusher.Flush()
+     }
+```
+
+Nothing in this loop holds `h.mu`. The broadcaster holds `h.mu` only to
+snapshot the subscriber pointer list, not for the actual sends. Slow flushes
+on one subscriber cannot block other subscribers or the request path.
+
+##### Probe lifecycle
+
+Started by `Proxy.Start()`. Stopped by `Proxy.Close()` via `h.done` channel
+closure.
+
+```go
+func (h *HealthMonitor) runProbe(ctx context.Context) {
+    if h.interval <= 0 {
+        return
+    }
+    defer h.wg.Done()
+
+    ticker := time.NewTicker(h.interval)
+    defer ticker.Stop()
+
+    for {
+        select {
+        case <-h.done:
+            return
+        case <-ticker.C:
+            h.runProbeOnce(ctx)
+        }
+    }
+}
+```
+
+`runProbeOnce` builds a synthetic `*http.Request` against
+`upstreamURL + probePath`, runs it through `h.transport.RoundTrip` (which is
+the Proxy), interprets the result, and calls `h.observeProbe(src)`:
+
+- HEAD response with status < 500 and no `X-Httptape-Source` header → `live`.
+- Any response with `X-Httptape-Source: l1-cache` → `l1-cache`.
+- Any response with `X-Httptape-Source: l2-cache` → `l2-cache`.
+- HEAD response with status 405 or 501 → promote `h.probeMethod` to GET (under
+  `h.probeMethodMu`), do not call `observeProbe` for this tick (the upstream
+  is up but rejected our method — this is not a tier signal).
+- Transport error AND response is nil → do not call `observeProbe`. The
+  Proxy's own fallback already handled state via `observe` if the request
+  produced a tier hit. If the Proxy returned `nil, err` (no cache match), the
+  state stays unchanged — which is the correct behavior per definition B
+  ("if neither cache matched, state remains whatever it was").
+- Always update `h.lastProbed = now()` regardless of outcome (the snapshot
+  field reports "did the probe at least *run*"), via a tiny separate call:
+  `h.recordProbeAttempt()`.
+
+The probe **uses a context derived from `h.done`**, not the long-lived
+`context.Background()` of the Proxy, so a Close immediately cancels any
+in-flight probe RoundTrip.
+
+Probe request shape:
+
+```go
+req, _ := http.NewRequestWithContext(ctx, h.probeMethod, h.upstreamURL+h.probePath, nil)
+req.Header.Set("X-Httptape-Probe", "1")  // diagnostic, not used for routing
+```
+
+The `X-Httptape-Probe` header lets operators see probe traffic in upstream
+access logs and lets future versions filter probes out of recording (out of
+scope here — the probe is recorded normally so it actually feeds L1/L2,
+keeping caches warm).
+
+##### Proxy integration
+
+`Proxy.RoundTrip` and `Proxy.fallback` already know which tier they served
+from. They each gain a single one-line call:
+
+- Top of the success branch (after the upstream call returns and we are about
+  to record): `p.health.observe(StateLive)`.
+- Inside `tapeToResponse`, just before returning to the caller: pass the
+  source string in and call `p.health.observe(src)` (where `src` is `l1-cache`
+  or `l2-cache` mapped to the const).
+- If both fallbacks miss and the original error is returned: do **not** call
+  `observe`. State stays as-is. This matches the PM's locked-in rule.
+
+`p.health.observe(src)` is a no-op when `p.health == nil`, so when
+`WithProxyHealthEndpoint` is not set, this is a single nil-receiver method
+call per request — effectively free, and behavior is byte-for-byte identical.
+
+##### CLI flag wiring
+
+In `cmd/httptape/main.go`'s `runProxy`:
+
+```go
+healthEndpoint := fs.Bool("health-endpoint", false,
+    "Mount /__httptape/health (JSON snapshot) and /__httptape/health/stream (SSE).")
+upstreamProbeInterval := fs.Duration("upstream-probe-interval", 0,
+    "Active upstream probe cadence. 0 = disabled. When --health-endpoint is set "+
+    "and this is unset, defaults to 2s.")
+```
+
+After parsing:
+
+```go
+if *healthEndpoint {
+    proxyOpts = append(proxyOpts, httptape.WithProxyHealthEndpoint())
+    interval := *upstreamProbeInterval
+    if interval == 0 {
+        interval = 2 * time.Second
+    }
+    proxyOpts = append(proxyOpts, httptape.WithProxyProbeInterval(interval))
+} else if *upstreamProbeInterval > 0 {
+    return &usageError{fmt.Errorf("--upstream-probe-interval requires --health-endpoint")}
+}
+```
+
+Routing the listener:
+
+```go
+var handler http.Handler = rp
+if hh := tapeProxy.HealthHandler(); hh != nil {
+    mux := http.NewServeMux()
+    mux.Handle("/__httptape/", hh)
+    mux.Handle("/", rp)
+    handler = mux
+}
+// CORS wrapper (existing) goes around `handler` after this.
+```
+
+The path prefix `/__httptape/` is reserved for httptape's technical surface
+and will never be forwarded upstream. (The current proxy has no concept of a
+reserved prefix; this is established by this ADR.)
+
+Lifecycle in `runProxy`:
+
+```go
+tapeProxy.Start()                 // no-op if no probe configured
+defer tapeProxy.Close()           // belt-and-braces; the signal handler also calls it
+
+go func() {
+    <-ctx.Done()
+    // existing httpServer.Shutdown(...) block
+    if err := tapeProxy.Close(); err != nil {
+        logger.Printf("proxy close error: %v", err)
+    }
+}()
+```
+
+##### Sequence diagram (text): upstream goes down → probe detects → SSE fires → frontend re-fetches
+
+```
+t=0       Frontend connects:  GET /__httptape/health/stream
+            -> SSE handler subscribes, sends initial event {state:"live"}
+            -> Frontend renders "LIVE" badge.
+
+t=2s      Probe tick #1:
+            HealthMonitor.runProbeOnce()
+              -> HEAD upstream/  -> 200 OK, no X-Httptape-Source
+              -> observeProbe(StateLive)
+                   no transition (state already "live") => no SSE event
+              -> recordProbeAttempt() updates lastProbed.
+
+t=3s      Upstream goes down (network partition).
+
+t=4s      Probe tick #2:
+            HEAD upstream/  -> transport error
+            Proxy.fallback runs through L1: hit
+              -> tapeToResponse(tape, "l1-cache") returns 200 with
+                 X-Httptape-Source: l1-cache
+              -> Proxy calls p.health.observe(StateL1Cache)
+                   transition live -> l1-cache
+                   broadcast: send {state:"l1-cache",since:t=4s,...} to
+                   every subscriber's bounded channel.
+            runProbeOnce inspects the response, sees l1-cache header, does
+            NOT call observeProbe (already observed by the success/fallback
+            path); only recordProbeAttempt().
+
+t=4s+ms   SSE handler reads from its channel, writes
+            "data: {\"state\":\"l1-cache\",...}\n\n" + flush.
+          Frontend's EventSource onmessage fires.
+          Frontend re-fetches data, swaps badge to "L1 CACHE".
+
+t=10s     Upstream recovers.
+
+t=12s     Probe tick #5:
+            HEAD upstream/  -> 200 OK, no X-Httptape-Source
+            Proxy success path: writes L1+L2, calls
+              p.health.observe(StateLive)
+                transition l1-cache -> live, broadcast.
+          SSE handler emits {state:"live",since:t=12s,...}.
+          Frontend re-fetches, badge back to "LIVE".
+
+t=...     User hits Ctrl-C. SIGTERM -> ctx cancel.
+            Proxy.Close():
+              close(h.done)
+              probe goroutine's select picks <-h.done, returns; wg.Wait drains.
+              broadcaster snapshot of subscribers + close(ch) for each.
+              SSE handlers' select picks closed channel, return; HTTP write
+              loop unwinds; net/http closes the underlying TCP connection.
+              Frontend EventSource sees onclose; auto-retry (per "retry: 2000")
+              eventually fails when the listener is gone — frontend handles.
+```
+
+##### Error cases
+
+| Where | Symptom | Handling |
+|---|---|---|
+| `NewHealthMonitor` called with empty upstream URL | Programming error | Panic with `httptape: NewHealthMonitor requires a non-empty upstream URL` (constructor guard, per L-11). |
+| `NewHealthMonitor` called with nil transport | Programming error | Panic with `httptape: NewHealthMonitor requires a non-nil transport`. |
+| Probe HEAD returns 405/501 | Upstream does not support HEAD on the probe path | Sticky-promote `h.probeMethod` to GET under `h.probeMethodMu`. Skip `observeProbe` for this tick (no tier signal). Subsequent ticks use GET. |
+| Probe transport error AND no cached fallback | `Proxy.RoundTrip` returned `nil, err` | `runProbeOnce` swallows the error (passes it to `h.onError` if set) and does NOT call `observeProbe`. State stays at its previous value, matching the locked-in rule "if neither cache matched, state remains whatever it was before that failed serve." |
+| Probe transport error WITH cached fallback | Cache hit happened inside the proxy | `Proxy.RoundTrip` already called `observe(StateL1Cache)` or `observe(StateL2Cache)` synchronously. `runProbeOnce` sees the response, does not double-emit. |
+| SSE handler called with non-`http.Flusher` writer | Defensive — net/http always satisfies Flusher | Return 500 with body `httptape: streaming not supported`. |
+| SSE subscriber buffer full | Slow / dead client | Drop subscriber: `close(sub.ch)`, remove from set. Handler goroutine sees closed channel, returns, net/http closes the connection. Client `EventSource` auto-reconnects and re-seeds via initial event. |
+| Health endpoint receives unsupported method (e.g. POST) | Misuse | Return 405 with `Allow: GET`. |
+| Health endpoint receives unknown subpath | Misuse | Return 404. The mux only routes `/__httptape/health` and `/__httptape/health/stream`. |
+| `Proxy.Close` called twice | Idempotency | `closeOnce.Do(...)` ensures workers are drained exactly once. Returns `nil` on subsequent calls. |
+| `Proxy.Start` called twice | Idempotency | `startOnce.Do(...)` ensures the probe goroutine is launched at most once. |
+| JSON marshal of `HealthSnapshot` fails | Cannot happen for these field types | Errors-by-default-discarded; the marshal call is paired with a `_ = err` and a comment explaining the unreachable branch. (No panic, no log spam.) |
+| `json.NewEncoder(w).Encode(snapshot)` on the snapshot endpoint | Network-side error | Errors are passed to `h.onError` if set. The HTTP response is already partially written; nothing actionable beyond logging. |
+
+##### Test strategy
+
+All in `health_test.go` unless noted. Stdlib `testing` only.
+Race-clean (`go test -race ./...`). Coverage target ≥ 90% for `health.go`.
+
+| Test | Pattern | What it verifies |
+|---|---|---|
+| `TestHealthMonitor_InitialState` | direct | New monitor reports `state=live`, `since` ≈ now, `lastProbed=nil`. |
+| `TestHealthMonitor_ObserveTransition` | table-driven | Sequence of `observe` calls produces correct state machine transitions and updates `since` only on transitions. |
+| `TestHealthMonitor_ObserveNoEventOnSameState` | direct | Two consecutive `observe(StateLive)` calls produce exactly one initial SSE event (from subscribe), no follow-up events. |
+| `TestHealthMonitor_BroadcastFanOut` | direct | 100 concurrent subscribers all receive one transition event. |
+| `TestHealthMonitor_SlowSubscriberDropped` | direct | Subscriber that never drains its buffer is dropped after `sseBufferSize+1` transitions; channel is closed; other subscribers are unaffected. |
+| `TestHealthMonitor_SubscribeReceivesInitial` | direct | Newly subscribed client immediately receives the current snapshot. |
+| `TestHealthMonitor_CloseDrainsSubscribers` | direct | After `Close()`, all subscriber channels are closed and `subscribe` returns. |
+| `TestHealthMonitor_CloseStopsProbe` | direct, with a fake transport that records call count | After `Close()`, no further probe RoundTrips occur within 3× the interval. |
+| `TestHealthMonitor_ProbeHEADtoGETPromotion` | direct, with a fake transport returning 405 once | After a 405, subsequent probe ticks use GET; `probeMethod` is sticky. |
+| `TestHealthMonitor_ProbeFedThroughProxy` | integration-ish, in-memory | A fake upstream first succeeds, then errors; L1 cache is primed; probe drives state from `live` to `l1-cache` and back. SSE subscriber receives both transition events without any real client request between transitions. |
+| `TestHealthMonitor_SnapshotJSONShape` | direct | JSON marshals to exactly the documented field set; `last_probed_at` is omitted when nil; `probe_interval_ms` is 0 when probing disabled. |
+| `TestHealthMonitor_HTTPSnapshotEndpoint` | `httptest` | `GET /__httptape/health` returns 200, `Content-Type: application/json`, body matches snapshot. |
+| `TestHealthMonitor_HTTPStreamEndpoint` | `httptest` + `http.Client` reading body line by line | Stream emits an initial `data:` line within 100ms of subscribe and one more `data:` line per `observe` transition. Test waits with timeouts, never `time.Sleep` of fixed duration alone. |
+| `TestHealthMonitor_HTTPStreamGracefulShutdown` | `httptest` | After `Close()`, the stream's body reader sees EOF (not a hung read). |
+| `TestHealthMonitor_HTTPMethodNotAllowed` | `httptest` | POST to either endpoint returns 405 with `Allow: GET`. |
+| `TestProxy_HealthDisabledByDefault` (in `proxy_test.go`) | direct | `NewProxy(...)` without `WithProxyHealthEndpoint` returns a proxy whose `HealthHandler()` is nil. No goroutines started by `Start()`. |
+| `TestProxy_HealthHeaderUnchanged` (in `proxy_test.go`) | direct | With `WithProxyHealthEndpoint` set, `X-Httptape-Source` is still emitted on cache fallbacks. |
+| `TestProxy_StartCloseIdempotent` (in `proxy_test.go`) | direct | `Start()` and `Close()` can each be called twice with no panic and no double-spawn. |
+| `TestCLI_HealthFlags` (in `cmd/httptape/main_test.go`) | smoke | `--health-endpoint` mounts the endpoint; `--upstream-probe-interval` without `--health-endpoint` returns a usage error. |
+
+A goroutine leak check helper (`goleakish`: count goroutines before/after each
+test that involves Close, asserting count returns to baseline) is added at the
+top of `health_test.go`. We avoid the `go.uber.org/goleak` dependency — a
+30-line stdlib helper using `runtime.NumGoroutine` with retry/backoff is
+sufficient for our needs.
+
+##### Backward compatibility verification
+
+The compatibility guarantee is enforced by:
+
+1. **`p.health == nil` fast path**: every new call site
+   (`p.health.observe(...)`) is on a nil-receiver-safe method. With the option
+   absent, the only added cost is one nil-receiver method call per request,
+   which the Go compiler often inlines away entirely.
+2. **Test `TestProxy_HealthDisabledByDefault`** (above): explicitly asserts
+   `HealthHandler() == nil` and that no goroutine starts.
+3. **CLI test**: ensures the proxy mux only diverges from today when the flag
+   is set.
+4. **Header preservation test**: `X-Httptape-Source` is still written by
+   `tapeToResponse`; this is unchanged.
+
+#### Consequences
+
+##### Positive
+
+- Embedders gain a real-time state surface usable from any frontend that
+  speaks SSE (`EventSource` is in every browser).
+- The "single source of truth fed by both real and probe traffic" property
+  means the snapshot endpoint and the SSE stream cannot drift — they read the
+  same field protected by the same mutex.
+- Probe goes through `Proxy.RoundTrip`, so it benefits from every existing
+  proxy feature (TLS, sanitizer, fallback, L1/L2 writes) for free, and
+  warming the caches as a side effect is actually a feature, not a bug.
+- The default-off design makes this a zero-risk change for users not opting
+  in. Existing tests, fixtures, and integration setups are unaffected.
+- New `Proxy.Close` and `Proxy.Start` lifecycle methods give us a clean place
+  to hang future background workers (e.g. periodic L2 compaction) without
+  another API breakage.
+- stdlib only. No new dependencies.
+
+##### Negative
+
+- `Proxy` grows new lifecycle methods (`Start`, `Close`). Any embedder that
+  builds a `Proxy` and never serves it is fine (Start is a no-op, Close on a
+  never-started monitor is a no-op), but anyone using the new options is now
+  expected to pair them with `Close()` for clean shutdown. This is documented
+  in godoc.
+- The bounded-buffer-then-disconnect strategy means a wedged subscriber will
+  miss intermediate events between disconnect and reconnect. We mitigate by
+  emitting the initial snapshot on every (re)connect, so application-visible
+  state is always correct on resume. This is a deliberate trade-off and is
+  documented in godoc on the SSE endpoint.
+- The probe records into L1/L2. For very low-traffic backends this means the
+  cache contains many probe responses. Acceptable: probe responses are
+  legitimate cache entries (HEAD/GET on `/`). If this becomes a problem in
+  practice, a future ADR can add `WithProxyProbeRecord(false)` to skip
+  recording probe traffic.
+- Adds a `/__httptape/` reserved path prefix to the proxy mode. Callers who
+  happened to be routing real upstream traffic on a path beginning with
+  `/__httptape/` (extremely unlikely) would see a behavior change — but only
+  when they opt in via `--health-endpoint`. With the flag off, the prefix is
+  not reserved.
+
+##### Risks
+
+- Goroutine leak on `Close` if the probe loop or an SSE handler is stuck.
+  Mitigated by deriving all blocking operations from contexts/channels we
+  explicitly close, and by the dedicated `TestHealthMonitor_CloseStopsProbe`
+  and goroutine-count check.
+- SSE handler holding the mutex during a slow Flush. Mitigated by design:
+  the handler holds no `HealthMonitor` mutex during Flush; it only reads from
+  its own channel.
+- Panic in user-supplied `onError` propagating into the probe loop. Mitigated
+  by wrapping the callback in `defer recover()` and swallowing the panic with
+  a log line on stderr (matches the existing pattern in
+  `recorder.runDispatcher`).
+
+##### Migration
+
+- No migration needed for existing users. Defaults preserve current behavior.
+- Embedders who want the new surface add `httptape.WithProxyHealthEndpoint()`
+  (and optionally `WithProxyProbeInterval(...)`) to their `NewProxy` call
+  site, and call `Start()` / `Close()` around the lifetime of their HTTP
+  server.
+
+---
+
+## PM Log
+
+### 2026-04-16
+
+- **Created #121** — `feat: technical health endpoint surface for proxy mode (snapshot + SSE + active probe)`.
+  - Labels: `priority:high`. No milestone (per request).
+  - Adds `/__httptape/health` (JSON snapshot) and `/__httptape/health/stream` (SSE) under explicit opt-in CLI flags `--health-endpoint` and `--upstream-probe-interval`. Active background probe feeds the same state machine the request path does.
+  - Settled the "what is state?" question in favor of definition B (most-recently-served source: `live` / `l1-cache` / `l2-cache`) — rationale: aligns with what the consuming UI is communicating to the user and gives a single source of truth fed by both real and synthetic (probe) traffic.
+  - Status comment posted: `READY_FOR_ARCH`.
+  - Open questions flagged for the architect: final flag names, default probe cadence, probe method/path, SSE back-pressure strategy, JSON field names, SSE event-name convention.
+  - Downstream consumer noted: `ts-frontend-first` will switch its badge to drive off the SSE stream once this lands. The hosted-demo / per-visitor outage simulation feature in `~/workspace/httptape-demos/ts-frontend-first/BACKLOG.md` is explicitly out of scope here and depends on this issue landing first.
+
+- **Created #122** — `chore: enrich Docker Hub & GHCR registry pages (OCI labels, README sync, README parity)`.
+  - Labels: `priority:medium`, `documentation`. No milestone (cosmetic/docs scope).
+  - Three concrete deliverables in one chore-issue: (1) add `org.opencontainers.image.*` labels to the root `Dockerfile` (with `version` wired from a build-arg in `.github/workflows/docker.yml`), (2) extend release CI with a `peter-evans/dockerhub-description` step that pushes the GitHub README to Docker Hub on tag pushes, (3) rebalance the README's `## Docker` section so GHCR is given equal billing with Docker Hub instead of being a one-line footnote.
+  - Explicit non-goals: image signing/cosign, SBOM/provenance attestations, vulnerability scanning, renaming the Docker Hub repo, multi-version registry docs. Each is a separate future issue.
+  - Called out that the Docker Hub README sync only takes effect on the *next* push to the registry — merging the PR is not enough on its own to make the hub.docker.com page change. The GHCR auto-link verification is also a post-release manual step (the only acceptance criterion that cannot be confirmed pre-merge).
+  - Open questions flagged for the architect: single consolidated `LABEL` vs. one `LABEL` per key; which workflow file (`docker.yml` vs. `release.yml`) hosts the README-sync step; whether the existing `DOCKERHUB_TOKEN` is scoped wide enough to write the repo description (vs. push-only).
+  - Status comment posted: `READY_FOR_ARCH`.

--- a/doc.go
+++ b/doc.go
@@ -47,6 +47,28 @@
 // [MatchMethod], [MatchPath], [MatchQueryParams], [MatchBodyHash]) can be
 // composed for custom matching strategies.
 //
+// # Health endpoints (proxy mode)
+//
+// When a [Proxy] is constructed with [WithProxyHealthEndpoint], it exposes a
+// small technical surface that downstream UIs can use to react to upstream
+// state changes in real time:
+//
+//   - GET /__httptape/health        — JSON snapshot ([HealthSnapshot]).
+//   - GET /__httptape/health/stream — text/event-stream emitting one event
+//     on connect (initial seed) and one event per state transition.
+//
+// State values mirror the existing X-Httptape-Source header semantics
+// ([StateLive], [StateL1Cache], [StateL2Cache]) and are fed by the same code
+// path real client traffic takes, plus an optional active probe configured
+// via [WithProxyProbeInterval]. SSE subscribers whose buffers overflow are
+// disconnected; the EventSource auto-reconnect plus the initial-on-connect
+// event re-seeds correct state. Mount the handler returned by
+// [Proxy.HealthHandler] on your listener and pair [Proxy.Start] /
+// [Proxy.Close] with the lifetime of your HTTP server.
+//
+// With these options absent, [Proxy.HealthHandler] returns nil, no
+// goroutines are started, and proxy behavior is byte-for-byte unchanged.
+//
 // # Design principles
 //
 // httptape follows hexagonal architecture: core types have zero I/O, all

--- a/health.go
+++ b/health.go
@@ -215,8 +215,13 @@ func (h *HealthMonitor) recordProbeAttempt() {
 }
 
 // applyObservation runs the observe algorithm: detect transition, update
-// state under the lock, snapshot subscribers, then send out events without
-// holding the lock.
+// state under the lock, then broadcast to subscribers while still holding the
+// lock. Holding h.mu during the send is what protects against the
+// send-on-closed-channel race: dropSubscriber (the single owner of close) also
+// requires h.mu, so a subscriber's channel cannot be closed mid-send. The
+// per-subscriber buffer is bounded; select/default keeps the broadcast
+// non-blocking and overflowed subscribers are dropped in-place under the same
+// lock.
 func (h *HealthMonitor) applyObservation(src SourceState, fromProbe bool) {
 	if !validSourceState(src) {
 		return
@@ -225,6 +230,8 @@ func (h *HealthMonitor) applyObservation(src SourceState, fromProbe bool) {
 	now := h.now().UTC()
 
 	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	transitioned := src != h.state
 	if transitioned {
 		h.state = src
@@ -236,24 +243,30 @@ func (h *HealthMonitor) applyObservation(src SourceState, fromProbe bool) {
 	}
 
 	if !transitioned {
-		h.mu.Unlock()
 		return
 	}
 
 	snap := h.snapshotLocked()
-	subs := make([]*healthSubscriber, 0, len(h.subscribers))
-	for sub := range h.subscribers {
-		subs = append(subs, sub)
-	}
-	h.mu.Unlock()
+	h.broadcastLocked(snap)
+}
 
-	for _, sub := range subs {
+// broadcastLocked sends snap to every subscriber non-blockingly. Subscribers
+// whose buffer is full are dropped (channel closed, removed from the set)
+// under the same lock. Caller MUST hold h.mu.
+func (h *HealthMonitor) broadcastLocked(snap HealthSnapshot) {
+	var toDrop []*healthSubscriber
+	for sub := range h.subscribers {
 		select {
 		case sub.ch <- snap:
 		default:
-			// Bounded buffer overflow: drop and disconnect.
-			h.dropSubscriber(sub)
+			// Bounded buffer overflow: schedule a drop after we finish iterating
+			// (don't mutate the map while ranging over it).
+			toDrop = append(toDrop, sub)
 		}
+	}
+	for _, sub := range toDrop {
+		delete(h.subscribers, sub)
+		close(sub.ch)
 	}
 }
 
@@ -282,21 +295,34 @@ func (h *HealthMonitor) snapshotLocked() HealthSnapshot {
 
 // subscribe registers a new SSE subscriber and returns its receive channel
 // plus an unsubscribe func. The channel is closed when the subscriber is
-// dropped (either by overflow or by Close).
+// dropped (either by overflow or by Close, which goes through dropSubscriber).
+//
+// The initial seed is delivered while holding h.mu. The channel is fresh with
+// capacity sseBufferSize so the send is guaranteed not to block; holding the
+// lock makes the registration + seed atomic with respect to broadcast and
+// dropSubscriber, eliminating any send-on-closed-channel window.
 func (h *HealthMonitor) subscribe() (<-chan HealthSnapshot, func()) {
 	sub := &healthSubscriber{ch: make(chan HealthSnapshot, sseBufferSize)}
 
 	h.mu.Lock()
+	// Reject post-Close subscribes deterministically: return a closed channel
+	// and a no-op unsub so callers don't block forever.
+	select {
+	case <-h.done:
+		h.mu.Unlock()
+		close(sub.ch)
+		return sub.ch, func() {}
+	default:
+	}
 	snap := h.snapshotLocked()
 	h.subscribers[sub] = struct{}{}
-	h.mu.Unlock()
-
-	// Initial seed: the channel is fresh and capacity is sseBufferSize, so
-	// this never blocks. We still use select/default for paranoia.
+	// Initial seed: send under the lock so dropSubscriber cannot race us. The
+	// buffer is fresh, so this cannot block; select/default is defensive.
 	select {
 	case sub.ch <- snap:
 	default:
 	}
+	h.mu.Unlock()
 
 	unsub := func() {
 		h.dropSubscriber(sub)

--- a/health.go
+++ b/health.go
@@ -344,11 +344,14 @@ func (h *HealthMonitor) runProbe() {
 	defer ticker.Stop()
 
 	// Probe context cancels when the monitor is closed so any in-flight
-	// RoundTrip is aborted promptly.
+	// RoundTrip is aborted promptly. The watcher goroutine is tracked in wg
+	// so Close() waits for it to exit before returning.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	h.wg.Add(1)
 	go func() {
+		defer h.wg.Done()
 		select {
 		case <-h.done:
 			cancel()
@@ -361,7 +364,16 @@ func (h *HealthMonitor) runProbe() {
 		case <-h.done:
 			return
 		case <-ticker.C:
-			h.runProbeOnce(ctx)
+			// Re-check h.done non-blockingly: when both <-h.done and <-ticker.C
+			// are ready, Go's select picks at random. Without this guard a
+			// probe could fire after Close() has already been observed, which
+			// breaks the "no probes after Close" contract.
+			select {
+			case <-h.done:
+				return
+			default:
+				h.runProbeOnce(ctx)
+			}
 		}
 	}
 }
@@ -389,13 +401,15 @@ func (h *HealthMonitor) runProbeOnce(ctx context.Context) {
 
 	resp, err := h.transport.RoundTrip(req)
 	if err != nil {
-		// Transport error AND no response: state stays as-is per definition B.
-		// The Proxy itself may have called observe(...) on a cache hit before
-		// returning an error path; we don't second-guess that.
-		if resp == nil {
-			h.reportError(fmt.Errorf("httptape: probe transport: %w", err))
-			return
+		// http.RoundTripper allows (resp != nil, err != nil) — e.g. partial
+		// body reads. We always close the body if present to avoid leaking
+		// connections, surface the error, and return: the response cannot be
+		// trusted to drive the state machine in this case.
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
 		}
+		h.reportError(fmt.Errorf("httptape: probe transport: %w", err))
+		return
 	}
 	if resp == nil {
 		return

--- a/health.go
+++ b/health.go
@@ -1,0 +1,580 @@
+package httptape
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// SourceState identifies which tier produced the most recent serve through
+// the proxy. Values mirror the X-Httptape-Source response header semantics
+// established in ADR-26.
+type SourceState string
+
+const (
+	// StateLive indicates that the last serve came from the real upstream.
+	// On the per-request response, this corresponds to the absence of an
+	// X-Httptape-Source header.
+	StateLive SourceState = "live"
+	// StateL1Cache indicates that the last serve came from the L1 (in-memory)
+	// fallback cache. Mirrors X-Httptape-Source: l1-cache.
+	StateL1Cache SourceState = "l1-cache"
+	// StateL2Cache indicates that the last serve came from the L2 (on-disk)
+	// fallback cache. Mirrors X-Httptape-Source: l2-cache.
+	StateL2Cache SourceState = "l2-cache"
+)
+
+// HealthSnapshot is the JSON payload returned by GET /__httptape/health and
+// emitted on every SSE event on /__httptape/health/stream. The snapshot
+// endpoint and the SSE stream agree byte-for-byte at any instant — both
+// surfaces read the same protected state.
+type HealthSnapshot struct {
+	// State is the current "most-recently-served source".
+	State SourceState `json:"state"`
+	// UpstreamURL is the configured upstream URL the proxy targets.
+	UpstreamURL string `json:"upstream_url"`
+	// LastProbedAt is the timestamp of the most recent active probe attempt
+	// (RFC 3339). Nil/omitted when probing is disabled or no probe has run yet.
+	LastProbedAt *time.Time `json:"last_probed_at,omitempty"`
+	// ProbeIntervalMS is the configured probe cadence in milliseconds.
+	// Zero when probing is disabled.
+	ProbeIntervalMS int64 `json:"probe_interval_ms"`
+	// Since is when the proxy last transitioned into the current state
+	// (RFC 3339).
+	Since time.Time `json:"since"`
+}
+
+// HealthMonitor owns the proxy's "most-recently-served source" state, the SSE
+// subscriber set, and the active probe loop. It is created by the Proxy when
+// WithProxyHealthEndpoint is enabled. With the option absent, the Proxy holds
+// a nil *HealthMonitor and the request path takes a fast no-op branch — this
+// preserves byte-for-byte default behavior.
+//
+// HealthMonitor is safe for concurrent use.
+type HealthMonitor struct {
+	upstreamURL string
+	interval    time.Duration // 0 = no probe loop
+	probePath   string
+	transport   http.RoundTripper
+	onError     func(error)
+	now         func() time.Time
+
+	probeMethodMu sync.Mutex
+	probeMethod   string // dynamically promoted from HEAD to GET on 405/501
+
+	// state machine + subscriber set
+	mu          sync.Mutex
+	state       SourceState
+	since       time.Time
+	lastProbed  *time.Time
+	subscribers map[*healthSubscriber]struct{}
+
+	// lifecycle
+	startOnce sync.Once
+	closeOnce sync.Once
+	done      chan struct{}
+	wg        sync.WaitGroup
+}
+
+// HealthMonitorOption configures a HealthMonitor.
+type HealthMonitorOption func(*HealthMonitor)
+
+// healthSubscriber is one connected SSE client. The buffer is bounded; if a
+// send would block (buffer full) the broadcast routine drops the subscriber,
+// closes the buffer, and the handler goroutine exits writing EOF to the
+// underlying connection.
+type healthSubscriber struct {
+	ch chan HealthSnapshot
+}
+
+const (
+	sseBufferSize        = 8 // per-subscriber bounded buffer
+	defaultProbeInterval = 2 * time.Second
+	defaultProbePath     = "/"
+	defaultProbeMethod   = http.MethodHead
+	healthEndpointPath   = "/__httptape/health"
+	healthStreamPath     = "/__httptape/health/stream"
+	sseRetryBackoffMS    = 2000
+	probeHeaderName      = "X-Httptape-Probe"
+)
+
+// WithHealthClock injects a clock for tests. Defaults to time.Now.
+func WithHealthClock(now func() time.Time) HealthMonitorOption {
+	return func(h *HealthMonitor) {
+		if now != nil {
+			h.now = now
+		}
+	}
+}
+
+// WithHealthInterval sets the active probe cadence on the HealthMonitor
+// directly. Library users typically configure this through
+// WithProxyProbeInterval; this option exists so callers constructing a
+// HealthMonitor by hand (tests, advanced embedding) can set the interval.
+func WithHealthInterval(d time.Duration) HealthMonitorOption {
+	return func(h *HealthMonitor) {
+		if d < 0 {
+			d = 0
+		}
+		h.interval = d
+	}
+}
+
+// WithHealthProbePath sets the URL path the active probe targets on the
+// upstream (default "/"). Library-only knob.
+func WithHealthProbePath(path string) HealthMonitorOption {
+	return func(h *HealthMonitor) {
+		if path != "" {
+			h.probePath = path
+		}
+	}
+}
+
+// WithHealthErrorHandler sets a callback for non-fatal errors inside the
+// health surface (probe transport errors that are not state transitions,
+// SSE write errors, etc.).
+func WithHealthErrorHandler(fn func(error)) HealthMonitorOption {
+	return func(h *HealthMonitor) {
+		if fn != nil {
+			h.onError = fn
+		}
+	}
+}
+
+// NewHealthMonitor constructs a HealthMonitor. transport is the
+// http.RoundTripper the active probe will hit — in production this is the
+// Proxy itself, so the probe takes the same resolution path as real client
+// traffic. upstreamURL is reported in the snapshot. opts may inject a clock,
+// configure the probe interval, or provide an error callback.
+//
+// upstreamURL must be non-empty and transport must be non-nil. Both are
+// programming errors and panic per the constructor-guard convention.
+func NewHealthMonitor(upstreamURL string, transport http.RoundTripper, opts ...HealthMonitorOption) *HealthMonitor {
+	if upstreamURL == "" {
+		panic("httptape: NewHealthMonitor requires a non-empty upstream URL")
+	}
+	if transport == nil {
+		panic("httptape: NewHealthMonitor requires a non-nil transport")
+	}
+
+	h := &HealthMonitor{
+		upstreamURL: upstreamURL,
+		transport:   transport,
+		probePath:   defaultProbePath,
+		probeMethod: defaultProbeMethod,
+		now:         time.Now,
+		subscribers: make(map[*healthSubscriber]struct{}),
+		done:        make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	h.state = StateLive
+	h.since = h.now().UTC()
+
+	return h
+}
+
+// observe is called by the Proxy on every served request (excluding probe
+// requests) with the source the response was served from. It updates the
+// state machine and broadcasts to SSE subscribers on transitions.
+//
+// observe is a no-op when called on a nil receiver — this is the fast path
+// for proxies built without WithProxyHealthEndpoint.
+func (h *HealthMonitor) observe(src SourceState) {
+	if h == nil {
+		return
+	}
+	h.applyObservation(src, false)
+}
+
+// observeProbe is the variant called from the probe loop. In addition to the
+// state machine update + broadcast it always bumps lastProbed.
+func (h *HealthMonitor) observeProbe(src SourceState) {
+	if h == nil {
+		return
+	}
+	h.applyObservation(src, true)
+}
+
+// recordProbeAttempt updates lastProbed without altering the state machine.
+// Called by the probe loop on every tick regardless of outcome.
+func (h *HealthMonitor) recordProbeAttempt() {
+	if h == nil {
+		return
+	}
+	now := h.now().UTC()
+	h.mu.Lock()
+	h.lastProbed = &now
+	h.mu.Unlock()
+}
+
+// applyObservation runs the observe algorithm: detect transition, update
+// state under the lock, snapshot subscribers, then send out events without
+// holding the lock.
+func (h *HealthMonitor) applyObservation(src SourceState, fromProbe bool) {
+	if !validSourceState(src) {
+		return
+	}
+
+	now := h.now().UTC()
+
+	h.mu.Lock()
+	transitioned := src != h.state
+	if transitioned {
+		h.state = src
+		h.since = now
+	}
+	if fromProbe {
+		probedAt := now
+		h.lastProbed = &probedAt
+	}
+
+	if !transitioned {
+		h.mu.Unlock()
+		return
+	}
+
+	snap := h.snapshotLocked()
+	subs := make([]*healthSubscriber, 0, len(h.subscribers))
+	for sub := range h.subscribers {
+		subs = append(subs, sub)
+	}
+	h.mu.Unlock()
+
+	for _, sub := range subs {
+		select {
+		case sub.ch <- snap:
+		default:
+			// Bounded buffer overflow: drop and disconnect.
+			h.dropSubscriber(sub)
+		}
+	}
+}
+
+// snapshot returns the current state as a HealthSnapshot value. Safe to call
+// concurrently with observe and broadcast.
+func (h *HealthMonitor) snapshot() HealthSnapshot {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.snapshotLocked()
+}
+
+// snapshotLocked builds the snapshot value. Caller must hold h.mu.
+func (h *HealthMonitor) snapshotLocked() HealthSnapshot {
+	snap := HealthSnapshot{
+		State:           h.state,
+		UpstreamURL:     h.upstreamURL,
+		ProbeIntervalMS: h.interval.Milliseconds(),
+		Since:           h.since,
+	}
+	if h.lastProbed != nil {
+		t := *h.lastProbed
+		snap.LastProbedAt = &t
+	}
+	return snap
+}
+
+// subscribe registers a new SSE subscriber and returns its receive channel
+// plus an unsubscribe func. The channel is closed when the subscriber is
+// dropped (either by overflow or by Close).
+func (h *HealthMonitor) subscribe() (<-chan HealthSnapshot, func()) {
+	sub := &healthSubscriber{ch: make(chan HealthSnapshot, sseBufferSize)}
+
+	h.mu.Lock()
+	snap := h.snapshotLocked()
+	h.subscribers[sub] = struct{}{}
+	h.mu.Unlock()
+
+	// Initial seed: the channel is fresh and capacity is sseBufferSize, so
+	// this never blocks. We still use select/default for paranoia.
+	select {
+	case sub.ch <- snap:
+	default:
+	}
+
+	unsub := func() {
+		h.dropSubscriber(sub)
+	}
+	return sub.ch, unsub
+}
+
+// dropSubscriber removes sub from the set and closes its channel exactly once.
+func (h *HealthMonitor) dropSubscriber(sub *healthSubscriber) {
+	h.mu.Lock()
+	if _, ok := h.subscribers[sub]; !ok {
+		h.mu.Unlock()
+		return
+	}
+	delete(h.subscribers, sub)
+	close(sub.ch)
+	h.mu.Unlock()
+}
+
+// start launches the probe loop exactly once if an interval is configured.
+// Idempotent: subsequent calls are no-ops.
+func (h *HealthMonitor) start() {
+	if h == nil {
+		return
+	}
+	h.startOnce.Do(func() {
+		if h.interval <= 0 {
+			return
+		}
+		h.wg.Add(1)
+		go h.runProbe()
+	})
+}
+
+// runProbe is the active probe loop. Started exactly once by start().
+// Exits when h.done is closed.
+func (h *HealthMonitor) runProbe() {
+	defer h.wg.Done()
+
+	if h.interval <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(h.interval)
+	defer ticker.Stop()
+
+	// Probe context cancels when the monitor is closed so any in-flight
+	// RoundTrip is aborted promptly.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-h.done:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	for {
+		select {
+		case <-h.done:
+			return
+		case <-ticker.C:
+			h.runProbeOnce(ctx)
+		}
+	}
+}
+
+// runProbeOnce performs a single probe attempt. The result feeds the same
+// state machine real client traffic does (via observeProbe). recordProbeAttempt
+// is always called so the snapshot reports "did the probe at least run".
+func (h *HealthMonitor) runProbeOnce(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.reportError(fmt.Errorf("httptape: panic in probe loop: %v", r))
+		}
+	}()
+	defer h.recordProbeAttempt()
+
+	method := h.currentProbeMethod()
+	target := h.upstreamURL + h.probePath
+
+	req, err := http.NewRequestWithContext(ctx, method, target, nil)
+	if err != nil {
+		h.reportError(fmt.Errorf("httptape: probe build request: %w", err))
+		return
+	}
+	req.Header.Set(probeHeaderName, "1")
+
+	resp, err := h.transport.RoundTrip(req)
+	if err != nil {
+		// Transport error AND no response: state stays as-is per definition B.
+		// The Proxy itself may have called observe(...) on a cache hit before
+		// returning an error path; we don't second-guess that.
+		if resp == nil {
+			h.reportError(fmt.Errorf("httptape: probe transport: %w", err))
+			return
+		}
+	}
+	if resp == nil {
+		return
+	}
+	if resp.Body != nil {
+		// Drain and close to release the connection. We don't need the bytes.
+		defer resp.Body.Close()
+	}
+
+	// HEAD-to-GET sticky promotion if the upstream rejects HEAD.
+	if method == http.MethodHead && (resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
+		h.promoteProbeMethod(http.MethodGet)
+		return
+	}
+
+	// Decode the source from the X-Httptape-Source header. If absent and the
+	// status is non-5xx, the upstream answered live.
+	src, ok := classifyProbeResponse(resp)
+	if !ok {
+		return
+	}
+	h.observeProbe(src)
+}
+
+// classifyProbeResponse maps a probe response to a SourceState. Returns
+// (state, true) if the response carries a meaningful tier signal; (zero,
+// false) otherwise (e.g. 5xx with no header, in which case state stays as-is).
+func classifyProbeResponse(resp *http.Response) (SourceState, bool) {
+	if resp == nil {
+		return "", false
+	}
+	if v := resp.Header.Get("X-Httptape-Source"); v != "" {
+		switch SourceState(v) {
+		case StateL1Cache:
+			return StateL1Cache, true
+		case StateL2Cache:
+			return StateL2Cache, true
+		}
+		// Unknown header value: ignore.
+		return "", false
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 500 {
+		return StateLive, true
+	}
+	return "", false
+}
+
+func (h *HealthMonitor) currentProbeMethod() string {
+	h.probeMethodMu.Lock()
+	defer h.probeMethodMu.Unlock()
+	return h.probeMethod
+}
+
+func (h *HealthMonitor) promoteProbeMethod(m string) {
+	h.probeMethodMu.Lock()
+	h.probeMethod = m
+	h.probeMethodMu.Unlock()
+}
+
+// ServeHTTP routes /__httptape/health and /__httptape/health/stream; returns
+// 404 for any other path. HealthMonitor implements http.Handler so it can be
+// mounted directly.
+func (h *HealthMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case healthEndpointPath:
+		h.serveSnapshot(w, r)
+	case healthStreamPath:
+		h.serveStream(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *HealthMonitor) serveSnapshot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	snap := h.snapshot()
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-cache")
+	if err := json.NewEncoder(w).Encode(snap); err != nil {
+		h.reportError(fmt.Errorf("httptape: snapshot encode: %w", err))
+	}
+}
+
+func (h *HealthMonitor) serveStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "httptape: streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	// Suggest a fast reconnect cadence to EventSource clients.
+	fmt.Fprintf(w, "retry: %d\n\n", sseRetryBackoffMS)
+	flusher.Flush()
+
+	ch, unsub := h.subscribe()
+	defer unsub()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-h.done:
+			return
+		case snap, ok := <-ch:
+			if !ok {
+				return
+			}
+			payload, err := json.Marshal(snap)
+			if err != nil {
+				// Cannot happen for these field types; report and exit.
+				h.reportError(fmt.Errorf("httptape: stream encode: %w", err))
+				return
+			}
+			if _, werr := fmt.Fprintf(w, "data: %s\n\n", payload); werr != nil {
+				h.reportError(fmt.Errorf("httptape: stream write: %w", werr))
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// Close drains the probe loop, closes all subscriber channels, and is
+// idempotent. Returns nil; the signature returns an error to leave room for
+// future failure modes without an API break.
+func (h *HealthMonitor) Close() error {
+	if h == nil {
+		return nil
+	}
+	h.closeOnce.Do(func() {
+		close(h.done)
+		h.wg.Wait()
+
+		h.mu.Lock()
+		subs := make([]*healthSubscriber, 0, len(h.subscribers))
+		for sub := range h.subscribers {
+			subs = append(subs, sub)
+		}
+		for _, sub := range subs {
+			delete(h.subscribers, sub)
+			close(sub.ch)
+		}
+		h.mu.Unlock()
+	})
+	return nil
+}
+
+func (h *HealthMonitor) reportError(err error) {
+	if h == nil || err == nil || h.onError == nil {
+		return
+	}
+	defer func() {
+		// User-supplied callback must not crash the probe loop.
+		_ = recover()
+	}()
+	h.onError(err)
+}
+
+func validSourceState(s SourceState) bool {
+	switch s {
+	case StateLive, StateL1Cache, StateL2Cache:
+		return true
+	}
+	return false
+}

--- a/health_test.go
+++ b/health_test.go
@@ -311,8 +311,7 @@ func TestHealthMonitor_CloseStopsProbe(t *testing.T) {
 
 	// Allow a couple of probe ticks.
 	time.Sleep(80 * time.Millisecond)
-	beforeClose := rt.callCount()
-	if beforeClose == 0 {
+	if rt.callCount() == 0 {
 		t.Fatal("probe never fired")
 	}
 
@@ -320,10 +319,16 @@ func TestHealthMonitor_CloseStopsProbe(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
+	// Sample AFTER Close: by then any in-flight probe has finished (Close
+	// waits on wg) and the recheck inside runProbe guarantees no further
+	// probe will start. This makes the post-Close growth check race-free —
+	// sampling before Close races with an in-flight tick at the boundary.
+	afterClose := rt.callCount()
+
 	// After close, no further calls within 3x the interval.
 	time.Sleep(80 * time.Millisecond)
-	if got := rt.callCount(); got > beforeClose {
-		t.Errorf("probe kept firing after Close: %d -> %d", beforeClose, got)
+	if got := rt.callCount(); got > afterClose {
+		t.Errorf("probe kept firing after Close: %d -> %d", afterClose, got)
 	}
 
 	waitForGoroutineCount(t, baseline, time.Second)

--- a/health_test.go
+++ b/health_test.go
@@ -839,6 +839,110 @@ func TestWithHealthProbePath_EmptyIgnored(t *testing.T) {
 	}
 }
 
+// TestHealthMonitor_SubscribeObserveCloseStress races subscribe/unsubscribe
+// against concurrent observe and Close. The single-owner-of-close discipline
+// (only dropSubscriber closes channels, both producers and dropSubscriber hold
+// h.mu) must prevent send-on-closed-channel panics under -race.
+func TestHealthMonitor_SubscribeObserveCloseStress(t *testing.T) {
+	const (
+		subscribers = 32
+		observers   = 8
+		duration    = 50 * time.Millisecond
+	)
+
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Observers: continuously toggle state, broadcasting to subscribers.
+	for i := 0; i < observers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			states := []SourceState{StateLive, StateL1Cache, StateL2Cache}
+			j := id
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				h.observe(states[j%len(states)])
+				j++
+			}
+		}(i)
+	}
+
+	// Subscribers: continuously subscribe, drain a few events, unsubscribe.
+	for i := 0; i < subscribers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				ch, unsub := h.subscribe()
+				// Drain whatever is buffered without blocking.
+			drain:
+				for k := 0; k < 4; k++ {
+					select {
+					case _, ok := <-ch:
+						if !ok {
+							break drain
+						}
+					default:
+						break drain
+					}
+				}
+				unsub()
+			}
+		}()
+	}
+
+	// Let the workload race for a bit, then close mid-flight.
+	time.Sleep(duration)
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Stop the workers and wait for them to exit. They should observe
+	// post-Close state cleanly: subscribe returns a closed channel + no-op
+	// unsub, observe still runs harmlessly (transitions broadcast to an empty
+	// subscriber set), and no goroutine should panic.
+	close(stop)
+	wg.Wait()
+}
+
+// TestHealthMonitor_SubscribeAfterCloseReturnsClosedChannel asserts that
+// subscribe() called after Close() does not block and returns a closed
+// channel + no-op unsub. This is the single-owner-of-close contract.
+func TestHealthMonitor_SubscribeAfterCloseReturnsClosedChannel(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	ch, unsub := h.subscribe()
+	if unsub == nil {
+		t.Fatal("subscribe returned nil unsub after Close")
+	}
+	// Calling the no-op unsub must be safe.
+	unsub()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected closed channel from subscribe after Close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscribe channel was not closed after Close")
+	}
+}
+
 // fakeClock is a controllable clock for tests.
 type fakeClock struct {
 	mu  sync.Mutex

--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,853 @@
+package httptape
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// healthNoopTransport is a stand-in transport for HealthMonitor construction in
+// tests where the probe loop is disabled.
+type healthNoopTransport struct{}
+
+func (healthNoopTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("healthNoopTransport: not implemented")
+}
+
+// recordingTransport counts RoundTrip calls and returns the configured
+// response/error.
+type recordingTransport struct {
+	mu     sync.Mutex
+	calls  int
+	respFn func(*http.Request) (*http.Response, error)
+}
+
+func (r *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	if r.respFn == nil {
+		return &http.Response{StatusCode: 200, Body: http.NoBody, Header: http.Header{}}, nil
+	}
+	return r.respFn(req)
+}
+
+func (r *recordingTransport) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// waitForGoroutineCount polls runtime.NumGoroutine with backoff and returns
+// true if the count returns to (or below) the baseline within the deadline.
+// Tests that spawn workers can use this as a leak check after Close.
+func waitForGoroutineCount(t *testing.T, baseline int, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		got := runtime.NumGoroutine()
+		if got <= baseline {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("goroutine count did not return to baseline=%d within %s (got %d)", baseline, within, got)
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestHealthMonitor_InitialState(t *testing.T) {
+	now := time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC)
+	h := NewHealthMonitor("http://example.com", healthNoopTransport{},
+		WithHealthClock(func() time.Time { return now }))
+
+	snap := h.snapshot()
+	if snap.State != StateLive {
+		t.Errorf("State=%q, want %q", snap.State, StateLive)
+	}
+	if !snap.Since.Equal(now) {
+		t.Errorf("Since=%v, want %v", snap.Since, now)
+	}
+	if snap.LastProbedAt != nil {
+		t.Errorf("LastProbedAt=%v, want nil", snap.LastProbedAt)
+	}
+	if snap.UpstreamURL != "http://example.com" {
+		t.Errorf("UpstreamURL=%q", snap.UpstreamURL)
+	}
+	if snap.ProbeIntervalMS != 0 {
+		t.Errorf("ProbeIntervalMS=%d, want 0", snap.ProbeIntervalMS)
+	}
+}
+
+func TestNewHealthMonitor_PanicsOnEmptyUpstream(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on empty upstream URL")
+		}
+	}()
+	NewHealthMonitor("", healthNoopTransport{})
+}
+
+func TestNewHealthMonitor_PanicsOnNilTransport(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil transport")
+		}
+	}()
+	NewHealthMonitor("http://example.com", nil)
+}
+
+func TestHealthMonitor_ObserveTransition(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []SourceState
+		wantSt SourceState
+	}{
+		{"single live", []SourceState{StateLive}, StateLive},
+		{"live to l1", []SourceState{StateLive, StateL1Cache}, StateL1Cache},
+		{"live to l2 to live", []SourceState{StateLive, StateL2Cache, StateLive}, StateLive},
+		{"unknown ignored", []SourceState{StateLive, "garbage", StateL1Cache}, StateL1Cache},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHealthMonitor("http://x", healthNoopTransport{})
+			for _, s := range tt.input {
+				h.observe(s)
+			}
+			if got := h.snapshot().State; got != tt.wantSt {
+				t.Errorf("State=%q, want %q", got, tt.wantSt)
+			}
+		})
+	}
+}
+
+func TestHealthMonitor_ObserveUpdatesSinceOnlyOnTransition(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC)}
+	h := NewHealthMonitor("http://x", healthNoopTransport{},
+		WithHealthClock(clock.Now))
+	initial := h.snapshot().Since
+
+	clock.advance(5 * time.Second)
+	h.observe(StateLive) // same state, no transition
+	if !h.snapshot().Since.Equal(initial) {
+		t.Error("Since changed despite no transition")
+	}
+
+	clock.advance(5 * time.Second)
+	h.observe(StateL1Cache) // transition
+	got := h.snapshot().Since
+	if got.Equal(initial) {
+		t.Error("Since did not change on transition")
+	}
+}
+
+func TestHealthMonitor_ObserveOnNilReceiverIsNoop(t *testing.T) {
+	var h *HealthMonitor
+	// Should not panic.
+	h.observe(StateLive)
+	h.observeProbe(StateLive)
+	h.recordProbeAttempt()
+	if err := h.Close(); err != nil {
+		t.Errorf("nil Close returned %v, want nil", err)
+	}
+	h.start()
+}
+
+func TestHealthMonitor_SubscribeReceivesInitial(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	ch, unsub := h.subscribe()
+	defer unsub()
+
+	select {
+	case snap := <-ch:
+		if snap.State != StateLive {
+			t.Errorf("State=%q, want %q", snap.State, StateLive)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive initial snapshot")
+	}
+}
+
+func TestHealthMonitor_NoEventOnSameState(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	ch, unsub := h.subscribe()
+	defer unsub()
+
+	// Drain the initial snapshot.
+	<-ch
+
+	h.observe(StateLive) // no transition
+	h.observe(StateLive)
+
+	select {
+	case snap, ok := <-ch:
+		if ok {
+			t.Errorf("unexpected event on no-transition: %+v", snap)
+		}
+	case <-time.After(50 * time.Millisecond):
+		// Expected: nothing sent.
+	}
+}
+
+func TestHealthMonitor_BroadcastFanOut(t *testing.T) {
+	const subs = 100
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+
+	channels := make([]<-chan HealthSnapshot, subs)
+	unsubs := make([]func(), subs)
+	for i := 0; i < subs; i++ {
+		channels[i], unsubs[i] = h.subscribe()
+	}
+	defer func() {
+		for _, u := range unsubs {
+			u()
+		}
+	}()
+
+	// Drain initial snapshots.
+	for i := 0; i < subs; i++ {
+		<-channels[i]
+	}
+
+	h.observe(StateL2Cache)
+
+	for i, ch := range channels {
+		select {
+		case snap := <-ch:
+			if snap.State != StateL2Cache {
+				t.Errorf("subscriber %d got state=%q, want %q", i, snap.State, StateL2Cache)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d did not receive transition event", i)
+		}
+	}
+}
+
+func TestHealthMonitor_SlowSubscriberDropped(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+
+	// Subscribe two subscribers; one will be drained, the other will not.
+	slowCh, _ := h.subscribe()
+	fastCh, fastUnsub := h.subscribe()
+	defer fastUnsub()
+
+	// Drain initial seeds so the buffers start empty.
+	<-slowCh
+	<-fastCh
+
+	// Push more transitions than the buffer can hold without draining the slow one.
+	states := []SourceState{StateL1Cache, StateLive, StateL1Cache, StateLive,
+		StateL1Cache, StateLive, StateL1Cache, StateLive,
+		StateL1Cache, StateLive, StateL1Cache, StateLive}
+	for _, s := range states {
+		h.observe(s)
+	}
+
+	// Drain the fast subscriber to keep it healthy.
+	go func() {
+		for range fastCh {
+			// drain
+		}
+	}()
+
+	// Slow subscriber's channel must be closed within a reasonable time.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-slowCh:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("slow subscriber was not dropped")
+		}
+	}
+}
+
+func TestHealthMonitor_CloseDrainsSubscribers(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	ch, _ := h.subscribe()
+
+	// Drain initial seed.
+	<-ch
+
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscriber channel was not closed by Close()")
+	}
+
+	// Idempotent.
+	if err := h.Close(); err != nil {
+		t.Errorf("second Close returned %v, want nil", err)
+	}
+}
+
+func TestHealthMonitor_CloseStopsProbe(t *testing.T) {
+	rt := &recordingTransport{}
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(20*time.Millisecond))
+
+	baseline := runtime.NumGoroutine()
+	h.start()
+
+	// Allow a couple of probe ticks.
+	time.Sleep(80 * time.Millisecond)
+	beforeClose := rt.callCount()
+	if beforeClose == 0 {
+		t.Fatal("probe never fired")
+	}
+
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// After close, no further calls within 3x the interval.
+	time.Sleep(80 * time.Millisecond)
+	if got := rt.callCount(); got > beforeClose {
+		t.Errorf("probe kept firing after Close: %d -> %d", beforeClose, got)
+	}
+
+	waitForGoroutineCount(t, baseline, time.Second)
+}
+
+func TestHealthMonitor_StartIdempotent(t *testing.T) {
+	rt := &recordingTransport{}
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(20*time.Millisecond))
+	defer h.Close() //nolint:errcheck
+
+	baseline := runtime.NumGoroutine()
+	h.start()
+	h.start()
+	h.start()
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Only one probe goroutine should be running, so calls should be roughly
+	// 60ms / 20ms = 3 (allow some slack), not 9.
+	got := rt.callCount()
+	if got > 6 {
+		t.Errorf("Start spawned multiple probe loops: %d calls in 60ms", got)
+	}
+	_ = baseline // we don't enforce a goroutine count here; CloseStopsProbe does.
+}
+
+func TestHealthMonitor_ProbeHEADtoGETPromotion(t *testing.T) {
+	var seenHead, seenGet atomic.Int32
+	rt := &recordingTransport{
+		respFn: func(req *http.Request) (*http.Response, error) {
+			switch req.Method {
+			case http.MethodHead:
+				seenHead.Add(1)
+				return &http.Response{StatusCode: 405, Body: http.NoBody, Header: http.Header{}}, nil
+			case http.MethodGet:
+				seenGet.Add(1)
+				return &http.Response{StatusCode: 200, Body: http.NoBody, Header: http.Header{}}, nil
+			}
+			return nil, errors.New("unexpected method")
+		},
+	}
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond))
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if seenHead.Load() >= 1 && seenGet.Load() >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("did not promote HEAD->GET (head=%d, get=%d)",
+				seenHead.Load(), seenGet.Load())
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+func TestHealthMonitor_ProbeFedThroughTransport(t *testing.T) {
+	// Phase 1: probe sees live, no transition (state already live).
+	// Phase 2: switch transport to return l2-cache header — state transitions
+	// to StateL2Cache and SSE subscriber receives the event.
+	var phase atomic.Int32 // 0 = live, 1 = l2
+
+	rt := &recordingTransport{
+		respFn: func(req *http.Request) (*http.Response, error) {
+			if phase.Load() == 0 {
+				return &http.Response{StatusCode: 200, Body: http.NoBody, Header: http.Header{}}, nil
+			}
+			h := http.Header{}
+			h.Set("X-Httptape-Source", string(StateL2Cache))
+			return &http.Response{StatusCode: 200, Body: http.NoBody, Header: h}, nil
+		},
+	}
+
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond))
+	defer h.Close() //nolint:errcheck
+
+	ch, unsub := h.subscribe()
+	defer unsub()
+
+	// Drain initial seed.
+	if snap := <-ch; snap.State != StateLive {
+		t.Fatalf("initial state %q, want %q", snap.State, StateLive)
+	}
+
+	h.start()
+
+	// Trigger the transition.
+	phase.Store(1)
+
+	select {
+	case snap := <-ch:
+		if snap.State != StateL2Cache {
+			t.Errorf("got state %q, want %q", snap.State, StateL2Cache)
+		}
+		if snap.LastProbedAt == nil {
+			t.Error("LastProbedAt should be set after probe ticks")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive l2-cache transition event from probe")
+	}
+
+	// Phase 3: revert to live; expect another transition.
+	phase.Store(0)
+
+	select {
+	case snap := <-ch:
+		if snap.State != StateLive {
+			t.Errorf("got state %q, want %q", snap.State, StateLive)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive recovery transition to live")
+	}
+}
+
+func TestHealthMonitor_SnapshotJSONShape(t *testing.T) {
+	clock := time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC)
+	h := NewHealthMonitor("http://example.com", healthNoopTransport{},
+		WithHealthClock(func() time.Time { return clock }),
+		WithHealthInterval(2*time.Second))
+
+	// Before any probe.
+	got, err := json.Marshal(h.snapshot())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	gotStr := string(got)
+	if strings.Contains(gotStr, "last_probed_at") {
+		t.Errorf("unexpected last_probed_at in snapshot before probe: %s", gotStr)
+	}
+	if !strings.Contains(gotStr, `"state":"live"`) {
+		t.Errorf("missing state field: %s", gotStr)
+	}
+	if !strings.Contains(gotStr, `"upstream_url":"http://example.com"`) {
+		t.Errorf("missing upstream_url: %s", gotStr)
+	}
+	if !strings.Contains(gotStr, `"probe_interval_ms":2000`) {
+		t.Errorf("wrong probe_interval_ms: %s", gotStr)
+	}
+
+	// After a probe attempt.
+	h.recordProbeAttempt()
+	got, _ = json.Marshal(h.snapshot())
+	if !strings.Contains(string(got), "last_probed_at") {
+		t.Errorf("expected last_probed_at after probe: %s", got)
+	}
+}
+
+func TestHealthMonitor_HTTPSnapshotEndpoint(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + healthEndpointPath)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status=%d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type=%q, want application/json", ct)
+	}
+
+	var snap HealthSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snap.State != StateLive {
+		t.Errorf("State=%q, want %q", snap.State, StateLive)
+	}
+}
+
+func TestHealthMonitor_HTTPSnapshotMethodNotAllowed(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	for _, path := range []string{healthEndpointPath, healthStreamPath} {
+		req, _ := http.NewRequest("POST", srv.URL+path, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Errorf("POST %s status=%d, want 405", path, resp.StatusCode)
+		}
+		if a := resp.Header.Get("Allow"); a != "GET" {
+			t.Errorf("POST %s Allow=%q, want GET", path, a)
+		}
+	}
+}
+
+func TestHealthMonitor_HTTPUnknownPath(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/__httptape/unknown")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHealthMonitor_HTTPStreamEndpoint(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+healthStreamPath, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status=%d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type=%q, want text/event-stream", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("Cache-Control=%q, want no-cache", cc)
+	}
+
+	br := bufio.NewReader(resp.Body)
+
+	// Read until we see the first data: line (initial event).
+	initial, err := readSSEEvent(br, 2*time.Second)
+	if err != nil {
+		t.Fatalf("read initial event: %v", err)
+	}
+	var snap HealthSnapshot
+	if err := json.Unmarshal([]byte(initial), &snap); err != nil {
+		t.Fatalf("unmarshal initial: %v (raw=%q)", err, initial)
+	}
+	if snap.State != StateLive {
+		t.Errorf("initial state=%q, want %q", snap.State, StateLive)
+	}
+
+	// Trigger a transition.
+	h.observe(StateL1Cache)
+	payload, err := readSSEEvent(br, 2*time.Second)
+	if err != nil {
+		t.Fatalf("read transition event: %v", err)
+	}
+	var snap2 HealthSnapshot
+	if err := json.Unmarshal([]byte(payload), &snap2); err != nil {
+		t.Fatalf("unmarshal transition: %v (raw=%q)", err, payload)
+	}
+	if snap2.State != StateL1Cache {
+		t.Errorf("transition state=%q, want %q", snap2.State, StateL1Cache)
+	}
+}
+
+func TestHealthMonitor_HTTPStreamGracefulShutdown(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+healthStreamPath, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	br := bufio.NewReader(resp.Body)
+	if _, err := readSSEEvent(br, 2*time.Second); err != nil {
+		t.Fatalf("read initial: %v", err)
+	}
+
+	// Close the monitor; the SSE handler should return and the body should hit EOF.
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Read should EOF (or the connection should be closed).
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, resp.Body)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil && err != io.EOF && !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "EOF") {
+			// Any clean termination is acceptable.
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("stream body did not unblock after Close")
+	}
+}
+
+func TestHealthMonitor_StreamCloseUnblocksOnClientCancel(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+healthStreamPath, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+
+	br := bufio.NewReader(resp.Body)
+	if _, err := readSSEEvent(br, 2*time.Second); err != nil {
+		t.Fatalf("read initial: %v", err)
+	}
+
+	cancel()
+	// Read remaining bytes should terminate quickly.
+	done := make(chan struct{})
+	go func() {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		resp.Body.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("client cancel did not unblock the stream")
+	}
+}
+
+// readSSEEvent reads lines until it finds a "data: " line and returns the
+// payload (without the prefix). Returns an error if the deadline elapses or
+// the stream ends.
+func readSSEEvent(br *bufio.Reader, within time.Duration) (string, error) {
+	type result struct {
+		payload string
+		err     error
+	}
+	out := make(chan result, 1)
+	go func() {
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				out <- result{err: err}
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			if strings.HasPrefix(line, "data: ") {
+				out <- result{payload: strings.TrimPrefix(line, "data: ")}
+				return
+			}
+		}
+	}()
+	select {
+	case r := <-out:
+		return r.payload, r.err
+	case <-time.After(within):
+		return "", errors.New("readSSEEvent: deadline exceeded")
+	}
+}
+
+func TestClassifyProbeResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *http.Response
+		want SourceState
+		ok   bool
+	}{
+		{"nil response", nil, "", false},
+		{"live 200", &http.Response{StatusCode: 200, Header: http.Header{}}, StateLive, true},
+		{"live 404", &http.Response{StatusCode: 404, Header: http.Header{}}, StateLive, true},
+		{"5xx no header", &http.Response{StatusCode: 500, Header: http.Header{}}, "", false},
+		{"l1 header", &http.Response{StatusCode: 200, Header: http.Header{"X-Httptape-Source": {"l1-cache"}}}, StateL1Cache, true},
+		{"l2 header", &http.Response{StatusCode: 200, Header: http.Header{"X-Httptape-Source": {"l2-cache"}}}, StateL2Cache, true},
+		{"unknown header", &http.Response{StatusCode: 200, Header: http.Header{"X-Httptape-Source": {"weird"}}}, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := classifyProbeResponse(tt.resp)
+			if ok != tt.ok || got != tt.want {
+				t.Errorf("got (%q, %v), want (%q, %v)", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestHealthMonitor_ErrorHandlerInvokedOnProbeError(t *testing.T) {
+	rt := &recordingTransport{
+		respFn: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("boom")
+		},
+	}
+
+	var captured atomic.Int32
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond),
+		WithHealthErrorHandler(func(error) {
+			captured.Add(1)
+		}))
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+	deadline := time.After(2 * time.Second)
+	for captured.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("error handler not called")
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+func TestHealthMonitor_PanicInOnErrorRecovered(t *testing.T) {
+	rt := &recordingTransport{
+		respFn: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("boom")
+		},
+	}
+
+	var calls atomic.Int32
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond),
+		WithHealthErrorHandler(func(error) {
+			calls.Add(1)
+			panic("intentional")
+		}))
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+
+	deadline := time.After(2 * time.Second)
+	for calls.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("probe loop stopped after panic in onError (calls=%d)", calls.Load())
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+func TestHealthMonitor_ProbeIntervalReportedInSnapshot(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{},
+		WithHealthInterval(750*time.Millisecond))
+	if got := h.snapshot().ProbeIntervalMS; got != 750 {
+		t.Errorf("ProbeIntervalMS=%d, want 750", got)
+	}
+}
+
+func TestWithHealthInterval_NegativeClampedToZero(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{},
+		WithHealthInterval(-time.Second))
+	if got := h.snapshot().ProbeIntervalMS; got != 0 {
+		t.Errorf("ProbeIntervalMS=%d, want 0", got)
+	}
+}
+
+func TestWithHealthErrorHandler_NilIgnored(t *testing.T) {
+	// Should not panic, should not crash the constructor.
+	h := NewHealthMonitor("http://x", healthNoopTransport{},
+		WithHealthErrorHandler(nil))
+	if h.onError != nil {
+		t.Errorf("nil error handler should not be set")
+	}
+}
+
+func TestWithHealthClock_NilIgnored(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{},
+		WithHealthClock(nil))
+	if h.now == nil {
+		t.Error("nil clock should not unset the default")
+	}
+}
+
+func TestWithHealthProbePath_EmptyIgnored(t *testing.T) {
+	h := NewHealthMonitor("http://x", healthNoopTransport{},
+		WithHealthProbePath(""))
+	if h.probePath != defaultProbePath {
+		t.Errorf("probePath=%q, want %q", h.probePath, defaultProbePath)
+	}
+}
+
+// fakeClock is a controllable clock for tests.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}

--- a/proxy.go
+++ b/proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 // Proxy is an http.RoundTripper that forwards requests to a real backend,
@@ -25,14 +26,29 @@ import (
 //
 // Proxy is safe for concurrent use by multiple goroutines.
 type Proxy struct {
-	transport  http.RoundTripper                   // real backend transport
-	l1         Store                               // raw/ephemeral (typically *MemoryStore)
-	l2         Store                               // sanitized/persistent (typically *FileStore)
-	sanitizer  Sanitizer                           // applied to L2 writes only
-	matcher    Matcher                             // for fallback lookups
-	route      string                              // logical route label
-	onError    func(error)                         // error callback
+	transport  http.RoundTripper                         // real backend transport
+	l1         Store                                     // raw/ephemeral (typically *MemoryStore)
+	l2         Store                                     // sanitized/persistent (typically *FileStore)
+	sanitizer  Sanitizer                                 // applied to L2 writes only
+	matcher    Matcher                                   // for fallback lookups
+	route      string                                    // logical route label
+	onError    func(error)                               // error callback
 	isFallback func(err error, resp *http.Response) bool // determines when to fall back
+
+	// health is the optional HealthMonitor enabled via WithProxyHealthEndpoint.
+	// nil when the option is absent — every call site is nil-receiver-safe so
+	// the default behavior is byte-for-byte identical to a Proxy without the
+	// health surface.
+	health *HealthMonitor
+
+	// healthEnabled tracks whether WithProxyHealthEndpoint was set so the
+	// other health-related options can apply (or noop) deterministically.
+	healthEnabled   bool
+	healthOpts      []HealthMonitorOption
+	probeInterval   time.Duration
+	probePath       string
+	healthErrorFunc func(error)
+	upstreamURLHint string
 }
 
 // ProxyOption configures a Proxy.
@@ -118,6 +134,75 @@ func WithProxyTLSConfig(cfg *tls.Config) ProxyOption {
 	}
 }
 
+// WithProxyHealthEndpoint enables the technical health surface on this Proxy.
+// When set, Proxy.HealthHandler() returns a non-nil http.Handler that serves
+// GET /__httptape/health (JSON snapshot) and GET /__httptape/health/stream
+// (text/event-stream).
+//
+// The active probe loop (if configured via WithProxyProbeInterval) is started
+// the first time Proxy.Start is called — never at construction time, so
+// embedders that build a Proxy without ever serving HTTP do not leak
+// goroutines.
+//
+// With this option absent, Proxy.HealthHandler() returns nil and the request
+// path takes a no-op branch when recording state — preserving byte-for-byte
+// default behavior.
+//
+// opts may inject a clock, an error handler, or other HealthMonitor knobs.
+func WithProxyHealthEndpoint(opts ...HealthMonitorOption) ProxyOption {
+	return func(p *Proxy) {
+		p.healthEnabled = true
+		p.healthOpts = append(p.healthOpts, opts...)
+	}
+}
+
+// WithProxyProbeInterval sets the active probe cadence. Zero disables the
+// probe loop (the request path still updates state, but no synthetic probe
+// runs). When WithProxyHealthEndpoint is set and this option is absent, the
+// default is 2s.
+//
+// This option is a no-op unless WithProxyHealthEndpoint is also set.
+func WithProxyProbeInterval(d time.Duration) ProxyOption {
+	return func(p *Proxy) {
+		if d < 0 {
+			d = 0
+		}
+		p.probeInterval = d
+	}
+}
+
+// WithProxyProbePath sets the URL path the active probe targets on the
+// upstream (default "/"). No-op unless WithProxyHealthEndpoint is also set.
+func WithProxyProbePath(path string) ProxyOption {
+	return func(p *Proxy) {
+		if path != "" {
+			p.probePath = path
+		}
+	}
+}
+
+// WithProxyHealthErrorHandler sets a callback for non-fatal errors inside the
+// health surface (probe transport errors, SSE write errors). Defaults to the
+// existing onError callback set by WithProxyOnError; if neither is set,
+// errors are swallowed. No-op unless WithProxyHealthEndpoint is also set.
+func WithProxyHealthErrorHandler(fn func(error)) ProxyOption {
+	return func(p *Proxy) {
+		p.healthErrorFunc = fn
+	}
+}
+
+// WithProxyUpstreamURL sets the upstream URL reported in the health snapshot
+// and used as the base URL for the active probe. The CLI passes this
+// automatically; library users embedding Proxy with the health surface
+// must set it explicitly.
+//
+// No-op unless WithProxyHealthEndpoint is also set.
+func WithProxyUpstreamURL(url string) ProxyOption {
+	return func(p *Proxy) {
+		p.upstreamURLHint = url
+	}
+}
+
 // NewProxy creates a new Proxy with the given L1 (ephemeral) and L2 (persistent)
 // stores.
 //
@@ -153,7 +238,82 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) *Proxy {
 		opt(p)
 	}
 
+	if p.healthEnabled {
+		// Default the upstream URL to "" when the embedder didn't provide one.
+		// HealthMonitor's constructor guard panics on empty upstream — give a
+		// clearer message here pointing at the right option.
+		if p.upstreamURLHint == "" {
+			panic("httptape: WithProxyHealthEndpoint requires WithProxyUpstreamURL")
+		}
+
+		// Resolve the error handler precedence: explicit health handler beats
+		// the proxy-wide onError, which beats nothing.
+		var errFn func(error)
+		switch {
+		case p.healthErrorFunc != nil:
+			errFn = p.healthErrorFunc
+		case p.onError != nil:
+			errFn = p.onError
+		}
+
+		// Default probe cadence: 2s when the option is unset.
+		interval := p.probeInterval
+		if interval == 0 {
+			interval = defaultProbeInterval
+		}
+
+		hOpts := []HealthMonitorOption{
+			WithHealthInterval(interval),
+		}
+		if p.probePath != "" {
+			hOpts = append(hOpts, WithHealthProbePath(p.probePath))
+		}
+		if errFn != nil {
+			hOpts = append(hOpts, WithHealthErrorHandler(errFn))
+		}
+		// Caller-supplied options come last so they can override the defaults.
+		hOpts = append(hOpts, p.healthOpts...)
+
+		p.health = NewHealthMonitor(p.upstreamURLHint, p, hOpts...)
+	}
+
 	return p
+}
+
+// HealthHandler returns the http.Handler that serves /__httptape/health and
+// /__httptape/health/stream. Returns nil when WithProxyHealthEndpoint was not
+// set — callers should mount the handler conditionally.
+//
+// The handler routes only the two health paths; any other path returns 404.
+// Callers compose it into their own mux.
+func (p *Proxy) HealthHandler() http.Handler {
+	if p.health == nil {
+		return nil
+	}
+	return p.health
+}
+
+// Start initializes background workers (currently: the active probe loop).
+// Safe to call zero or more times; subsequent calls are no-ops. Must be
+// called before serving HTTP if WithProxyHealthEndpoint and a non-zero probe
+// interval are set, otherwise the probe loop never runs.
+//
+// The CLI wires Start() into the proxy command's startup. Library users
+// embedding the Proxy choose when (and whether) to call it.
+func (p *Proxy) Start() {
+	p.health.start()
+}
+
+// Close stops background workers and closes all open SSE subscribers. Safe
+// to call zero or more times; idempotent. Returns when all goroutines spawned
+// by the Proxy have exited.
+//
+// Close does NOT close the L1/L2 stores — they are owned by the caller.
+func (p *Proxy) Close() error {
+	if p.health == nil {
+		return nil
+	}
+	return p.health.Close()
 }
 
 // RoundTrip executes the HTTP request via the inner transport. On success,
@@ -251,7 +411,10 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 		p.onErrorSafe(saveErr)
 	}
 
-	// 9. Return real response (with body restored).
+	// 9. Update health state (no-op when health surface disabled).
+	p.health.observe(StateLive)
+
+	// 10. Return real response (with body restored).
 	return resp, nil
 }
 
@@ -304,7 +467,8 @@ func (p *Proxy) matchFromStore(ctx context.Context, req *http.Request, store Sto
 
 // tapeToResponse synthesizes an *http.Response from a cached Tape.
 // The source parameter is set as the X-Httptape-Source header to indicate
-// where the response came from ("l1-cache" or "l2-cache").
+// where the response came from ("l1-cache" or "l2-cache"). The same value
+// drives the health-monitor state machine.
 func (p *Proxy) tapeToResponse(tape Tape, source string) *http.Response {
 	header := make(http.Header)
 	if tape.Response.Headers != nil {
@@ -319,6 +483,10 @@ func (p *Proxy) tapeToResponse(tape Tape, source string) *http.Response {
 	if body == nil {
 		body = []byte{}
 	}
+
+	// Update the health state machine (no-op when the health surface is
+	// disabled). A nil-receiver call here keeps the default-off path free.
+	p.health.observe(SourceState(source))
 
 	return &http.Response{
 		StatusCode: tape.Response.StatusCode,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,14 +1,20 @@
 package httptape
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // roundTripperFunc adapts a function to http.RoundTripper for testing.
@@ -568,5 +574,322 @@ func TestProxy_WithProxyRoute(t *testing.T) {
 	}
 	if l2Tapes[0].Route != "users-api" {
 		t.Errorf("L2 tape route=%q, want %q", l2Tapes[0].Route, "users-api")
+	}
+}
+
+// TestProxy_HealthDisabledByDefault is the backward-compat regression test
+// required by ADR-28: with the new health options absent, the proxy must
+// expose no health surface, spawn no goroutines on Start(), and behave
+// byte-for-byte as before.
+func TestProxy_HealthDisabledByDefault(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	baseline := runtime.NumGoroutine()
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(successTransport(200, "ok")),
+	)
+
+	if h := proxy.HealthHandler(); h != nil {
+		t.Fatalf("HealthHandler() = %v, want nil with default options", h)
+	}
+
+	// Start must be a no-op when no health monitor exists.
+	proxy.Start()
+	proxy.Start() // idempotent
+	time.Sleep(50 * time.Millisecond)
+	if got := runtime.NumGoroutine(); got > baseline+1 {
+		// Allow +1 for runtime jitter; we expect zero goroutines from Start().
+		t.Errorf("Start() spawned goroutines: baseline=%d, got=%d", baseline, got)
+	}
+
+	// A normal RoundTrip continues to behave exactly as before — no new
+	// headers, no panic on the nil-receiver observe call.
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	if src := resp.Header.Get("X-Httptape-Source"); src != "" {
+		t.Errorf("default-off proxy added X-Httptape-Source=%q on success", src)
+	}
+
+	if err := proxy.Close(); err != nil {
+		t.Errorf("Close on default proxy: %v", err)
+	}
+}
+
+// TestProxy_HealthHeaderUnchanged confirms X-Httptape-Source is still emitted
+// on cache fallbacks when the health endpoint is enabled.
+func TestProxy_HealthHeaderUnchanged(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	tape := NewTape("", RecordedReq{
+		Method: "GET", URL: "http://example.com/x", Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200, Headers: http.Header{}, Body: []byte("cached"),
+	})
+	l1.Save(context.Background(), tape) //nolint:errcheck
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("down"))),
+		WithProxyUpstreamURL("http://example.com"),
+		WithProxyHealthEndpoint(),
+		WithProxyProbeInterval(0), // no probe loop in this test
+	)
+	defer proxy.Close() //nolint:errcheck
+
+	req, _ := http.NewRequest("GET", "http://example.com/x", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	if src := resp.Header.Get("X-Httptape-Source"); src != "l1-cache" {
+		t.Errorf("X-Httptape-Source=%q, want l1-cache", src)
+	}
+}
+
+func TestProxy_HealthEndpointMounted(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(successTransport(200, "ok")),
+		WithProxyUpstreamURL("http://upstream.example"),
+		WithProxyHealthEndpoint(),
+		WithProxyProbeInterval(0),
+	)
+	defer proxy.Close() //nolint:errcheck
+
+	if proxy.HealthHandler() == nil {
+		t.Fatal("HealthHandler() is nil with WithProxyHealthEndpoint set")
+	}
+
+	srv := httptest.NewServer(proxy.HealthHandler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/__httptape/health")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status=%d, want 200", resp.StatusCode)
+	}
+	var snap HealthSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snap.UpstreamURL != "http://upstream.example" {
+		t.Errorf("UpstreamURL=%q", snap.UpstreamURL)
+	}
+}
+
+func TestProxy_StartCloseIdempotent(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(successTransport(200, "ok")),
+		WithProxyUpstreamURL("http://up"),
+		WithProxyHealthEndpoint(),
+		WithProxyProbeInterval(20*time.Millisecond),
+	)
+
+	baseline := runtime.NumGoroutine()
+	proxy.Start()
+	proxy.Start()
+	proxy.Start()
+
+	time.Sleep(80 * time.Millisecond)
+
+	if err := proxy.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	if err := proxy.Close(); err != nil {
+		t.Errorf("Close (second): %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Errorf("goroutine leak: baseline=%d, got=%d", baseline, runtime.NumGoroutine())
+}
+
+// TestProxy_HealthOptionsApplied verifies the additional health-related
+// proxy options (path, error handler) are wired into the resulting monitor.
+func TestProxy_HealthOptionsApplied(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	var captured atomic.Int32
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("boom"))),
+		WithProxyUpstreamURL("http://up"),
+		WithProxyHealthEndpoint(),
+		WithProxyProbeInterval(15*time.Millisecond),
+		WithProxyProbePath("/healthz"),
+		WithProxyHealthErrorHandler(func(error) { captured.Add(1) }),
+	)
+	defer proxy.Close() //nolint:errcheck
+
+	if proxy.health == nil || proxy.health.probePath != "/healthz" {
+		t.Errorf("probePath not propagated: %+v", proxy.health)
+	}
+
+	proxy.Start()
+	deadline := time.After(2 * time.Second)
+	for captured.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("custom error handler not invoked")
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+// TestProxy_HealthErrorHandlerFallsBackToOnError checks the precedence: a
+// proxy with WithProxyOnError but no explicit health error handler routes
+// probe errors through the existing onError callback.
+func TestProxy_HealthErrorHandlerFallsBackToOnError(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	var captured atomic.Int32
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("boom"))),
+		WithProxyUpstreamURL("http://up"),
+		WithProxyOnError(func(error) { captured.Add(1) }),
+		WithProxyHealthEndpoint(),
+		WithProxyProbeInterval(15*time.Millisecond),
+	)
+	defer proxy.Close() //nolint:errcheck
+
+	proxy.Start()
+	deadline := time.After(2 * time.Second)
+	for captured.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("onError fallback not invoked")
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+// TestProxy_HealthPanicsWithoutUpstreamURL confirms the constructor guard
+// fires when WithProxyHealthEndpoint is set without WithProxyUpstreamURL.
+func TestProxy_HealthPanicsWithoutUpstreamURL(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when health endpoint enabled without upstream URL")
+		}
+	}()
+	NewProxy(NewMemoryStore(), NewMemoryStore(),
+		WithProxyHealthEndpoint(),
+	)
+}
+
+// TestProxy_HealthIntegration exercises the full path: a transport whose
+// behaviour flips between healthy and broken; the probe drives the state
+// transitions; an SSE subscriber receives the live -> l1-cache -> live
+// sequence without any client-driven request.
+func TestProxy_HealthIntegration(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	// Pre-populate L1 with a tape matching the probe (HEAD /). The broken
+	// phase's probe will fall back to this entry, driving observe(l1-cache).
+	tape := NewTape("", RecordedReq{
+		Method:  "HEAD",
+		URL:     "http://upstream.example/",
+		Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/plain"}},
+		Body:       []byte(""),
+	})
+	l1.Save(context.Background(), tape) //nolint:errcheck
+
+	var broken atomic.Bool
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if broken.Load() {
+			return nil, errors.New("upstream down")
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(transport),
+		WithProxyUpstreamURL("http://upstream.example"),
+		WithProxyHealthEndpoint(),
+		WithProxyProbeInterval(20*time.Millisecond),
+	)
+	defer proxy.Close() //nolint:errcheck
+
+	srv := httptest.NewServer(proxy.HealthHandler())
+	defer srv.Close()
+
+	proxy.Start()
+
+	// Subscribe via SSE.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+"/__httptape/health/stream", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer resp.Body.Close()
+
+	br := bufio.NewReader(resp.Body)
+
+	// Drain initial seed.
+	if _, err := readSSEEvent(br, 2*time.Second); err != nil {
+		t.Fatalf("initial event: %v", err)
+	}
+
+	// Break the upstream; probe will fail, fallback hits L1, observe
+	// transitions to l1-cache.
+	broken.Store(true)
+	payload, err := readSSEEvent(br, 3*time.Second)
+	if err != nil {
+		t.Fatalf("expected l1-cache event: %v", err)
+	}
+	var snap HealthSnapshot
+	if err := json.Unmarshal([]byte(payload), &snap); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if snap.State != StateL1Cache {
+		t.Fatalf("expected l1-cache, got %q", snap.State)
+	}
+
+	// Restore the upstream; the next probe sees live, transition fires.
+	broken.Store(false)
+	payload, err = readSSEEvent(br, 3*time.Second)
+	if err != nil {
+		t.Fatalf("expected live recovery event: %v", err)
+	}
+	if err := json.Unmarshal([]byte(payload), &snap); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if snap.State != StateLive {
+		t.Fatalf("expected live, got %q", snap.State)
 	}
 }


### PR DESCRIPTION
Closes #121

## Summary

Adds an opt-in technical surface to proxy mode for real-time observation of the
"most-recently-served source" state machine:

- `GET /__httptape/health` — JSON snapshot.
- `GET /__httptape/health/stream` — `text/event-stream` (initial-on-connect + one event per state transition).
- Optional active probe (`HEAD /` with sticky `GET /` promotion on 405/501) that goes through `Proxy.RoundTrip` so it feeds the same state machine real client traffic does.

State values (`live`, `l1-cache`, `l2-cache`) mirror the existing `X-Httptape-Source` response header semantics. The header itself is preserved unchanged.

CLI flags: `--health-endpoint`, `--upstream-probe-interval` (defaults to 2s when the endpoint is enabled and the interval is unset). Library API: `WithProxyHealthEndpoint`, `WithProxyProbeInterval`, `WithProxyProbePath`, `WithProxyHealthErrorHandler`, `WithProxyUpstreamURL` plus `Proxy.HealthHandler`, `Proxy.Start`, `Proxy.Close`.

### Backward compatibility (locked)

With both flags absent / both options unset:

- `Proxy.HealthHandler()` returns `nil`.
- `Proxy.Start()` and `Proxy.Close()` are no-ops.
- The request path adds a single nil-receiver method call (`p.health.observe(...)`) which the compiler typically inlines away.
- No new headers, no new goroutines, no behavior change. Locked by `TestProxy_HealthDisabledByDefault` and the existing proxy tests.

### Concurrency model (per ADR-28)

- Single `sync.Mutex` guards `(state, since, lastProbed, subscribers)`.
- Per-subscriber bounded channel (size 8); on overflow the broadcaster drops and disconnects the subscriber, the SSE handler returns, and `EventSource` reconnects with a fresh initial seed.
- Probe loop derived from a `done` channel; `Close` cancels in-flight probe RoundTrips immediately and waits for the goroutine.
- All tests pass under `go test -race`.

## Sample output

`GET /__httptape/health`:
```
{"state":"live","upstream_url":"http://127.0.0.1:19999","last_probed_at":"2026-04-16T16:59:59.781417Z","probe_interval_ms":500,"since":"2026-04-16T16:59:58.773999Z"}
```

`GET /__httptape/health/stream`:
```
retry: 2000

data: {"state":"live","upstream_url":"http://127.0.0.1:19999","last_probed_at":"2026-04-16T16:59:59.781417Z","probe_interval_ms":500,"since":"2026-04-16T16:59:58.773999Z"}

```

## Test plan

- [x] `go test ./... -race` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [x] Backward-compat regression (`TestProxy_HealthDisabledByDefault`): default-off proxy exposes no health routes, starts no goroutines, emits no new headers.
- [x] `X-Httptape-Source` still emitted on cache fallback when health endpoint is enabled (`TestProxy_HealthHeaderUnchanged`).
- [x] Integration: probe drives live -> l1-cache -> live transitions; SSE subscriber receives both events without any client request between transitions (`TestProxy_HealthIntegration`).
- [x] Slow subscriber dropped after buffer overflow (`TestHealthMonitor_SlowSubscriberDropped`).
- [x] 100 concurrent subscribers each receive transition events (`TestHealthMonitor_BroadcastFanOut`).
- [x] Graceful shutdown closes SSE streams (`TestHealthMonitor_HTTPStreamGracefulShutdown`).
- [x] Probe loop exits on Close, no goroutine leaks (`TestHealthMonitor_CloseStopsProbe`, `TestProxy_StartCloseIdempotent`).
- [x] HEAD->GET sticky promotion on 405 (`TestHealthMonitor_ProbeHEADtoGETPromotion`).
- [x] CLI flags (`TestProxyHelpExposesHealthFlags`, `TestProxyUpstreamProbeIntervalRequiresHealthEndpoint`, `TestProxyHealthEndpointMounted`).
- [x] Coverage on `health.go` averages well above 90% (most functions 100%).

## Files

- `health.go`, `health_test.go` (new)
- `proxy.go`, `proxy_test.go`, `cmd/httptape/main.go`, `cmd/httptape/main_test.go`, `doc.go`, `README.md`, `decisions.md` (modified — `decisions.md` carries ADR-28)