### PR TITLE
chore: point README links to hosted docs, add VibeWarden attribution (#152)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ USER 65534
 # Dockerfile labels are the floor that guarantees metadata exists on local
 # `docker build .` and on downstream re-builds.
 LABEL org.opencontainers.image.title="httptape" \
-      org.opencontainers.image.description="HTTP traffic recording, redaction, and replay — embeddable Go library, CLI, and 6 MB Docker image." \
+      org.opencontainers.image.description="HTTP traffic recording, redaction, and replay — embeddable Go library, CLI, and 3 MB Docker image." \
       org.opencontainers.image.source="https://github.com/VibeWarden/httptape" \
       org.opencontainers.image.url="https://github.com/VibeWarden/httptape" \
       org.opencontainers.image.documentation="https://vibewarden.dev/docs/httptape/" \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ httptape captures HTTP request/response pairs, redacts sensitive data on write,
 and replays them as a mock server. Think WireMock, but with a 3 MB Docker image,
 an embeddable Go library, and a redaction pipeline built into the core.
 
+**Docs**: [vibewarden.dev/docs/httptape](https://vibewarden.dev/docs/httptape/) · **From**: [VibeWarden](https://vibewarden.dev)
+
 **The 3 Rs:**
 
 1. **Record** -- capture real HTTP traffic via a transparent `http.RoundTripper`
@@ -88,7 +90,7 @@ httptape proxy --upstream https://api.example.com \
     --fixtures ./cache --config redact.json
 ```
 
-When the upstream is reachable, requests are forwarded and responses are cached in two tiers (L1 in-memory, L2 on disk). When the upstream is down, httptape transparently serves cached responses. See [Proxy Mode](docs/proxy.md) for details.
+When the upstream is reachable, requests are forwarded and responses are cached in two tiers (L1 in-memory, L2 on disk). When the upstream is down, httptape transparently serves cached responses. See [Proxy Mode](https://vibewarden.dev/docs/httptape/proxy/) for details.
 
 ## Install
 
@@ -325,12 +327,18 @@ More examples coming. See [`examples/README.md`](examples/README.md) for the ind
 
 ## Documentation
 
-- [Getting Started](docs/getting-started.md)
-- [Recording](docs/recording.md) · [Replay](docs/replay.md) · [Redaction](docs/sanitization.md)
-- [Proxy Mode](docs/proxy.md) · [Matching](docs/matching.md) · [Storage](docs/storage.md)
-- [Import/Export](docs/import-export.md) · [JSON Config](docs/config.md)
-- [CLI Reference](docs/cli.md) · [Docker](docs/docker.md) · [Testcontainers](docs/testcontainers.md)
-- [API Reference](docs/api-reference.md)
+Full docs at **[vibewarden.dev/docs/httptape](https://vibewarden.dev/docs/httptape/)**.
+
+- [Getting Started](https://vibewarden.dev/docs/httptape/getting-started/)
+- [Recording](https://vibewarden.dev/docs/httptape/recording/) · [Replay](https://vibewarden.dev/docs/httptape/replay/) · [Redaction](https://vibewarden.dev/docs/httptape/sanitization/)
+- [Proxy Mode](https://vibewarden.dev/docs/httptape/proxy/) · [Matching](https://vibewarden.dev/docs/httptape/matching/) · [Storage](https://vibewarden.dev/docs/httptape/storage/)
+- [Import/Export](https://vibewarden.dev/docs/httptape/import-export/) · [JSON Config](https://vibewarden.dev/docs/httptape/config/)
+- [CLI Reference](https://vibewarden.dev/docs/httptape/cli/) · [Docker](https://vibewarden.dev/docs/httptape/docker/) · [Testcontainers](https://vibewarden.dev/docs/httptape/testcontainers/)
+- [API Reference](https://vibewarden.dev/docs/httptape/api-reference/)
+
+## About
+
+httptape is developed as part of [VibeWarden](https://vibewarden.dev). For the full docs, guides, and other projects from the VibeWarden team, visit [vibewarden.dev](https://vibewarden.dev).
 
 ## License
 

--- a/doc.go
+++ b/doc.go
@@ -75,4 +75,10 @@
 // persistence goes through the [Store] port, and all components are
 // configured via functional options. The library has zero external
 // dependencies (stdlib only) and no global mutable state.
+//
+// # Documentation
+//
+// Full documentation, guides, and examples live at
+// https://vibewarden.dev/docs/httptape/. httptape is developed as part of
+// VibeWarden — see https://vibewarden.dev/.
 package httptape


### PR DESCRIPTION
## Summary

Three related fixes to httptape's public-facing presentation:

### 1. README links → hosted docs

12+ `docs/*.md` relative links in the README only worked on github.com — broke when the README rendered on Docker Hub (via the description sync from #122). Switched all to absolute `https://vibewarden.dev/docs/httptape/<slug>/` URLs, which work on github.com, Docker Hub, and pkg.go.dev's linked-README render.

### 2. VibeWarden attribution

Added:
- A compact "**Docs**: vibewarden.dev/docs/httptape · **From**: VibeWarden" line right after the intro paragraph.
- An "## About" footer before License crediting VibeWarden.

No marketing copy — just factual attribution + links.

### 3. Dockerfile description label fix

`org.opencontainers.image.description` still said "6 MB Docker image" despite the actual image being ~3 MB (per Docker Hub API: `full_size: 3225539` bytes). This label feeds Docker Hub's **short-description tagline** (what I pointed out earlier — still visible as "...6 MB..." on the Hub page). Changed to "3 MB" so the next tag push updates it.

## doc.go addition

Added a "Documentation" heading to the package-level godoc so pkg.go.dev visitors can find `https://vibewarden.dev/docs/httptape/` and vibewarden.dev.

## Effect on Docker Hub (after next tag)

- Long-form description: links will resolve to real URLs (they already do since #135 switched to absolute logo URL, but the in-README links were still relative).
- Short-description tagline: switches from "6 MB" to "3 MB".

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -race` clean (no code changes; verified anyway)
- [x] Every new URL returns 200 (spot-checked `https://vibewarden.dev/docs/httptape/proxy/`)
- [x] Dockerfile still builds (LABEL change is a one-string swap)

Closes #152.