### PR TITLE
docs: documentation drift cleanup (#128)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,11 +8,12 @@ Quick reference of all exported types, functions, and options in the `httptape` 
 
 ```go
 type Tape struct {
-    ID         string       `json:"id"`
-    Route      string       `json:"route"`
-    RecordedAt time.Time    `json:"recorded_at"`
-    Request    RecordedReq  `json:"request"`
-    Response   RecordedResp `json:"response"`
+    ID         string         `json:"id"`
+    Route      string         `json:"route"`
+    RecordedAt time.Time      `json:"recorded_at"`
+    Request    RecordedReq    `json:"request"`
+    Response   RecordedResp   `json:"response"`
+    Metadata   map[string]any `json:"metadata,omitempty"`
 }
 
 func NewTape(route string, req RecordedReq, resp RecordedResp) Tape
@@ -88,6 +89,7 @@ func (r *Recorder) Close() error
 | WithMaxBodySize | `WithMaxBodySize(n int)` | `0` (no limit) |
 | WithSkipRedirects | `WithSkipRedirects(skip bool)` | `false` |
 | WithOnError | `WithOnError(fn func(error))` | no-op |
+| WithRecorderTLSConfig | `WithRecorderTLSConfig(cfg *tls.Config)` | nil |
 
 **Details:** [Recording](recording.md)
 
@@ -112,6 +114,7 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) // implemen
 | WithProxyRoute | `WithProxyRoute(route string)` | `""` |
 | WithProxyOnError | `WithProxyOnError(fn func(error))` | nil |
 | WithProxyFallbackOn | `WithProxyFallbackOn(fn func(error, *http.Response) bool)` | transport errors only |
+| WithProxyTLSConfig | `WithProxyTLSConfig(cfg *tls.Config)` | nil |
 
 **Details:** [Proxy Mode](proxy.md)
 
@@ -140,6 +143,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) // implements
 | WithReplayHeaders | `WithReplayHeaders(key, value string)` | none |
 
 **Details:** [Replay](replay.md)
+
+---
+
+## TLS helpers
+
+```go
+func BuildTLSConfig(certFile, keyFile, caFile string, insecure bool) (*tls.Config, error)
+```
+
+Constructs a `*tls.Config` from optional PEM file paths and an insecure flag. Returns `(nil, nil)` when all parameters are zero-valued (use Go defaults). `certFile` and `keyFile` must be supplied together for mTLS; `caFile` overrides the system root CAs; `insecure` sets `InsecureSkipVerify`. Used internally by the CLI's `--tls-*` flags and exposed for embedders that build their own `*tls.Config` from the same inputs.
+
+**Details:** [TLS](tls.md)
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -76,6 +76,8 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) // imple
 func (r *Recorder) Close() error
 ```
 
+Panics if `store` is nil.
+
 ### RecorderOption
 
 | Option | Signature | Default |
@@ -104,6 +106,8 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) *Proxy
 func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) // implements http.RoundTripper
 ```
 
+Panics if `l1` or `l2` is nil.
+
 ### ProxyOption
 
 | Option | Signature | Default |
@@ -128,6 +132,8 @@ type Server struct { /* unexported */ }
 func NewServer(store Store, opts ...ServerOption) *Server
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) // implements http.Handler
 ```
+
+Panics if `store` is nil.
 
 ### ServerOption
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,7 @@ httptape serve --fixtures ./fixtures [flags]
 | `--delay` | `0` | Fixed delay before every response (e.g., `200ms`, `1s`) |
 | `--error-rate` | `0` | Fraction of requests that return 500 (0.0-1.0) |
 | `--replay-header` | (none) | Header to inject into responses (`Key=Value`, repeatable) |
+| `--config` | (none) | Path to redaction config JSON. Accepted but not currently used by `serve` (reserved for future use). |
 
 The server uses `DefaultMatcher` (method + path matching) and loads fixtures from the specified directory. It shuts down gracefully on SIGINT/SIGTERM.
 
