### PR TITLE
chore: enrich Docker Hub & GHCR registry pages — OCI labels, README sync, README rebalance (#122)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,5 +68,18 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Update Docker Hub description
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: tibtof/httptape
+          short-description: "HTTP traffic recording, redaction, and replay — embeddable Go library, CLI, and 6 MB Docker image."
+          readme-filepath: ./README.md
+          enable-url-completion: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # --- Final stage ---
 FROM scratch
 
+# Build-arg (overridden by CI on tag pushes; defaults to "dev" for local
+# builds and non-tag CI runs).
+ARG VERSION=dev
+
 # Import CA certs so record mode can dial HTTPS upstreams.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
@@ -31,5 +35,18 @@ VOLUME ["/fixtures", "/config"]
 EXPOSE 8081
 
 USER 65534
+
+# OCI image labels. See https://github.com/opencontainers/image-spec/blob/main/annotations.md
+# Note: docker/metadata-action@v5 in CI also emits labels; for overlapping
+# keys, the metadata-action value overrides on the published image. These
+# Dockerfile labels are the floor that guarantees metadata exists on local
+# `docker build .` and on downstream re-builds.
+LABEL org.opencontainers.image.title="httptape" \
+      org.opencontainers.image.description="HTTP traffic recording, redaction, and replay — embeddable Go library, CLI, and 6 MB Docker image." \
+      org.opencontainers.image.source="https://github.com/VibeWarden/httptape" \
+      org.opencontainers.image.url="https://github.com/VibeWarden/httptape" \
+      org.opencontainers.image.documentation="https://vibewarden.dev/docs/httptape/" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${VERSION}"
 
 ENTRYPOINT ["httptape"]

--- a/README.md
+++ b/README.md
@@ -247,6 +247,17 @@ httptape import  --fixtures ./mocks --input bundle.tar.gz
 
 ## Docker
 
+Pull from either registry — the same image is published to both on every
+release:
+
+```bash
+docker pull tibtof/httptape           # Docker Hub
+docker pull ghcr.io/vibewarden/httptape   # GHCR
+```
+
+Examples below use `tibtof/httptape`; substitute `ghcr.io/vibewarden/httptape`
+freely.
+
 ```bash
 # Replay mode
 docker run -v ./mocks:/fixtures -p 8081:8081 tibtof/httptape serve --fixtures /fixtures
@@ -261,8 +272,6 @@ docker run -v ./cache:/fixtures -v ./config.json:/config/config.json -p 8081:808
     tibtof/httptape proxy --upstream https://api.example.com \
     --fixtures /fixtures --config /config/config.json
 ```
-
-Also available on GHCR: `ghcr.io/vibewarden/httptape`
 
 ## Testcontainers
 


### PR DESCRIPTION
Closes #122. Implements ADR-30 in `decisions.md`.

## Summary

Three logical commits, single PR — pure docs/CI change, zero Go code touched:

1. **`Dockerfile`** — adds `ARG VERSION=dev` and a single consolidated `LABEL` block in the final stage declaring 7 `org.opencontainers.image.*` keys (`title`, `description`, `source`, `url`, `documentation`, `licenses`, `version`). These are the floor for local/downstream builds; `docker/metadata-action@v5` overrides overlapping keys on CI-published images with richer values (plus emits `revision` and `created`).
2. **`.github/workflows/docker.yml`** — two surgical edits:
   - `build-args: VERSION=<tag-or-dev>` on the existing `Build and push` step so the Dockerfile-baked `version` label resolves to the semver tag on tag pushes.
   - New `Update Docker Hub description` step using `peter-evans/dockerhub-description@v5`, gated on `startsWith(github.ref, 'refs/tags/v')`, syncing `README.md` as the long description and a fixed 98-char tagline as the short description.
3. **`README.md`** — rebalances the `## Docker` section so GHCR has equal billing at the top of the section (two-line `docker pull` block + one-line orientation note). Runnable `docker run` examples stay on `tibtof/httptape` to match the rest of the docs surface; the docs-wide image-name rebalance is owned by #128.

## Pre-flight verification

- **`https://vibewarden.dev/docs/httptape/`** → returns **200** (verified via `curl -I`); safe to use as the `org.opencontainers.image.documentation` label value.
- **Local Dockerfile build (default)** → `docker build -t httptape:label-check .` succeeds; `docker inspect ... --format '{{json .Config.Labels}}'` shows all 7 `org.opencontainers.image.*` keys populated, `version=dev`.
- **Local Dockerfile build (build-arg)** → `docker build --build-arg VERSION=v0.9.0-rc1 -t httptape:label-check-v .` succeeds; `org.opencontainers.image.version=v0.9.0-rc1` confirmed via `docker inspect`.
- **Workflow YAML lint** → `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker.yml'))"` → OK. All other workflow files (`docs.yml`, `release.yml`, `scorecard.yml`, `test.yml`) also lint clean.
- **Tagline length** → `printf '%s' "<tagline>" | wc -m` → **98 characters** (well under Docker Hub's 100-char short-description limit).
- **Go build / vet / test** → `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all clean (no Go code modified, but verified as a no-regression check). The new `test.yml` workflow gate will exercise the same on PR.

## Verify-step the maintainer must run before tagging v0.9.0

ADR-30 calls out a pre-merge token-scope verification. I cannot inspect the Docker Hub PAT scope from this environment — that's a Hub-UI / user-managed action. **Please verify before merging or before cutting v0.9.0:**

1. Visit Docker Hub → Account Settings → Personal Access Tokens.
2. Find the token wired into `DOCKERHUB_TOKEN` (created `2026-04-02T19:20:16Z` per `gh secret list`).
3. Required scope: **`Repository: Read, Write, Delete`** (or whatever Hub's current label is for "edit repository description"). The newer-style scopes that include "Public Repo Read, Read & Write" with description-edit permission also work.
4. **`Read & Write` (push-only) is insufficient** — the action calls `PATCH /v2/repositories/{namespace}/{repository}/` and will fail silently (step exits 0 in some action versions) if scope is too narrow.
5. If insufficient: rotate the token to the wider scope, update the `DOCKERHUB_TOKEN` secret in repo settings, then merge. If sufficient: merge as-is.

The silent-failure mode if not caught: the v0.9.0 release push runs the workflow, the `Update Docker Hub description` step exits green, but <https://hub.docker.com/r/tibtof/httptape> still shows "No overview available". Pre-flight verification avoids this round trip.

## Reviewer notes

- **No immediate visible change on Docker Hub** after merging this PR. The `Update Docker Hub description` step is gated on tag pushes only, so the Hub overview page will not update until the next `v*` tag (intended: **v0.9.0**) is cut.
- **GHCR auto-link verification is post-release**. Acceptance criterion 4 requires a manual check after v0.9.0 ships that the GHCR package page shows a Source link back to `VibeWarden/httptape` and renders the README. The 8-step protocol is in ADR-30 and will be performed by the reviewer/PM after the tag.
- **Pre-merge timing matters.** This PR must merge before v0.9.0 is tagged so the v0.9.0 image carries the labels and the Hub README sync fires on the v0.9.0 push. If we ship v0.9.0 without it, the user-visible benefits slip to v0.9.1+.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -race -count=1` clean
- [x] `docker build .` produces image with all 7 OCI labels populated
- [x] `docker build --build-arg VERSION=...` overrides the `version` label
- [x] `docker.yml` parses as valid YAML
- [x] All other workflow YAML files still parse
- [x] `https://vibewarden.dev/docs/httptape/` returns 200
- [x] Tagline ≤ 100 characters
- [ ] Maintainer verifies `DOCKERHUB_TOKEN` scope per protocol above
- [ ] Post-v0.9.0: 8-step verification of Hub overview, GHCR Source link, GHCR README render, per-arch label set (out-of-scope for this PR; tracked on #122 until the verifier comments)