### PR TITLE
docs: fix Docker Hub README rendering — absolute logo URL + correct image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/logo.png" alt="httptape logo" width="300">
+  <img src="https://raw.githubusercontent.com/VibeWarden/httptape/main/assets/logo.png" alt="httptape logo" width="300">
 </p>
 
 <h3 align="center">Record, Redact, Replay</h3>
@@ -20,7 +20,7 @@
 ---
 
 httptape captures HTTP request/response pairs, redacts sensitive data on write,
-and replays them as a mock server. Think WireMock, but with a 6 MB Docker image,
+and replays them as a mock server. Think WireMock, but with a 3 MB Docker image,
 an embeddable Go library, and a redaction pipeline built into the core.
 
 **The 3 Rs:**
@@ -102,7 +102,7 @@ go get github.com/VibeWarden/httptape
 go install github.com/VibeWarden/httptape/cmd/httptape@latest
 ```
 
-**Docker** (6 MB, multi-arch):
+**Docker** (~3 MB, multi-arch):
 ```bash
 docker pull tibtof/httptape
 ```
@@ -293,7 +293,7 @@ resp, _ := http.Get(container.BaseURL() + "/api/users")
 |---|---|---|---|---|---|
 | Embeddable in Go | **yes** | no (Java) | no (Node) | no (browser) | yes |
 | Standalone server | **yes** | yes | yes | no | no |
-| Docker | **6 MB** | 200 MB+ | 50 MB+ | n/a | n/a |
+| Docker | **3 MB** | 200 MB+ | 50 MB+ | n/a | n/a |
 | Recording | **yes** | yes | no | no | no |
 | Redaction on write | **yes** | no | no | no | no |
 | Deterministic faking | **yes** | no | no | no | no |


### PR DESCRIPTION
## Summary

Two related fixes that affect what the README looks like when rendered on the Docker Hub repository overview (synced via `peter-evans/dockerhub-description` on every tag push, landed in #122).

### 1. Absolute logo URL

The `<img src="assets/logo.png">` was a relative path — works on github.com, breaks on hub.docker.com. The action's `enable-url-completion: true` only handles Markdown image syntax, not raw HTML img tags. Switched to absolute `raw.githubusercontent.com/.../main/assets/logo.png` — works everywhere.

### 2. Image size accuracy

README claimed "6 MB Docker image" in three places. Actual published v0.9.0 image per Docker Hub: **3.1 MiB**. Updated to "3 MB" / "~3 MB". Even better story vs WireMock's 200 MB+ and json-server's 50 MB+.

## Effect

- Docker Hub overview won't pick this up until the **next** tag push (v0.9.1+) or a manual sync via the Hub UI.
- The image at `:0.9.0` itself is unaffected — only the rendered description page.

## Out of scope

- Other docs (`docs/docker.md`, `llms.txt`, `llms-full.txt`) still have outdated size references — tracked in #128 (docs drift cleanup).

## Test plan

- [x] No code touched
- [x] README renders correctly on github.com (relative URL behavior preserved for the image since absolute URLs work the same way)