@@ -53,6 +54,10 @@ httptape record --upstream <url> --fixtures <dir> [flags]
 | `--config` | (none) | Path to redaction config JSON |
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
+| `--tls-cert` | (none) | Path to PEM client certificate for mTLS. See [TLS](tls.md). |
+| `--tls-key` | (none) | Path to PEM client private key for mTLS. See [TLS](tls.md). |
+| `--tls-ca` | (none) | Path to PEM CA certificate(s) for upstream verification. See [TLS](tls.md). |
+| `--tls-insecure` | `false` | Skip TLS verification (development only). See [TLS](tls.md). |
 
 The recorder starts a reverse proxy on the specified port. All requests are forwarded to the upstream, and responses are recorded (with optional redaction) to the fixtures directory.
 
@@ -86,6 +91,10 @@ httptape proxy --upstream <url> --fixtures <dir> [flags]
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
 | `--fallback-on-5xx` | `false` | Also fall back on 5xx responses from upstream |
+| `--tls-cert` | (none) | Path to PEM client certificate for mTLS. See [TLS](tls.md). |
+| `--tls-key` | (none) | Path to PEM client private key for mTLS. See [TLS](tls.md). |
+| `--tls-ca` | (none) | Path to PEM CA certificate(s) for upstream verification. See [TLS](tls.md). |
+| `--tls-insecure` | `false` | Skip TLS verification (development only). See [TLS](tls.md). |
 
 When the upstream is reachable, requests are forwarded and responses are cached:
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -73,7 +73,7 @@ Both are declared as `VOLUME` in the Dockerfile and pre-exist in the image.
 ## Image details
 
 - **Base:** `scratch` (no OS, no shell, no package manager)
-- **Size:** ~10 MB (static Go binary + CA certs)
+- **Size:** ~3 MB (static Go binary + CA certs)
 - **User:** `65534` (nobody) -- runs as non-root
 - **Exposed port:** `8081`
 - **Entrypoint:** `httptape`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ Record, Redact, and Replay HTTP traffic in 5 minutes.
 
 ## Prerequisites
 
-- Go 1.22 or later (for the Go library)
+- Go 1.26 or later (for the Go library)
 - Or: Docker (for CLI/Docker usage with any language)
 - `go get github.com/VibeWarden/httptape`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,11 +44,11 @@ func main() {
     defer resp.Body.Close()
 
     fmt.Println("Recorded:", resp.StatusCode)
-    // A JSON fixture file is now saved in ./fixtures/
+    // After rec.Close() returns, a JSON fixture file is saved in ./fixtures/.
 }
 ```
 
-After running this, check `./fixtures/` -- you will see a JSON file containing the full request and response.
+After running this (and after `rec.Close()` flushes the recorder), check `./fixtures/` -- you will see a JSON file containing the full request and response.
 
 ## Step 2: Replay recorded traffic
 
@@ -95,6 +95,7 @@ package main
 
 import (
     "net/http"
+    "strings"
 
     "github.com/VibeWarden/httptape"
 )
@@ -120,7 +121,7 @@ func main() {
 
     client := &http.Client{Transport: rec}
     client.Post("https://api.example.com/users", "application/json",
-        nil, // your request body here
+        strings.NewReader(`{"password":"hunter2","ssn":"123-45-6789","user":{"email":"alice@example.com","id":42}}`),
     )
 
     // The fixture file now has:

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ httptape captures HTTP request/response pairs, redacts sensitive data on write, 
     docker pull ghcr.io/vibewarden/httptape:latest
     ```
 
-Requires Go 1.22 or later for the library/CLI. Docker works with any platform.
+Requires Go 1.26 or later for the library/CLI. Docker works with any platform.
 
 ## Quick example
 

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -73,6 +73,57 @@ Sets a callback invoked when no tape matches an incoming request. The callback r
 
 This is useful for debugging which requests are not being matched during test development.
 
