### PR TITLE
chore: add Dependabot config and per-example CI smoke tests (#136)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,142 @@
+# .github/dependabot.yml
+#
+# Dependabot v2 configuration for httptape.
+#
+# Scope:
+#   - Library Go modules (root + testcontainers subpackage).
+#   - GitHub Actions used by repo workflows.
+#   - Docker base images (root Dockerfile + per-example Dockerfiles).
+#   - npm dependencies in JS/TS examples.
+#
+# Grouping policy:
+#   - Minor + patch updates per ecosystem are batched into a single PR
+#     (`minor-and-patch` group) to keep PR volume manageable.
+#   - Major updates ship as individual PRs so each can be reviewed in
+#     isolation (likely-breaking changes).
+#
+# Cadence:
+#   - Weekly on Mondays at 09:00 UTC (UK/EU morning, before US-Pacific
+#     business hours start) — matches the spec in #136.
+#
+# Labels:
+#   - All PRs get `dependencies` plus an ecosystem tag (`go` / `npm` /
+#     `docker` / `github-actions`) so they can be filtered cleanly.
+#
+# When adding a new example under examples/<name>/:
+#   - Add an `npm` block (if it has package.json) and a `docker` block
+#     (if it has a Dockerfile) following the ts-frontend-first pattern
+#     below.
+
+version: 2
+updates:
+  # ----- Library: root Go module (stdlib-only by design; covers tooling) -----
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "go"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ----- Testcontainers subpackage (third-party deps by design) -----
+  - package-ecosystem: "gomod"
+    directory: "/testcontainers"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "go"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ----- CI Actions (workflows under .github/workflows) -----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ----- Root Dockerfile base images -----
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "docker"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ----- Example: ts-frontend-first (npm) -----
+  - package-ecosystem: "npm"
+    directory: "/examples/ts-frontend-first"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ----- Example: ts-frontend-first (Dockerfile, node:20-alpine) -----
+  - package-ecosystem: "docker"
+    directory: "/examples/ts-frontend-first"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "docker"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,77 @@
+# .github/workflows/examples.yml
+#
+# Per-example smoke build for examples/<name>/.
+#
+# Lives in its own workflow (separate from `test.yml`) so that an
+# example breakage does not turn the library "Tests" badge red. Each
+# example is a matrix entry; `fail-fast: false` keeps one broken
+# example from short-circuiting the others.
+#
+# Path filter restricts triggers to changes under examples/** or this
+# workflow file itself. Library-only changes do not run this workflow.
+#
+# Adding a new example:
+#   1. Add an entry to the `matrix.example` list. Required keys:
+#        name              - human-readable check label
+#        path              - directory under examples/
+#        node-version      - Node.js major to install
+#        lockfile          - relative path to the npm lockfile
+#                            (used by setup-node cache)
+#        build-command     - shell command run inside `path`
+#   2. Add matching dependabot.yml blocks for the example's ecosystems
+#      (see .github/dependabot.yml for the pattern).
+#   3. Append a row to examples/README.md.
+
+name: Examples
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - ".github/workflows/examples.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - ".github/workflows/examples.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: examples-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (${{ matrix.example.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - name: ts-frontend-first
+            path: examples/ts-frontend-first
+            node-version: "20"
+            lockfile: examples/ts-frontend-first/package-lock.json
+            build-command: npm run build
+    defaults:
+      run:
+        working-directory: ${{ matrix.example.path }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.example.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ matrix.example.lockfile }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: ${{ matrix.example.build-command }}

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,3 +13,27 @@ Each subdirectory is a self-contained, runnable example of httptape used in a re
 - Each example owns its own dependencies — Go examples have their own `go.mod` so they don't pollute the library's stdlib-only constraint.
 - `docker-compose.yml`, where present, pins to a published httptape image (`ghcr.io/vibewarden/httptape:<version>`) so examples Just Run on a fresh clone — no local build of httptape required. Bumped per release.
 - Examples are kept opinionated and minimal — they showcase httptape behavior, not framework taste.
+
+## CI smoke tests
+
+Each example is built in CI by [`.github/workflows/examples.yml`](../.github/workflows/examples.yml) on every push/PR that touches `examples/**`. The workflow uses a matrix keyed on example name with `fail-fast: false`, so a broken example never blocks the others, and each example surfaces as its own named check (`build (<example-name>)`).
+
+Note: this is a separate workflow from the library's `Tests` workflow on purpose — an example failure must never blink the library's CI badge.
+
+### Adding a new example to CI
+
+1. Drop the example under `examples/<name>/` and verify `npm ci && npm run build` (or the equivalent) works locally.
+2. Add a row to the `matrix.example` list in `.github/workflows/examples.yml`:
+
+   ```yaml
+   - name: <example-name>
+     path: examples/<example-name>
+     node-version: "20"
+     lockfile: examples/<example-name>/package-lock.json
+     build-command: npm run build
+   ```
+
+3. Add matching `npm` and (if the example has a Dockerfile) `docker` blocks to [`.github/dependabot.yml`](../.github/dependabot.yml), copying the `ts-frontend-first` pattern.
+4. Append a row to the table above.
+
+That's the full recipe — no per-example workflow files, no shared dependency setup. Each example stays self-contained.


### PR DESCRIPTION
Closes #136

## Summary

Establishes a maintenance pattern that keeps `examples/*/` from going stale as the JS/TS/Go ecosystem moves, and that catches drift introduced by library changes (e.g. a renamed option breaking a published example).

Per ADR design (issue body + dev runbook in the architect comment):

- Separate `examples.yml` workflow, **not** an extension of `test.yml`. Example failures must never blink the library `Tests` badge.
- Matrix-keyed on example name with `fail-fast: false` and per-example `name:` interpolation, so each example surfaces as its own GitHub check (`build (<example-name>)`).
- Path filter `examples/**` + the workflow file itself; library-only changes do not trigger this workflow.
- Dependabot grouping policy: `minor-and-patch` grouped per ecosystem (with `applies-to: version-updates`), majors get individual PRs. Weekly cadence, Mondays 09:00 UTC.
- Compose smoke is intentionally deferred to a follow-up issue (three flake vectors: GHCR pull, port races, probe-interval timing).

## Files

**New:**
- `.github/dependabot.yml` — six update blocks: gomod root, gomod testcontainers, github-actions, docker root, npm `examples/ts-frontend-first`, docker `examples/ts-frontend-first`. Labels: `dependencies` + ecosystem tag.
- `.github/workflows/examples.yml` — `Examples` workflow, one matrix job `build` keyed on example name, `fail-fast: false`, `concurrency.cancel-in-progress: true`, path-filtered to `examples/**`.

**Modified:**
- `examples/README.md` — appended `## CI smoke tests` section documenting the matrix recipe for adding the next example.

**Pre-created labels** (for the first round of Dependabot PRs to land cleanly):
- `dependencies`, `go`, `npm`, `docker`, `github-actions`

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"` — passes (6 update blocks).
- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/examples.yml'))\"` — passes.
- [x] `cd examples/ts-frontend-first && npm ci --silent && npm run build` — succeeds locally (vite v8.0.8, builds in ~350ms). Confirms the smoke job will pass on CI.
- [x] `go build ./... && go vet ./...` — clean (no Go files touched, but verified).
- [ ] **Post-merge verification** (cannot be done pre-merge):
  - Check `Insights → Dependency graph → Dependabot` for green parse on all six rows.
  - Validate end-to-end on the first incoming Dependabot PR within 7 days.
  - First push to `main` after merge will trigger `Examples` workflow on whatever changes touch `examples/**`; until then, the workflow is dormant by design.

## Notes for reviewer

- No README badge added (per the architect's hard constraint — the `Tests` badge stays the single CI signal).
- No changes to existing `test.yml`, `release.yml`, `docker.yml`, `docs.yml`, or `scorecard.yml`.
- No new Go-module dependencies; CI Action versions are not Go deps.
- `decisions.md` is intentionally not modified — the architect maintains that file.