### PR TITLE
docs: document the typed Faker surface (#127)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -171,6 +171,38 @@ func (p *Pipeline) Sanitize(t Tape) Tape // implements Sanitizer
 | RedactHeaders | `RedactHeaders(names ...string) SanitizeFunc` |
 | RedactBodyPaths | `RedactBodyPaths(paths ...string) SanitizeFunc` |
 | FakeFields | `FakeFields(seed string, paths ...string) SanitizeFunc` |
+| FakeFieldsWith | `FakeFieldsWith(seed string, fields map[string]Faker) SanitizeFunc` |
+
+### Faker interface
+
+```go
+type Faker interface {
+    Fake(seed string, original any) any
+}
+```
+
+`FakeFieldsWith` wires explicit `Faker` implementations to JSONPath-like paths, in contrast to `FakeFields` which auto-detects the strategy from each value's runtime type.
+
+### Built-in fakers
+
+All twelve are exported struct types and are constructed as struct literals (no `NewXFaker` constructors).
+
+| Type | Construction | Output |
+|---|---|---|
+| `RedactedFaker` | `RedactedFaker{}` | strings -> `"[REDACTED]"`, numbers -> `0`, bools -> `false` |
+| `FixedFaker` | `FixedFaker{Value: any}` | always returns `Value` |
+| `HMACFaker` | `HMACFaker{}` | strings -> `"fake_<hex>"`, numbers -> positive int |
+| `EmailFaker` | `EmailFaker{}` | `"user_<hex>@example.com"` |
+| `PhoneFaker` | `PhoneFaker{}` | digits replaced, format preserved |
+| `CreditCardFaker` | `CreditCardFaker{}` | `XXXX-XXXX-XXXX-XXXX`, prefix preserved, valid Luhn |
+| `NumericFaker` | `NumericFaker{Length: int}` | string of N HMAC-derived digits |
+| `DateFaker` | `DateFaker{Format: string}` | date in Go layout (default `"2006-01-02"`) |
+| `PatternFaker` | `PatternFaker{Pattern: string}` | `#` -> digit, `?` -> letter, others literal |
+| `PrefixFaker` | `PrefixFaker{Prefix: string}` | `"<Prefix><16-hex>"` |
+| `NameFaker` | `NameFaker{}` | `"<First> <Last>"` from internal lists |
+| `AddressFaker` | `AddressFaker{}` | `"<num> <street> <suffix>, <city>, <ST> <zip>"` |
+
+PII-shaped and generic fakers leave non-string inputs unchanged. `RedactedFaker` and `HMACFaker` additionally handle numbers (and `RedactedFaker` handles booleans).
 
 ### Constants and helpers
 
@@ -180,7 +212,7 @@ const Redacted = "[REDACTED]"
 func DefaultSensitiveHeaders() []string
 ```
 
-**Details:** [Redaction](sanitization.md)
+**Details:** [Redaction](sanitization.md#typed-fakers)
 
 ---
 
@@ -302,16 +334,38 @@ type Config struct {
 }
 
 type Rule struct {
-    Action  string   `json:"action"`
-    Headers []string `json:"headers,omitempty"`
-    Paths   []string `json:"paths,omitempty"`
-    Seed    string   `json:"seed,omitempty"`
+    Action  string         `json:"action"`
+    Headers []string       `json:"headers,omitempty"`
+    Paths   []string       `json:"paths,omitempty"`
+    Seed    string         `json:"seed,omitempty"`
+    Fields  map[string]any `json:"fields,omitempty"`
 }
 
 func LoadConfig(r io.Reader) (*Config, error)
 func LoadConfigFile(path string) (*Config, error)
 func (c *Config) Validate() error
 func (c *Config) BuildPipeline() *Pipeline
+```
+
+For `fake` rules, set either `Paths` (for auto-detect, mapping to `FakeFields`) or `Fields` (for typed fakers, mapping to `FakeFieldsWith`) -- the two are mutually exclusive. Each value in `Fields` is either a string shorthand (for example `"email"`) or an object (for example `{"type": "numeric", "length": 3}`). See [Config -> Typed fake fields](config.md#typed-fake-fields) for the full syntax.
+
+Programmatic example:
+
+```go
+cfg := &httptape.Config{
+    Version: "1",
+    Rules: []httptape.Rule{
+        {
+            Action: httptape.ActionFake,
+            Seed:   "my-seed",
+            Fields: map[string]any{
+                "$.user.email": "email",
+                "$.user.cvv":   map[string]any{"type": "numeric", "length": 3},
+            },
+        },
+    },
+}
+pipeline := cfg.BuildPipeline()
 ```
 
 ### Action constants

--- a/docs/config.md
+++ b/docs/config.md
@@ -51,13 +51,81 @@ The `paths` field is required and must be non-empty.
 
 ### fake
 
-Maps to `FakeFields()`. Replaces values with deterministic HMAC-based fakes.
+Replaces values with deterministic HMAC-based fakes. The `seed` field is always required. The faking strategy is selected by which other field you set:
+
+- `paths` -- auto-detects the strategy from each value's runtime type (maps to `FakeFields`).
+- `fields` -- selects an explicit faker per path (maps to `FakeFieldsWith`).
+
+Exactly one of `paths` or `fields` must be set; specifying both is rejected.
+
+#### Auto-detect form (paths)
 
 ```json
 { "action": "fake", "seed": "my-project-seed", "paths": ["$.user.email", "$.user.id", "$.user.name"] }
 ```
 
-Both `seed` and `paths` are required and must be non-empty.
+Auto-detect picks `EmailFaker`-equivalent output for strings containing `@`, UUID-shaped output for UUID strings, a positive integer for numbers, and `"fake_<hex>"` for other strings. See [Redaction](sanitization.md#fakefields) for the full table.
+
+#### Typed fake fields
+
+When you need a specific format -- credit card, fixed-length digits, a sentinel value -- use the `fields` map. Each entry maps a JSONPath-like path to a faker spec.
+
+```json
+{
+  "action": "fake",
+  "seed": "my-project-seed",
+  "fields": {
+    "$.user.email":   "email",
+    "$.user.phone":   "phone",
+    "$.card.number":  "credit_card",
+    "$.card.cvv":     { "type": "numeric", "length": 3 },
+    "$.user.dob":     { "type": "date", "format": "2006-01-02" },
+    "$.order.status": { "type": "fixed", "value": "active" }
+  }
+}
+```
+
+A faker spec is either a **string shorthand** or an **object** with a `type` field.
+
+##### String shorthands
+
+These names construct the corresponding zero-value Faker:
+
+| Shorthand | Faker | Output |
+|---|---|---|
+| `"redacted"` | `RedactedFaker{}` | strings -> `"[REDACTED]"`, numbers -> `0`, bools -> `false` |
+| `"hmac"` | `HMACFaker{}` | strings -> `"fake_<hex>"`, numbers -> positive int |
+| `"email"` | `EmailFaker{}` | `"user_<hex>@example.com"` |
+| `"phone"` | `PhoneFaker{}` | digits replaced, format preserved |
+| `"credit_card"` | `CreditCardFaker{}` | `XXXX-XXXX-XXXX-XXXX`, prefix preserved, valid Luhn |
+| `"name"` | `NameFaker{}` | `"<First> <Last>"` from internal lists |
+| `"address"` | `AddressFaker{}` | `"<num> <street> <suffix>, <city>, <ST> <zip>"` |
+
+A shorthand may also be written in object form (`{ "type": "email" }`) -- handy when an editor's JSON schema completion prefers objects, or when you want to keep all entries visually uniform.
+
+##### Object-form fakers
+
+Five fakers take parameters and must be written as objects:
+
+| `type` | Required fields | Maps to |
+|---|---|---|
+| `"numeric"` | `length` (number > 0) | `NumericFaker{Length: ...}` |
+| `"date"` | (optional) `format` (Go layout string; defaults to `"2006-01-02"`) | `DateFaker{Format: ...}` |
+| `"pattern"` | `pattern` (non-empty string) | `PatternFaker{Pattern: ...}` -- `#` -> digit, `?` -> letter |
+| `"prefix"` | `prefix` (non-empty string) | `PrefixFaker{Prefix: ...}` -> `"<Prefix><16-hex>"` |
+| `"fixed"` | `value` (any JSON value) | `FixedFaker{Value: ...}` -- always returns `value` |
+
+Examples:
+
+```json
+{ "type": "numeric", "length": 16 }
+{ "type": "date", "format": "2006-01-02T15:04:05Z07:00" }
+{ "type": "pattern", "pattern": "###-##-####" }
+{ "type": "prefix", "prefix": "cust_" }
+{ "type": "fixed", "value": true }
+```
+
+See [Redaction -> Typed fakers](sanitization.md#typed-fakers) for output examples and prose descriptions of each faker.
 
 ## Loading config in Go
 
@@ -113,6 +181,14 @@ Validation checks:
 - Fields irrelevant to an action are rejected (e.g., `paths` on `redact_headers`)
 - Unknown JSON fields are rejected
 
+Additional rules for `fake`:
+- `seed` must be present and non-empty.
+- Exactly one of `paths` or `fields` must be set; setting both is rejected, setting neither is rejected.
+- Each key in `fields` must be a valid JSONPath-like path.
+- Each value in `fields` must be either a known string shorthand or an object with a known `type`.
+- Object-form fakers must include their required parameters (`numeric.length`, `pattern.pattern`, `prefix.prefix`, `fixed.value`); `date.format` is optional.
+- Anything else (numbers, arrays, nulls) as a `fields` value is rejected.
+
 ## JSON Schema
 
 A JSON Schema is available at [`config.schema.json`](https://github.com/VibeWarden/httptape/blob/main/config.schema.json) for IDE autocompletion and CI validation.
@@ -159,8 +235,73 @@ Reference it in your config file:
 }
 ```
 
+## Typed-faker examples
+
+### Email shorthand
+
+The simplest typed-faker config: route a single field through `EmailFaker` so it always lands as `user_<hex>@example.com` regardless of what the upstream actually sends.
+
+```json
+{
+  "version": "1",
+  "rules": [
+    {
+      "action": "fake",
+      "seed": "my-project-2024",
+      "fields": {
+        "$.user.email": "email"
+      }
+    }
+  ]
+}
+```
+
+### Numeric object form
+
+Force a fixed-width numeric ID (CVV, OTP, account number) into a deterministic three-digit string. Auto-detect would treat the field as a generic string and produce `"fake_<hex>"`, which would not pass downstream length validation.
+
+```json
+{
+  "version": "1",
+  "rules": [
+    {
+      "action": "fake",
+      "seed": "my-project-2024",
+      "fields": {
+        "$.payment.cvv": { "type": "numeric", "length": 3 }
+      }
+    }
+  ]
+}
+```
+
+### Credit card shorthand
+
+Generate a Luhn-valid card number that preserves the issuer prefix from the original. Combine with `redact_body` to also clear out an unrelated CVV in the same pipeline.
+
+```json
+{
+  "version": "1",
+  "rules": [
+    {
+      "action": "redact_body",
+      "paths": ["$.payment.cvv"]
+    },
+    {
+      "action": "fake",
+      "seed": "my-project-2024",
+      "fields": {
+        "$.payment.card_number": "credit_card"
+      }
+    }
+  ]
+}
+```
+
 ## See also
 
 - [Redaction](sanitization.md) -- programmatic redaction pipeline API
+- [Redaction -> Typed fakers](sanitization.md#typed-fakers) -- prose descriptions of every built-in faker
+- [API Reference -> Faker interface](api-reference.md#faker-interface) -- full Go signatures
 - [CLI](cli.md) -- using config files with the CLI
 - [Docker](docker.md) -- mounting config files into containers

--- a/docs/sanitization.md
+++ b/docs/sanitization.md
@@ -181,6 +181,226 @@ With `FakeFields("my-seed", "$.user.email", "$.user.id", "$.user.name")`:
 
 The key property: if `alice@company.com` appears in another fixture, it will be faked to the same value. This preserves relational consistency across your fixture set.
 
+## Typed fakers
+
+`FakeFields` auto-detects the faking strategy from each value's runtime type. When you need explicit control -- for example, to force a generic-looking string into the credit-card format, or to fake a numeric ID as a fixed-length digit string -- use the typed-faker API.
+
+The contract is the `Faker` interface:
+
+```go
+type Faker interface {
+    Fake(seed string, original any) any
+}
+```
+
+Implementations take an HMAC seed and the original JSON value (already decoded by `encoding/json`, so strings are `string`, numbers are `float64`, booleans are `bool`, nulls are `nil`, objects are `map[string]any`, arrays are `[]any`). They must be deterministic: the same seed and original must always produce the same fake.
+
+Typed fakers are wired into a pipeline with `FakeFieldsWith`, which takes a seed and a path-to-`Faker` map:
+
+```go
+sanitizer := httptape.NewPipeline(
+    httptape.FakeFieldsWith("my-seed", map[string]httptape.Faker{
+        "$.user.email":  httptape.EmailFaker{},
+        "$.user.phone":  httptape.PhoneFaker{},
+        "$.card.number": httptape.CreditCardFaker{},
+        "$.card.cvv":    httptape.NumericFaker{Length: 3},
+    }),
+)
+```
+
+Path syntax is identical to `RedactBodyPaths` and `FakeFields`. Invalid JSON bodies, missing paths, and invalid path strings are silently skipped (no error). All twelve built-in fakers are constructed as struct literals; none has a `NewXFaker` constructor.
+
+### Auto-detect vs. typed -- when to use each
+
+| Use case | API |
+|---|---|
+| Mixed body, you trust the value-type heuristic, want minimum config | `FakeFields(seed, paths...)` |
+| You need a specific format (credit card, fixed-length digits, pattern, prefix) | `FakeFieldsWith(seed, fields)` |
+| You want to fully redact a leaf rather than fake it | `FakeFieldsWith(...)` with `RedactedFaker{}` |
+| You want a constant value at a path regardless of input | `FakeFieldsWith(...)` with `FixedFaker{Value: ...}` |
+| You need a custom format the built-ins do not cover | Implement `Faker` and pass it to `FakeFieldsWith` |
+
+### Built-in fakers -- redaction-style
+
+These fakers replace values without preserving any information from the original. Use them when the original content is sensitive enough that even a deterministic transform of it should not appear in fixtures.
+
+#### RedactedFaker
+
+Replaces strings with `"[REDACTED]"`, numbers with `0`, and booleans with `false`. Other types (nil, objects, arrays) pass through unchanged. Equivalent to the leaf behavior of `RedactBodyPaths`, but addressable through the typed-faker map so you can mix it with other fakers in a single `FakeFieldsWith` call.
+
+```go
+httptape.FakeFieldsWith("seed", map[string]httptape.Faker{
+    "$.password": httptape.RedactedFaker{},
+    "$.email":    httptape.EmailFaker{},
+})
+```
+
+#### FixedFaker
+
+Always returns its `Value` field, ignoring both seed and original. Useful for stamping a known sentinel into a field (e.g., `"status": "active"`) so downstream tests can assert against it.
+
+```go
+httptape.FixedFaker{Value: "active"}
+httptape.FixedFaker{Value: float64(1)}
+httptape.FixedFaker{Value: true}
+```
+
+`Value` is `any`, so the encoded JSON type follows Go's `encoding/json` rules.
+
+### Built-in fakers -- generic deterministic
+
+These fakers produce a deterministic value derived from `HMAC-SHA256(seed, original)`, with no PII shape. Use them when you need consistency across fixtures but do not need the output to look like any particular format.
+
+#### HMACFaker
+
+Mirrors the auto-detect default for generic strings and numbers. Strings become `"fake_<8-hex>"`; numbers become a positive integer in `[1, 2^31-1]`; booleans, nulls, objects, and arrays pass through unchanged.
+
+```go
+httptape.HMACFaker{}
+// "abc"        -> "fake_a1b2c3d4"
+// float64(42)  -> 1734567890
+```
+
+#### NumericFaker
+
+Generates a string of `Length` HMAC-derived digits. Useful for fixed-width numeric IDs (CVVs, OTPs, account numbers) where digit-count matters.
+
+```go
+httptape.NumericFaker{Length: 3}   // CVV
+httptape.NumericFaker{Length: 16}  // account number
+```
+
+If the input is not a string, it is returned unchanged. Output length always equals `Length`, even if `Length` exceeds 32 (the HMAC is re-chained).
+
+#### PatternFaker
+
+Fills a template where `#` becomes a digit, `?` becomes a lowercase letter, and any other character is copied literally.
+
+```go
+httptape.PatternFaker{Pattern: "###-##-####"}     // SSN-shaped
+httptape.PatternFaker{Pattern: "??-#####"}         // 2 letters, dash, 5 digits
+httptape.PatternFaker{Pattern: "ORDER-####-????"} // mixed literal + variable
+```
+
+If the input is not a string, it is returned unchanged.
+
+#### PrefixFaker
+
+Generates `"<Prefix><16-hex>"`. Useful when an upstream issues namespaced identifiers (e.g., `cust_*`, `order_*`) and downstream tests look at the prefix.
+
+```go
+httptape.PrefixFaker{Prefix: "cust_"}   // "cust_a1b2c3d4e5f60718"
+httptape.PrefixFaker{Prefix: "order_"}  // "order_a1b2c3d4e5f60718"
+```
+
+If the input is not a string, it is returned unchanged.
+
+#### DateFaker
+
+Generates a date string formatted with `Format` (Go reference layout; defaults to `"2006-01-02"` when empty). The date is drawn deterministically from a ~100-year window starting at 2000-01-01.
+
+```go
+httptape.DateFaker{}                       // "2042-09-13"
+httptape.DateFaker{Format: "2006-01-02"}   // "2042-09-13"
+httptape.DateFaker{Format: time.RFC3339}   // "2042-09-13T00:00:00Z"
+```
+
+If the input is not a string, it is returned unchanged.
+
+### Built-in fakers -- PII-shaped
+
+These fakers preserve a recognizable shape (so downstream parsers do not break) while replacing the underlying content. They are the right choice for fields whose format matters to consumers (clients that validate emails, payment processors that check Luhn, address forms that expect a US zip).
+
+#### EmailFaker
+
+Replaces strings with `"user_<8-hex>@example.com"`. Non-string inputs pass through unchanged.
+
+```go
+httptape.EmailFaker{}
+// "alice@corp.com" -> "user_a1b2c3d4@example.com"
+```
+
+#### PhoneFaker
+
+Replaces digits in the input with HMAC-derived digits while preserving every non-digit character (spaces, dashes, parentheses, plus signs). Output length always equals input length.
+
+```go
+httptape.PhoneFaker{}
+// "+1 (555) 123-4567" -> "+1 (937) 481-2056"
+// "555-1234"          -> "938-1742"
+```
+
+If the input is not a string, it is returned unchanged.
+
+#### CreditCardFaker
+
+Generates a 16-digit number formatted as `XXXX-XXXX-XXXX-XXXX`. The first 6 digits (issuer prefix) are taken from the original; if the original has fewer than 6 digits, the prefix `400000` is used. The middle 9 digits are HMAC-derived; the last digit is a valid Luhn check digit.
+
+```go
+httptape.CreditCardFaker{}
+// "4532-1234-5678-9012" -> "4532-12<derived>-<luhn>"
+```
+
+If the input is not a string, it is returned unchanged.
+
+#### NameFaker
+
+Picks a first name and a last name from internal fixed lists using two HMAC bytes. Output is `"<First> <Last>"`.
+
+```go
+httptape.NameFaker{}
+// "Alice Johnson" -> "Olivia Martinez" (deterministic for that seed+input)
+```
+
+If the input is not a string, it is returned unchanged.
+
+#### AddressFaker
+
+Generates a US-style address: `"<number> <street> <suffix>, <city>, <ST> <zip>"`. House number is in `[1, 9999]`; zip is 5 digits; city, state, and street components are picked from internal fixed lists.
+
+```go
+httptape.AddressFaker{}
+// "123 Main St, Anytown, CA 90210" -> "8421 Cedar Drive, Salem, NV 30418"
+```
+
+If the input is not a string, it is returned unchanged.
+
+### Custom fakers
+
+Anything that satisfies the `Faker` interface works. A typical use case is wrapping an existing data source (a list of canonical fake company names, a generator of valid IBANs, etc.) so the recorded fixtures are coherent with the rest of your test data.
+
+```go
+import (
+    "crypto/hmac"
+    "crypto/sha256"
+)
+
+type CompanyFaker struct {
+    Names []string
+}
+
+func (f CompanyFaker) Fake(seed string, original any) any {
+    s, ok := original.(string)
+    if !ok || len(f.Names) == 0 {
+        return original
+    }
+    // Deterministic pick using the HMAC of seed||s.
+    mac := hmac.New(sha256.New, []byte(seed))
+    mac.Write([]byte(s))
+    h := mac.Sum(nil)
+    idx := int(h[0]) % len(f.Names)
+    return f.Names[idx]
+}
+
+sanitizer := httptape.NewPipeline(
+    httptape.FakeFieldsWith("my-seed", map[string]httptape.Faker{
+        "$.employer": CompanyFaker{Names: []string{"Acme", "Globex", "Initech"}},
+    }),
+)
+```
+
+Make sure your implementation is deterministic (same seed + original always produces the same output) and does not mutate `original` -- httptape passes the value pulled out of `json.Unmarshal` directly.
+
 ## Combining redaction and faking
 
 Order matters. Typically, redact first (remove things that should be gone entirely), then fake (replace things that need consistent stand-in values):
@@ -230,6 +450,8 @@ Instead of building pipelines in code, you can define redaction rules in a JSON 
   ]
 }
 ```
+
+The `fake` action also accepts a `fields` map that selects a typed faker per path -- the JSON-config equivalent of `FakeFieldsWith`. See [Config](config.md#typed-fake-fields) for syntax and the full list of shorthands.
 
 ## Custom sanitize functions
 


### PR DESCRIPTION
Closes #127.

## Summary

Documents the previously-undocumented typed-`Faker` public surface across the three relevant docs files. JSON-config users now have an in-docs path to discover the typed entrypoint and all twelve built-in fakers.

### `docs/sanitization.md`
- New `## Typed fakers` H2 with:
  - The `Faker` interface contract and decoded-JSON value-type note.
  - `FakeFieldsWith(seed, fields)` wiring with a 4-faker example.
  - Auto-detect-vs-typed decision-guide table.
  - Per-faker H4 entries for all 12 built-ins, grouped under three thematic H3 categories: redaction-style (`RedactedFaker`, `FixedFaker`), generic deterministic (`HMACFaker`, `NumericFaker`, `PatternFaker`, `PrefixFaker`, `DateFaker`), and PII-shaped (`EmailFaker`, `PhoneFaker`, `CreditCardFaker`, `NameFaker`, `AddressFaker`).
  - A custom-`Faker` example using `crypto/hmac` + `crypto/sha256`.
- Added a one-line cross-link from the existing `## Declarative configuration` section to `config.md#typed-fake-fields`.

### `docs/api-reference.md`
- Added `FakeFieldsWith` to the Built-in sanitize functions table.
- New `### Faker interface` and `### Built-in fakers` subsections covering all 12 typed fakers in a construction/output table.
- Updated the `Rule` struct to include the `Fields map[string]any \`json:\"fields,omitempty\"\`` field, plus a programmatic Go-literal example using `Rule.Fields`.
- Updated the existing Sanitization `Details` link to anchor `#typed-fakers`.

### `docs/config.md`
- Restructured `### fake` to cover both `paths` (auto-detect, `FakeFields`) and `fields` (typed, `FakeFieldsWith`) syntaxes with a clear mutual-exclusion note.
- New `#### Typed fake fields` subsection listing all 7 string shorthands (`redacted`, `hmac`, `email`, `phone`, `credit_card`, `name`, `address`) and all 5 object-form types (`numeric`, `date`, `pattern`, `prefix`, `fixed`) with required-fields tables.
- Extended the Validation list with fake-specific rules (per ADR-31's "document rules, not error strings" decision).
- New `## Typed-faker examples` section with three end-to-end JSON examples (email shorthand, numeric object form, credit-card shorthand).
- Added two cross-links in `## See also` to `sanitization.md#typed-fakers` and `api-reference.md#faker-interface`.

## Pre-flight verification

Confirmed `FakeFieldsWith` exists in `sanitizer.go`/`faker.go` (originally flagged in the dispatch as something to verify) -- it is the typed-faker entrypoint and is documented as such.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -race -count=1` clean (no Go changes; sanity check only)
- [x] Code samples reference real signatures from `faker.go` (twelve `Fake(seed, original)` implementations + struct-literal construction), `sanitizer.go` (`FakeFieldsWith(seed, fields map[string]Faker)`, `SanitizeFunc`, `NewPipeline`), and `config.go` (`Rule.Fields`, `validShorthands`, object-form `parseFakerSpec`).
- [x] Cross-links verified against actual heading slugs: `sanitization.md#typed-fakers`, `sanitization.md#fakefields`, `config.md#typed-fake-fields`, `api-reference.md#faker-interface`.
- [x] Hard constraints honored: zero `.go` files, zero `go.mod`/`go.sum` changes, no edits to `decisions.md`, `config.schema.json`, `README.md`, `llms*.txt`, or `docs/cli.md`.