+### WithCORS
+
+```go
+func WithCORS() ServerOption
+```
+
+Enables permissive CORS headers (`Access-Control-Allow-Origin: *`) on every replayed response and short-circuits `OPTIONS` preflight requests with 204. Intended for local development where a frontend dev server (e.g., `localhost:3000`) calls the mock backend (e.g., `localhost:3001`). Opt-in only.
+
+```go
+srv := httptape.NewServer(store, httptape.WithCORS())
+```
+
+### WithDelay
+
+```go
+func WithDelay(d time.Duration) ServerOption
+```
+
+Adds a fixed delay before every response. The delay is applied after matching but before writing the response. If the request context is cancelled during the delay (e.g., the client disconnects), `ServeHTTP` returns immediately without writing. A zero or negative duration is a no-op.
+
+```go
+srv := httptape.NewServer(store, httptape.WithDelay(200*time.Millisecond))
+```
+
+### WithErrorRate
+
+```go
+func WithErrorRate(rate float64) ServerOption
+```
+
+Causes a fraction of requests to return `500 Internal Server Error` with an `X-Httptape-Error: simulated` header instead of the recorded response. `rate` must be between `0.0` and `1.0` inclusive (`0.0` disables error simulation, `1.0` fails every request). Panics if `rate` is outside `[0.0, 1.0]`.
+
+```go
+srv := httptape.NewServer(store, httptape.WithErrorRate(0.1)) // 10% failure rate
+```
+
+### WithReplayHeaders
+
+```go
+func WithReplayHeaders(key, value string) ServerOption
+```
+
+Injects a header into every replayed response, applied after tape matching. Overrides any header with the same key from the recorded tape. May be called multiple times to set multiple headers. Useful for environment-specific tokens, correlation IDs, or cache-control values.
+
+```go
+srv := httptape.NewServer(store,
+    httptape.WithReplayHeaders("X-Request-ID", "test-run-1"),
+    httptape.WithReplayHeaders("Cache-Control", "no-store"),
+)
+```
+
 ## How replay works
 
 For each incoming request, the `Server`:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -107,11 +107,14 @@ Each tape is stored as pretty-printed JSON with a trailing newline:
       "Content-Type": ["application/json"]
     },
     "body": "eyJ1c2VyIjoib2N0b2NhdCJ9"
-  }
+  },
+  "metadata": {}
 }
 ```
 
 Fixtures are human-readable and safe to commit to version control (especially when sanitized).
+
+The `metadata` field is optional and is omitted from the JSON when empty during serialization. See [Fixture Authoring](fixtures-authoring.md) for the metadata keys (`delay`, `error`, etc.) the replay server reads.
 
 ### ID validation
 

--- a/docs/ui-first-dev.md
+++ b/docs/ui-first-dev.md
@@ -381,7 +381,7 @@ services:
 | Error simulation | `metadata.error` per fixture, `WithErrorRate` global | Per-route rules in GUI |
 | Latency simulation | `metadata.delay` per fixture, `WithDelay` global | Per-route latency in GUI |
 | Go integration | Native -- embeddable in Go tests | None (separate process) |
-| Docker | Minimal scratch image (~10 MB) | Node.js-based image |
+| Docker | Minimal scratch image (~3 MB) | Node.js-based image |
 | CORS | `--cors` flag | Built-in toggle |
 
 **Choose httptape when** you want text-file-based fixtures, Git-friendly diffs, Go test integration, or sanitization.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -187,7 +187,7 @@ httptape captures HTTP request/response pairs, redacts sensitive data on write, 
     docker pull ghcr.io/vibewarden/httptape:latest
     ```
 
-Requires Go 1.22 or later for the library/CLI. Docker works with any platform.
+Requires Go 1.26 or later for the library/CLI. Docker works with any platform.
 
 ## Quick example
 
@@ -261,7 +261,7 @@ Record, Redact, and Replay HTTP traffic in 5 minutes.
 
 ## Prerequisites
 
-- Go 1.22 or later (for the Go library)
+- Go 1.26 or later (for the Go library)
 - Or: Docker (for CLI/Docker usage with any language)
 - `go get github.com/VibeWarden/httptape`
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -100,7 +100,7 @@ httptape import  --fixtures <dir> [--input file.tar.gz]
 
 ```
 docker pull ghcr.io/vibewarden/httptape:latest
-# ~10 MB scratch image, runs as non-root (65534)
+# ~3 MB scratch image, runs as non-root (65534)
 ```
 
 ## JSON Config (redaction rules)
@@ -2592,7 +2592,7 @@ services:
 | Error simulation | `metadata.error` per fixture, `WithErrorRate` global | Per-route rules in GUI |
 | Latency simulation | `metadata.delay` per fixture, `WithDelay` global | Per-route latency in GUI |
 | Go integration | Native -- embeddable in Go tests | None (separate process) |
-| Docker | Minimal scratch image (~10 MB) | Node.js-based image |
+| Docker | Minimal scratch image (~3 MB) | Node.js-based image |
 | CORS | `--cors` flag | Built-in toggle |
 
 **Choose httptape when** you want text-file-based fixtures, Git-friendly diffs, Go test integration, or sanitization.
@@ -3401,7 +3401,7 @@ Both are declared as `VOLUME` in the Dockerfile and pre-exist in the image.
 ## Image details
 
 - **Base:** `scratch` (no OS, no shell, no package manager)
-- **Size:** ~10 MB (static Go binary + CA certs)
+- **Size:** ~3 MB (static Go binary + CA certs)
 - **User:** `65534` (nobody) -- runs as non-root
 - **Exposed port:** `8081`
 - **Entrypoint:** `httptape`

--- a/llms.txt
+++ b/llms.txt
@@ -100,7 +100,7 @@ httptape import  --fixtures <dir> [--input file.tar.gz]
 
 ```
 docker pull ghcr.io/vibewarden/httptape:latest
-# ~10 MB scratch image, runs as non-root (65534)
+# ~3 MB scratch image, runs as non-root (65534)
 ```
 
 ## JSON Config (redaction rules)


### PR DESCRIPTION
Closes #128

## Summary

Pure-docs PR that addresses eight independent drift items surfaced by
the audit against `main @ bf456dc`. Per ADR-32, each acceptance
criterion is a separate commit so a bisect later is trivial.

| # | Commit | Files |
|---|---|---|
| 1 | `docs: bump Go version requirement to 1.26 across docs` | `docs/getting-started.md`, `docs/index.md`, `llms-full.txt` (x2) |
| 2 | `docs: align Docker image size to ~3 MB across docs and LLM summaries` | `docs/docker.md`, `docs/ui-first-dev.md`, `llms.txt`, `llms-full.txt` (x3) |
| 3 | `docs(cli): document TLS flags on record/proxy and --config on serve` | `docs/cli.md` |
| 4 | `docs(replay): document WithCORS, WithDelay, WithErrorRate, WithReplayHeaders` | `docs/replay.md` |
| 5 | `docs(api-reference): add WithRecorderTLSConfig, WithProxyTLSConfig, BuildTLSConfig, Tape.Metadata` | `docs/api-reference.md` |
| 6 | `docs(api-reference): document panic conditions for NewRecorder, NewServer, NewProxy` | `docs/api-reference.md` |
| 7 | `docs(getting-started): correct async-flush wording and POST body example` | `docs/getting-started.md` |
| 8 | `docs(storage): include metadata key in sample fixture JSON` | `docs/storage.md` |

### Architect-discovered additions vs. PM brief

- Go version drift was in **4** locations, not 2 (`llms-full.txt` lines 190 and 264 also drifted).
- Docker image-size drift was in **6** locations, not 5 (`llms-full.txt:2595` also drifted).
- `NewProxy` panics in **two** conditions (nil `l1` at `proxy.go:220`, nil `l2` at `proxy.go:223`); the documentation note covers both with one sentence.

### Image-size measurement

Canonical figure is the registry compressed size, not the local
`docker images` (uncompressed-on-disk) figure. Per ADR-32:

```
$ curl -sL https://hub.docker.com/v2/repositories/tibtof/httptape/tags/0.9.0/
# full_size: 3225539 (3.2 MB) for amd64
# full_size: 2936414 (2.9 MB) for arm64
```

Both round to `~3 MB` (tilde signals approximation, matching the README
update from #135).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -race -count=1` clean (~7s)
- [x] Step 3 of `docs/getting-started.md` (with the new `strings.NewReader` body) compiles in a scratch `main`
- [x] All four `docs/replay.md` H3 snippets compile in a scratch `main`
- [x] Repo-wide `Go 1.22` grep returns zero matches
- [x] Repo-wide `~10 MB` grep returns zero matches outside `decisions.md` (historical ADR, do-not-touch per ADR-32)
- [x] Internal cross-link `[TLS](tls.md)` in `docs/cli.md` and `docs/api-reference.md` resolves to existing file
- [x] No `.go`, `Dockerfile`, schema, or CI workflow files touched
- [x] No external dependencies added; `go.mod` / `go.sum` unchanged