### PR TITLE
feat(#45): response templating -- Mustache-style request data interpolation in fixtures

### DIFF
--- a/server.go
+++ b/server.go
@@ -14,16 +14,18 @@ import (
 // Server is safe for concurrent use by multiple goroutines. All fields are
 // immutable after construction.
 type Server struct {
-	store          Store
-	matcher        Matcher
-	fallbackStatus int              // HTTP status when no tape matches
-	fallbackBody   []byte           // response body when no tape matches
-	onNoMatch      func(*http.Request) // optional callback when no tape matches
-	cors           bool             // if true, add CORS headers to all responses
-	delay          time.Duration    // fixed delay before every response; zero means no delay
-	errorRate      float64          // fraction of requests that return 500 (0.0-1.0)
-	randFloat      func() float64   // random number generator (injectable for testing)
-	replayHeaders  map[string]string // headers injected into every replayed response
+	store            Store
+	matcher          Matcher
+	fallbackStatus   int                 // HTTP status when no tape matches
+	fallbackBody     []byte              // response body when no tape matches
+	onNoMatch        func(*http.Request) // optional callback when no tape matches
+	cors             bool                // if true, add CORS headers to all responses
+	delay            time.Duration       // fixed delay before every response; zero means no delay
+	errorRate        float64             // fraction of requests that return 500 (0.0-1.0)
+	randFloat        func() float64      // random number generator (injectable for testing)
+	replayHeaders    map[string]string   // headers injected into every replayed response
+	templating       bool                // if true, resolve {{request.*}} in responses
+	strictTemplating bool                // if true, unresolvable expressions produce 500
 }
 
 // ServerOption configures a Server.
@@ -109,6 +111,41 @@ func WithReplayHeaders(key, value string) ServerOption {
 	}
 }
 
+// WithTemplating controls whether Mustache-style {{request.*}} template
+// expressions in response bodies and headers are resolved against the
+// incoming request at serve time. When enabled, template expressions are
+// replaced with values from the request (method, path, headers, query
+// params, body fields). When disabled, no scanning or replacement occurs
+// and response bodies/headers are written exactly as stored.
+//
+// Templating is enabled by default. The {{...}} delimiter is vanishingly
+// rare in real HTTP payloads, so enabling it by default is safe. Users who
+// only replay recorded traffic (no {{ in fixtures) see zero behavioral
+// change, as the fast path skips processing for bodies without "{{".
+//
+// See also WithStrictTemplating for error handling of unresolvable
+// expressions.
+func WithTemplating(enabled bool) ServerOption {
+	return func(s *Server) { s.templating = enabled }
+}
+
+// WithStrictTemplating controls the error behavior when a template
+// expression cannot be resolved. When strict is true, an unresolvable
+// expression (e.g., referencing a missing header) causes the server to
+// return HTTP 500 with an X-Httptape-Error: template header and a body
+// describing which expression failed. When strict is false (the default),
+// unresolvable expressions are silently replaced with an empty string.
+//
+// Strict mode is useful in tests where fixture authoring mistakes should
+// be caught early. Lenient mode is useful for production-like tests where
+// a missing value is acceptable.
+//
+// Strict mode has no effect when templating is disabled via
+// WithTemplating(false).
+func WithStrictTemplating(strict bool) ServerOption {
+	return func(s *Server) { s.strictTemplating = strict }
+}
+
 // withRandFloat overrides the random number generator for testing.
 // This is unexported -- only used in tests to make error simulation
 // deterministic.
@@ -126,6 +163,7 @@ func withRandFloat(fn func() float64) ServerOption {
 //   - CORS disabled
 //   - no delay
 //   - no error simulation
+//   - templating enabled (lenient mode)
 //
 // The store must not be nil. Passing a nil store is a programming error and
 // will panic.
@@ -139,6 +177,7 @@ func NewServer(store Store, opts ...ServerOption) *Server {
 		matcher:        DefaultMatcher(),
 		fallbackStatus: http.StatusNotFound,
 		fallbackBody:   []byte("httptape: no matching tape found"),
+		templating:     true,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -162,8 +201,9 @@ func NewServer(store Store, opts ...ServerOption) *Server {
 //  3. Normal replay -- existing match-and-respond logic
 //  4. Per-fixture error override -- after matching, before writing
 //  5. Delay -- sleep before writing the real response
-//  6. Replay header injection -- override/add headers from WithReplayHeaders
-//  7. Write response
+//  6. Templating -- resolve {{request.*}} expressions in body and headers
+//  7. Replay header injection -- override/add headers from WithReplayHeaders
+//  8. Write response
 //
 // Performance note: ServeHTTP calls Store.List with an empty filter on every
 // request, resulting in an O(n) scan over all tapes. This is acceptable for
@@ -258,20 +298,39 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 8. Write the matched tape's response.
-	// 8a: copy response headers (clone slices to prevent aliasing with tape data).
-	for key, values := range tape.Response.Headers {
+	// 8. Templating -- resolve {{request.*}} expressions in response body and headers.
+	respBody := tape.Response.Body
+	respHeaders := tape.Response.Headers
+	if s.templating {
+		var err error
+		respBody, err = ResolveTemplateBody(respBody, r, s.strictTemplating)
+		if err != nil {
+			w.Header().Set("X-Httptape-Error", "template")
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		respHeaders, err = ResolveTemplateHeaders(respHeaders, r, s.strictTemplating)
+		if err != nil {
+			w.Header().Set("X-Httptape-Error", "template")
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// 9. Write the matched tape's response.
+	// 9a: copy response headers (clone slices to prevent aliasing with tape data).
+	for key, values := range respHeaders {
 		w.Header()[key] = append([]string(nil), values...)
 	}
-	// 8b: apply replay header overrides (if any).
+	// 9b: apply replay header overrides (if any).
 	for key, value := range s.replayHeaders {
 		w.Header().Set(key, value)
 	}
-	// 8c: remove Content-Length — the recorded value may be stale if the body
-	// was modified by sanitization. Let net/http set it from the actual body.
+	// 9c: remove Content-Length — the recorded value may be stale if the body
+	// was modified by sanitization or templating. Let net/http set it from the actual body.
 	w.Header().Del("Content-Length")
-	// 8d: write status code.
+	// 9d: write status code.
 	w.WriteHeader(tape.Response.StatusCode)
-	// 8e: write body.
-	w.Write(tape.Response.Body) //nolint:errcheck // response write failure is not actionable
+	// 9e: write body.
+	w.Write(respBody) //nolint:errcheck // response write failure is not actionable
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1157,3 +1157,290 @@ func TestServer_ReplayHeaders_NotSetByDefault(t *testing.T) {
 		t.Errorf("X-Original = %q, want %q", got, "value")
 	}
 }
+
+// --- Templating integration tests ---
+
+func TestServer_Templating_BodySubstitution(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "POST", "/echo", 200,
+		`{"method":"{{request.method}}","path":"{{request.path}}"}`, nil)
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/echo", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"method":"POST","path":"/echo"}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestServer_Templating_HeaderSubstitution(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "POST", "/payments", 200, `{"ok":true}`, http.Header{
+		"X-Idempotency-Key": {"{{request.headers.Idempotency-Key}}"},
+	})
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/payments", nil)
+	req.Header.Set("Idempotency-Key", "idem-xyz-456")
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-Idempotency-Key"); got != "idem-xyz-456" {
+		t.Errorf("X-Idempotency-Key = %q, want %q", got, "idem-xyz-456")
+	}
+}
+
+func TestServer_Templating_Disabled(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/raw", 200, `{{request.method}}`, nil)
+
+	srv := NewServer(store, WithTemplating(false))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/raw", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	// With templating disabled, body should be returned verbatim.
+	if got := rec.Body.String(); got != "{{request.method}}" {
+		t.Errorf("body = %q, want %q", got, "{{request.method}}")
+	}
+}
+
+func TestServer_Templating_StrictMode_Error(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/strict", 200, `{{request.headers.Missing}}`, nil)
+
+	srv := NewServer(store, WithStrictTemplating(true))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/strict", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	if got := rec.Header().Get("X-Httptape-Error"); got != "template" {
+		t.Errorf("X-Httptape-Error = %q, want %q", got, "template")
+	}
+	if !strings.Contains(rec.Body.String(), "request.headers.Missing") {
+		t.Errorf("body = %q, should mention the failed expression", rec.Body.String())
+	}
+}
+
+func TestServer_Templating_StrictMode_HeaderError(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/strict-hdr", 200, "ok", http.Header{
+		"X-Echo": {"{{request.headers.Missing}}"},
+	})
+
+	srv := NewServer(store, WithStrictTemplating(true))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/strict-hdr", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	if got := rec.Header().Get("X-Httptape-Error"); got != "template" {
+		t.Errorf("X-Httptape-Error = %q, want %q", got, "template")
+	}
+}
+
+func TestServer_Templating_LenientMode_MissingRef(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/lenient", 200,
+		`key={{request.headers.Missing}}`, nil)
+
+	srv := NewServer(store) // default: lenient
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/lenient", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "key=" {
+		t.Errorf("body = %q, want %q", got, "key=")
+	}
+}
+
+func TestServer_Templating_NoTemplates_FastPath(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/plain", 200, `{"static":"response"}`, nil)
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/plain", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"static":"response"}` {
+		t.Errorf("body = %q, want %q", got, `{"static":"response"}`)
+	}
+}
+
+func TestServer_Templating_QueryParam(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/search", 200,
+		`{"q":"{{request.query.q}}","page":"{{request.query.page}}"}`, nil)
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/search?q=hello&page=3", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"q":"hello","page":"3"}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestServer_Templating_BodyField(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "POST", "/echo-body", 200,
+		`{"echo_email":"{{request.body.user.email}}"}`, nil)
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/echo-body",
+		strings.NewReader(`{"user":{"email":"test@example.com"}}`))
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"echo_email":"test@example.com"}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestServer_Templating_DoesNotModifyStoredFixture(t *testing.T) {
+	store := NewMemoryStore()
+	tape := storeTape(t, store, "GET", "/immutable", 200,
+		`{{request.method}}`, nil)
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/immutable", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	// The response should be resolved.
+	if got := rec.Body.String(); got != "GET" {
+		t.Errorf("body = %q, want %q", got, "GET")
+	}
+
+	// The stored fixture should be unchanged.
+	loaded, err := store.Load(context.Background(), tape.ID)
+	if err != nil {
+		t.Fatalf("load tape: %v", err)
+	}
+	if string(loaded.Response.Body) != "{{request.method}}" {
+		t.Errorf("stored body = %q, should be unchanged", string(loaded.Response.Body))
+	}
+}
+
+func TestServer_Templating_WithCORS(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/cors-template", 200,
+		`{{request.method}}`, nil)
+
+	srv := NewServer(store, WithCORS())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/cors-template", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "GET" {
+		t.Errorf("body = %q, want %q", got, "GET")
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("CORS header missing: %q", got)
+	}
+}
+
+func TestServer_Templating_EnabledByDefault(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/default-on", 200, `{{request.method}}`, nil)
+
+	// NewServer without any templating options — should be enabled by default.
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/default-on", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "GET" {
+		t.Errorf("body = %q, want %q (templating should be on by default)", got, "GET")
+	}
+}
+
+func TestServer_Templating_NonRequestNamespace_Literal(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/state", 200,
+		`count={{state.counter}}`, nil)
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/state", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	// Non-request namespace expressions should be left as-is.
+	if got := rec.Body.String(); got != "count={{state.counter}}" {
+		t.Errorf("body = %q, want %q", got, "count={{state.counter}}")
+	}
+}
+
+func TestServer_Templating_URL(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/url-echo", 200,
+		`url={{request.url}}`, nil)
+
+	srv := NewServer(store)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/url-echo?key=val", nil)
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "url=/url-echo?key=val" {
+		t.Errorf("body = %q, want %q", got, "url=/url-echo?key=val")
+	}
+}

--- a/templating.go
+++ b/templating.go
@@ -1,0 +1,311 @@
+package httptape
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+// templateExpr represents a parsed template expression extracted from a
+// Mustache-style {{...}} placeholder. It stores the raw expression text
+// and its byte offsets within the source.
+type templateExpr struct {
+	// raw is the expression text between {{ and }}, trimmed of whitespace.
+	raw string
+	// start is the byte offset of the opening "{{" in the source.
+	start int
+	// end is the byte offset just past the closing "}}" in the source.
+	end int
+}
+
+// scanTemplateExprs scans src for all {{...}} expressions and returns them
+// in order of appearance. Nested or malformed delimiters ({{ without }})
+// are left as literal text. This is the "hand-rolled scanner" approach:
+// a single bytes.Index loop, ~80 lines, no regex.
+func scanTemplateExprs(src []byte) []templateExpr {
+	var exprs []templateExpr
+	pos := 0
+	for pos < len(src) {
+		openIdx := bytes.Index(src[pos:], []byte("{{"))
+		if openIdx < 0 {
+			break
+		}
+		openIdx += pos // absolute offset
+
+		closeIdx := bytes.Index(src[openIdx+2:], []byte("}}"))
+		if closeIdx < 0 {
+			break // unclosed {{ — treat rest as literal
+		}
+		closeIdx += openIdx + 2 // absolute offset of first char of "}}"
+
+		raw := string(bytes.TrimSpace(src[openIdx+2 : closeIdx]))
+		exprs = append(exprs, templateExpr{
+			raw:   raw,
+			start: openIdx,
+			end:   closeIdx + 2, // past the "}}"
+		})
+		pos = closeIdx + 2
+	}
+	return exprs
+}
+
+// resolveExpr resolves a single template expression against the incoming
+// HTTP request. It returns the resolved string value and true, or ("", false)
+// if the expression is unresolvable.
+//
+// Supported expression prefixes:
+//   - request.method        -> r.Method
+//   - request.path          -> r.URL.Path
+//   - request.url           -> r.URL.String()
+//   - request.headers.<N>   -> r.Header.Get(http.CanonicalHeaderKey(N))
+//   - request.query.<N>     -> r.URL.Query().Get(N)
+//   - request.body.<path>   -> JSON field at $.path (dot-separated)
+//
+// Non-"request." prefixed expressions are left as literal text (returned
+// as-is with ok=true). This is forward-compatible with future namespaces
+// like "state.*" (#46).
+func resolveExpr(expr string, r *http.Request, reqBody []byte) (string, bool) {
+	// Non-request namespace: leave as literal (forward-compat).
+	if len(expr) < 8 || expr[:8] != "request." {
+		return "{{" + expr + "}}", true
+	}
+
+	rest := expr[8:] // strip "request."
+	switch {
+	case rest == "method":
+		return r.Method, true
+	case rest == "path":
+		return r.URL.Path, true
+	case rest == "url":
+		return r.URL.String(), true
+	}
+
+	// request.headers.<Name>
+	if len(rest) > 8 && rest[:8] == "headers." {
+		name := rest[8:]
+		val := r.Header.Get(http.CanonicalHeaderKey(name))
+		if val == "" {
+			// Header not present — unresolvable.
+			return "", false
+		}
+		return val, true
+	}
+
+	// request.query.<name>
+	if len(rest) > 6 && rest[:6] == "query." {
+		name := rest[6:]
+		val := r.URL.Query().Get(name)
+		if val == "" {
+			return "", false
+		}
+		return val, true
+	}
+
+	// request.body.<json.path>
+	if len(rest) > 5 && rest[:5] == "body." {
+		jsonPath := rest[5:]
+		return resolveBodyField(reqBody, jsonPath)
+	}
+
+	// request.path.<param> — unresolvable today (no path-template matcher).
+	// Any other request.* sub-key is also unresolvable.
+	return "", false
+}
+
+// resolveBodyField extracts a scalar value from a JSON body using dot-notation.
+// The dotPath is prepended with "$." and parsed via parsePath from sanitizer.go,
+// then extracted via extractAtPath from matcher.go.
+//
+// Only scalar values (string, number, bool) are converted to strings. Objects
+// and arrays return ("", false) as they cannot be meaningfully interpolated.
+func resolveBodyField(body []byte, dotPath string) (string, bool) {
+	if len(body) == 0 {
+		return "", false
+	}
+
+	pp, ok := parsePath("$." + dotPath)
+	if !ok {
+		return "", false
+	}
+
+	var data any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return "", false
+	}
+
+	val, ok := extractAtPath(data, pp.segments)
+	if !ok {
+		return "", false
+	}
+
+	return scalarToString(val)
+}
+
+// scalarToString converts a JSON scalar value to its string representation.
+// Returns ("", false) for non-scalar types (nil, objects, arrays).
+func scalarToString(v any) (string, bool) {
+	switch val := v.(type) {
+	case string:
+		return val, true
+	case float64:
+		// Use strconv for clean formatting (no trailing zeros).
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10), true
+		}
+		return strconv.FormatFloat(val, 'f', -1, 64), true
+	case bool:
+		return strconv.FormatBool(val), true
+	default:
+		// nil, map[string]any, []any — not scalar.
+		return "", false
+	}
+}
+
+// ResolveTemplateBody resolves all {{request.*}} template expressions in body
+// against the incoming HTTP request. It returns the resolved body bytes.
+//
+// If strict is true, any unresolvable expression causes an error describing
+// which expression failed. If strict is false (lenient mode), unresolvable
+// expressions are replaced with an empty string.
+//
+// Non-"request." expressions (e.g., {{state.counter}}) are left as literal
+// text in both modes, providing forward-compatibility for future namespaces.
+//
+// If body contains no "{{" sequence, it is returned unchanged with zero
+// allocations (fast path).
+//
+// ResolveTemplateBody is safe for concurrent use — it is a pure function
+// with no shared mutable state. The request body is read once and cached
+// in memory for the duration of the call.
+func ResolveTemplateBody(body []byte, r *http.Request, strict bool) ([]byte, error) {
+	// Fast path: no template delimiters at all.
+	if !bytes.Contains(body, []byte("{{")) {
+		return body, nil
+	}
+
+	reqBody := readRequestBody(r)
+
+	exprs := scanTemplateExprs(body)
+	if len(exprs) == 0 {
+		return body, nil
+	}
+
+	// Build result by walking through expressions in order.
+	var buf bytes.Buffer
+	buf.Grow(len(body))
+	prev := 0
+
+	for _, expr := range exprs {
+		// Copy literal text before this expression.
+		buf.Write(body[prev:expr.start])
+
+		resolved, ok := resolveExpr(expr.raw, r, reqBody)
+		if !ok {
+			if strict {
+				return nil, fmt.Errorf("httptape: unresolvable template expression: {{%s}}", expr.raw)
+			}
+			// Lenient: replace with empty string (write nothing).
+		} else {
+			buf.WriteString(resolved)
+		}
+		prev = expr.end
+	}
+	// Copy trailing literal text.
+	buf.Write(body[prev:])
+
+	return buf.Bytes(), nil
+}
+
+// ResolveTemplateHeaders resolves all {{request.*}} template expressions in
+// response header values against the incoming HTTP request. It returns a new
+// http.Header map with resolved values.
+//
+// If strict is true, any unresolvable expression causes an error. If strict
+// is false (lenient mode), unresolvable expressions are replaced with an
+// empty string.
+//
+// Non-"request." expressions are left as literal text (forward-compat).
+//
+// Headers that contain no "{{" sequences are copied as-is (fast path per
+// header value).
+//
+// ResolveTemplateHeaders is safe for concurrent use — it is a pure function
+// with no shared mutable state.
+func ResolveTemplateHeaders(h http.Header, r *http.Request, strict bool) (http.Header, error) {
+	if h == nil {
+		return nil, nil
+	}
+
+	reqBody := readRequestBody(r)
+	result := make(http.Header, len(h))
+
+	for key, values := range h {
+		resolved := make([]string, len(values))
+		for i, v := range values {
+			rv, err := resolveTemplateString(v, r, reqBody, strict)
+			if err != nil {
+				return nil, err
+			}
+			resolved[i] = rv
+		}
+		result[key] = resolved
+	}
+
+	return result, nil
+}
+
+// resolveTemplateString resolves all {{...}} expressions in a single string.
+// Used by ResolveTemplateHeaders for individual header values.
+func resolveTemplateString(s string, r *http.Request, reqBody []byte, strict bool) (string, error) {
+	// Fast path: no delimiters.
+	if !bytes.Contains([]byte(s), []byte("{{")) {
+		return s, nil
+	}
+
+	src := []byte(s)
+	exprs := scanTemplateExprs(src)
+	if len(exprs) == 0 {
+		return s, nil
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(len(s))
+	prev := 0
+
+	for _, expr := range exprs {
+		buf.Write(src[prev:expr.start])
+
+		resolved, ok := resolveExpr(expr.raw, r, reqBody)
+		if !ok {
+			if strict {
+				return "", fmt.Errorf("httptape: unresolvable template expression: {{%s}}", expr.raw)
+			}
+			// Lenient: empty string.
+		} else {
+			buf.WriteString(resolved)
+		}
+		prev = expr.end
+	}
+	buf.Write(src[prev:])
+
+	return buf.String(), nil
+}
+
+// readRequestBody reads the full request body and restores it so the body
+// remains readable by downstream handlers. Returns nil if the body is nil
+// or empty.
+func readRequestBody(r *http.Request) []byte {
+	if r.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil
+	}
+	// Restore the body for any downstream readers.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return body
+}

--- a/templating_test.go
+++ b/templating_test.go
@@ -1,0 +1,850 @@
+package httptape
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestScanTemplateExprs(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []templateExpr
+	}{
+		{
+			name: "no expressions",
+			src:  "hello world",
+			want: nil,
+		},
+		{
+			name: "single expression",
+			src:  "Hello {{request.method}}!",
+			want: []templateExpr{
+				{raw: "request.method", start: 6, end: 24},
+			},
+		},
+		{
+			name: "multiple expressions",
+			src:  "{{request.method}} {{request.path}}",
+			want: []templateExpr{
+				{raw: "request.method", start: 0, end: 18},
+				{raw: "request.path", start: 19, end: 35},
+			},
+		},
+		{
+			name: "expression with whitespace",
+			src:  "{{ request.method }}",
+			want: []templateExpr{
+				{raw: "request.method", start: 0, end: 20},
+			},
+		},
+		{
+			name: "unclosed expression",
+			src:  "hello {{request.method",
+			want: nil,
+		},
+		{
+			name: "empty expression",
+			src:  "hello {{}} world",
+			want: []templateExpr{
+				{raw: "", start: 6, end: 10},
+			},
+		},
+		{
+			name: "nested braces not treated as nested",
+			src:  "{{request.headers.X-Key}}",
+			want: []templateExpr{
+				{raw: "request.headers.X-Key", start: 0, end: 25},
+			},
+		},
+		{
+			name: "expression at end of string",
+			src:  "prefix {{request.path}}",
+			want: []templateExpr{
+				{raw: "request.path", start: 7, end: 23},
+			},
+		},
+		{
+			name: "expression at start and end",
+			src:  "{{request.method}} and {{request.path}}",
+			want: []templateExpr{
+				{raw: "request.method", start: 0, end: 18},
+				{raw: "request.path", start: 23, end: 39},
+			},
+		},
+		{
+			name: "only opening braces",
+			src:  "{{ no close",
+			want: nil,
+		},
+		{
+			name: "only closing braces",
+			src:  "no open }}",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scanTemplateExprs([]byte(tt.src))
+			if len(got) != len(tt.want) {
+				t.Fatalf("scanTemplateExprs(%q) returned %d expressions, want %d", tt.src, len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i].raw != tt.want[i].raw {
+					t.Errorf("expr[%d].raw = %q, want %q", i, got[i].raw, tt.want[i].raw)
+				}
+				if got[i].start != tt.want[i].start {
+					t.Errorf("expr[%d].start = %d, want %d", i, got[i].start, tt.want[i].start)
+				}
+				if got[i].end != tt.want[i].end {
+					t.Errorf("expr[%d].end = %d, want %d", i, got[i].end, tt.want[i].end)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveExpr(t *testing.T) {
+	reqBody := []byte(`{"user":{"email":"alice@example.com","age":30},"active":true,"score":99.5}`)
+	req := httptest.NewRequest("POST", "/api/users?page=2&sort=name", bytes.NewReader(reqBody))
+	req.Header.Set("X-Request-Id", "req-abc-123")
+	req.Header.Set("Content-Type", "application/json")
+
+	tests := []struct {
+		name    string
+		expr    string
+		wantVal string
+		wantOk  bool
+	}{
+		{
+			name:    "request.method",
+			expr:    "request.method",
+			wantVal: "POST",
+			wantOk:  true,
+		},
+		{
+			name:    "request.path",
+			expr:    "request.path",
+			wantVal: "/api/users",
+			wantOk:  true,
+		},
+		{
+			name:    "request.url",
+			expr:    "request.url",
+			wantVal: "/api/users?page=2&sort=name",
+			wantOk:  true,
+		},
+		{
+			name:    "request.headers existing",
+			expr:    "request.headers.X-Request-Id",
+			wantVal: "req-abc-123",
+			wantOk:  true,
+		},
+		{
+			name:    "request.headers case insensitive",
+			expr:    "request.headers.x-request-id",
+			wantVal: "req-abc-123",
+			wantOk:  true,
+		},
+		{
+			name:    "request.headers missing",
+			expr:    "request.headers.X-Missing",
+			wantVal: "",
+			wantOk:  false,
+		},
+		{
+			name:    "request.query existing",
+			expr:    "request.query.page",
+			wantVal: "2",
+			wantOk:  true,
+		},
+		{
+			name:    "request.query missing",
+			expr:    "request.query.missing",
+			wantVal: "",
+			wantOk:  false,
+		},
+		{
+			name:    "request.body string field",
+			expr:    "request.body.user.email",
+			wantVal: "alice@example.com",
+			wantOk:  true,
+		},
+		{
+			name:    "request.body number field",
+			expr:    "request.body.user.age",
+			wantVal: "30",
+			wantOk:  true,
+		},
+		{
+			name:    "request.body boolean field",
+			expr:    "request.body.active",
+			wantVal: "true",
+			wantOk:  true,
+		},
+		{
+			name:    "request.body fractional number",
+			expr:    "request.body.score",
+			wantVal: "99.5",
+			wantOk:  true,
+		},
+		{
+			name:    "request.body non-scalar (object)",
+			expr:    "request.body.user",
+			wantVal: "",
+			wantOk:  false,
+		},
+		{
+			name:    "request.body missing field",
+			expr:    "request.body.nonexistent",
+			wantVal: "",
+			wantOk:  false,
+		},
+		{
+			name:    "non-request namespace",
+			expr:    "state.counter",
+			wantVal: "{{state.counter}}",
+			wantOk:  true,
+		},
+		{
+			name:    "request.path.param (unresolvable today)",
+			expr:    "request.path.id",
+			wantVal: "",
+			wantOk:  false,
+		},
+		{
+			name:    "unknown request sub-key",
+			expr:    "request.unknown",
+			wantVal: "",
+			wantOk:  false,
+		},
+		{
+			name:    "empty expression",
+			expr:    "",
+			wantVal: "{{}}",
+			wantOk:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVal, gotOk := resolveExpr(tt.expr, req, reqBody)
+			if gotOk != tt.wantOk {
+				t.Errorf("resolveExpr(%q) ok = %v, want %v", tt.expr, gotOk, tt.wantOk)
+			}
+			if gotVal != tt.wantVal {
+				t.Errorf("resolveExpr(%q) = %q, want %q", tt.expr, gotVal, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestResolveExpr_NilBody(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	val, ok := resolveExpr("request.body.field", req, nil)
+	if ok {
+		t.Errorf("expected unresolvable for nil body, got ok=true, val=%q", val)
+	}
+}
+
+func TestScalarToString(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  any
+		want   string
+		wantOk bool
+	}{
+		{"string", "hello", "hello", true},
+		{"integer float", float64(42), "42", true},
+		{"fractional float", float64(3.14), "3.14", true},
+		{"negative integer", float64(-7), "-7", true},
+		{"zero", float64(0), "0", true},
+		{"true", true, "true", true},
+		{"false", false, "false", true},
+		{"nil", nil, "", false},
+		{"map", map[string]any{"k": "v"}, "", false},
+		{"slice", []any{1, 2}, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := scalarToString(tt.input)
+			if ok != tt.wantOk {
+				t.Errorf("scalarToString(%v) ok = %v, want %v", tt.input, ok, tt.wantOk)
+			}
+			if got != tt.want {
+				t.Errorf("scalarToString(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTemplateBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		method  string
+		path    string
+		headers http.Header
+		reqBody string
+		strict  bool
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "no templates",
+			body:   `{"id": "pay_123"}`,
+			method: "GET",
+			path:   "/test",
+			want:   `{"id": "pay_123"}`,
+		},
+		{
+			name:   "method substitution",
+			body:   `{"method": "{{request.method}}"}`,
+			method: "POST",
+			path:   "/test",
+			want:   `{"method": "POST"}`,
+		},
+		{
+			name:   "path substitution",
+			body:   `{"path": "{{request.path}}"}`,
+			method: "GET",
+			path:   "/users/42",
+			want:   `{"path": "/users/42"}`,
+		},
+		{
+			name:   "url substitution",
+			body:   `{"url": "{{request.url}}"}`,
+			method: "GET",
+			path:   "/users?page=1",
+			want:   `{"url": "/users?page=1"}`,
+		},
+		{
+			name:    "header substitution",
+			body:    `{"key": "{{request.headers.X-Request-Id}}"}`,
+			method:  "GET",
+			path:    "/test",
+			headers: http.Header{"X-Request-Id": {"req-123"}},
+			want:    `{"key": "req-123"}`,
+		},
+		{
+			name:   "query substitution",
+			body:   `{"page": "{{request.query.page}}"}`,
+			method: "GET",
+			path:   "/test?page=5",
+			want:   `{"page": "5"}`,
+		},
+		{
+			name:    "body field substitution",
+			body:    `{"echo_email": "{{request.body.user.email}}"}`,
+			method:  "POST",
+			path:    "/test",
+			reqBody: `{"user":{"email":"bob@example.com"}}`,
+			want:    `{"echo_email": "bob@example.com"}`,
+		},
+		{
+			name:   "multiple substitutions",
+			body:   `{"method":"{{request.method}}","path":"{{request.path}}"}`,
+			method: "PUT",
+			path:   "/api/resource",
+			want:   `{"method":"PUT","path":"/api/resource"}`,
+		},
+		{
+			name:   "lenient unresolvable replaces with empty",
+			body:   `{"val": "{{request.headers.Missing}}"}`,
+			method: "GET",
+			path:   "/test",
+			strict: false,
+			want:   `{"val": ""}`,
+		},
+		{
+			name:    "strict unresolvable returns error",
+			body:    `{"val": "{{request.headers.Missing}}"}`,
+			method:  "GET",
+			path:    "/test",
+			strict:  true,
+			wantErr: true,
+		},
+		{
+			name:   "non-request namespace left as literal",
+			body:   `{"counter": "{{state.counter}}"}`,
+			method: "GET",
+			path:   "/test",
+			want:   `{"counter": "{{state.counter}}"}`,
+		},
+		{
+			name:   "mixed resolvable and literal namespace",
+			body:   `{{request.method}} {{state.x}}`,
+			method: "GET",
+			path:   "/test",
+			want:   `GET {{state.x}}`,
+		},
+		{
+			name:    "idempotency key echo (headline example)",
+			body:    `{"id": "pay_123", "idempotency_key": "{{request.headers.Idempotency-Key}}"}`,
+			method:  "POST",
+			path:    "/payments",
+			headers: http.Header{"Idempotency-Key": {"idem-abc-789"}},
+			want:    `{"id": "pay_123", "idempotency_key": "idem-abc-789"}`,
+		},
+		{
+			name:   "nil body returns nil",
+			body:   "",
+			method: "GET",
+			path:   "/test",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bodyReader io.Reader
+			if tt.reqBody != "" {
+				bodyReader = strings.NewReader(tt.reqBody)
+			}
+			req := httptest.NewRequest(tt.method, tt.path, bodyReader)
+			for k, vs := range tt.headers {
+				for _, v := range vs {
+					req.Header.Add(k, v)
+				}
+			}
+
+			var bodyBytes []byte
+			if tt.body != "" {
+				bodyBytes = []byte(tt.body)
+			}
+
+			got, err := ResolveTemplateBody(bodyBytes, req, tt.strict)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("got %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTemplateBody_NilBody(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	got, err := ResolveTemplateBody(nil, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %q", string(got))
+	}
+}
+
+func TestResolveTemplateBody_FastPath_NoDelimiters(t *testing.T) {
+	body := []byte(`{"no":"templates","here":true}`)
+	req := httptest.NewRequest("GET", "/test", nil)
+	got, err := ResolveTemplateBody(body, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Fast path should return the exact same slice.
+	if &got[0] != &body[0] {
+		t.Error("fast path should return the same slice, got a copy")
+	}
+}
+
+func TestResolveTemplateHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		headers    http.Header
+		method     string
+		path       string
+		reqHeaders http.Header
+		reqBody    string
+		strict     bool
+		want       http.Header
+		wantErr    bool
+	}{
+		{
+			name:    "no templates in headers",
+			headers: http.Header{"Content-Type": {"application/json"}},
+			method:  "GET",
+			path:    "/test",
+			want:    http.Header{"Content-Type": {"application/json"}},
+		},
+		{
+			name:       "header with template",
+			headers:    http.Header{"X-Echo": {"{{request.headers.X-Request-Id}}"}},
+			method:     "GET",
+			path:       "/test",
+			reqHeaders: http.Header{"X-Request-Id": {"id-42"}},
+			want:       http.Header{"X-Echo": {"id-42"}},
+		},
+		{
+			name:    "header with method template",
+			headers: http.Header{"X-Method": {"{{request.method}}"}},
+			method:  "DELETE",
+			path:    "/test",
+			want:    http.Header{"X-Method": {"DELETE"}},
+		},
+		{
+			name:    "multiple header values",
+			headers: http.Header{"X-Multi": {"{{request.method}}", "static"}},
+			method:  "GET",
+			path:    "/test",
+			want:    http.Header{"X-Multi": {"GET", "static"}},
+		},
+		{
+			name:    "lenient mode missing ref",
+			headers: http.Header{"X-Key": {"{{request.headers.Missing}}"}},
+			method:  "GET",
+			path:    "/test",
+			strict:  false,
+			want:    http.Header{"X-Key": {""}},
+		},
+		{
+			name:    "strict mode missing ref",
+			headers: http.Header{"X-Key": {"{{request.headers.Missing}}"}},
+			method:  "GET",
+			path:    "/test",
+			strict:  true,
+			wantErr: true,
+		},
+		{
+			name:   "nil headers returns nil",
+			method: "GET",
+			path:   "/test",
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bodyReader io.Reader
+			if tt.reqBody != "" {
+				bodyReader = strings.NewReader(tt.reqBody)
+			}
+			req := httptest.NewRequest(tt.method, tt.path, bodyReader)
+			for k, vs := range tt.reqHeaders {
+				for _, v := range vs {
+					req.Header.Add(k, v)
+				}
+			}
+
+			got, err := ResolveTemplateHeaders(tt.headers, req, tt.strict)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+
+			for key, wantVals := range tt.want {
+				gotVals := got[key]
+				if len(gotVals) != len(wantVals) {
+					t.Errorf("header %s: got %d values, want %d", key, len(gotVals), len(wantVals))
+					continue
+				}
+				for i := range wantVals {
+					if gotVals[i] != wantVals[i] {
+						t.Errorf("header %s[%d] = %q, want %q", key, i, gotVals[i], wantVals[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestResolveTemplateBody_StrictErrorMessage(t *testing.T) {
+	body := []byte(`prefix {{request.headers.Missing}} suffix`)
+	req := httptest.NewRequest("GET", "/test", nil)
+
+	_, err := ResolveTemplateBody(body, req, true)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "request.headers.Missing") {
+		t.Errorf("error message %q should mention the failed expression", err.Error())
+	}
+	if !strings.Contains(err.Error(), "httptape") {
+		t.Errorf("error message %q should include package prefix", err.Error())
+	}
+}
+
+func TestResolveTemplateBody_BodyFieldTypes(t *testing.T) {
+	reqBody := `{"s":"hello","n":42,"f":3.14,"b":true,"null":null,"obj":{"k":"v"},"arr":[1,2]}`
+
+	tests := []struct {
+		name   string
+		expr   string
+		want   string
+		strict bool
+	}{
+		{"string field", "{{request.body.s}}", "hello", false},
+		{"integer field", "{{request.body.n}}", "42", false},
+		{"float field", "{{request.body.f}}", "3.14", false},
+		{"boolean field", "{{request.body.b}}", "true", false},
+		{"null field lenient", "{{request.body.null}}", "", false},
+		{"object field lenient", "{{request.body.obj}}", "", false},
+		{"array field lenient", "{{request.body.arr}}", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/test", strings.NewReader(reqBody))
+			got, err := ResolveTemplateBody([]byte(tt.expr), req, tt.strict)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("got %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTemplateBody_NonScalarStrict(t *testing.T) {
+	reqBody := `{"obj":{"k":"v"},"arr":[1,2],"null":null}`
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{"object in strict", "{{request.body.obj}}"},
+		{"array in strict", "{{request.body.arr}}"},
+		{"null in strict", "{{request.body.null}}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/test", strings.NewReader(reqBody))
+			_, err := ResolveTemplateBody([]byte(tt.expr), req, true)
+			if err == nil {
+				t.Fatal("expected error for non-scalar in strict mode")
+			}
+		})
+	}
+}
+
+func TestResolveTemplateBody_InvalidJSON(t *testing.T) {
+	req := httptest.NewRequest("POST", "/test", strings.NewReader("not json"))
+	body := []byte(`echo: {{request.body.field}}`)
+
+	// Lenient mode: invalid JSON body -> unresolvable -> empty string.
+	got, err := ResolveTemplateBody(body, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "echo: " {
+		t.Errorf("got %q, want %q", string(got), "echo: ")
+	}
+}
+
+func TestResolveTemplateBody_PreservesRequestBody(t *testing.T) {
+	originalBody := `{"key":"value"}`
+	req := httptest.NewRequest("POST", "/test", strings.NewReader(originalBody))
+
+	body := []byte(`{{request.body.key}}`)
+	_, err := ResolveTemplateBody(body, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Request body should still be readable.
+	remaining, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading body after templating: %v", err)
+	}
+	if string(remaining) != originalBody {
+		t.Errorf("request body after templating = %q, want %q", string(remaining), originalBody)
+	}
+}
+
+func TestResolveBodyField(t *testing.T) {
+	body := []byte(`{"user":{"email":"a@b.com","name":"Alice"},"count":3}`)
+
+	tests := []struct {
+		name   string
+		path   string
+		want   string
+		wantOk bool
+	}{
+		{"top level string", "count", "3", true},
+		{"nested string", "user.email", "a@b.com", true},
+		{"nested name", "user.name", "Alice", true},
+		{"missing field", "user.phone", "", false},
+		{"non-scalar object", "user", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveBodyField(body, tt.path)
+			if ok != tt.wantOk {
+				t.Errorf("resolveBodyField(%q) ok = %v, want %v", tt.path, ok, tt.wantOk)
+			}
+			if got != tt.want {
+				t.Errorf("resolveBodyField(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBodyField_EmptyBody(t *testing.T) {
+	got, ok := resolveBodyField(nil, "field")
+	if ok {
+		t.Errorf("expected false for nil body, got true with value %q", got)
+	}
+
+	got2, ok2 := resolveBodyField([]byte{}, "field")
+	if ok2 {
+		t.Errorf("expected false for empty body, got true with value %q", got2)
+	}
+}
+
+func TestResolveBodyField_InvalidJSON(t *testing.T) {
+	got, ok := resolveBodyField([]byte("not-json"), "field")
+	if ok {
+		t.Errorf("expected false for invalid JSON, got true with value %q", got)
+	}
+}
+
+func TestResolveBodyField_InvalidPath(t *testing.T) {
+	// parsePath rejects paths without the $. prefix -- we prepend it,
+	// but a completely empty path segment should fail.
+	got, ok := resolveBodyField([]byte(`{"a":"b"}`), "")
+	if ok {
+		t.Errorf("expected false for empty path, got true with value %q", got)
+	}
+}
+
+func TestReadRequestBody(t *testing.T) {
+	t.Run("truly nil body", func(t *testing.T) {
+		req := &http.Request{Body: nil}
+		got := readRequestBody(req)
+		if got != nil {
+			t.Errorf("expected nil for truly nil body, got %q", string(got))
+		}
+	})
+
+	t.Run("httptest nil body", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", nil)
+		got := readRequestBody(req)
+		// httptest.NewRequest with nil body sets Body to http.NoBody,
+		// which reads as empty. readRequestBody returns an empty slice.
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %q", string(got))
+		}
+	})
+
+	t.Run("non-nil body", func(t *testing.T) {
+		original := "hello body"
+		req := httptest.NewRequest("POST", "/test", strings.NewReader(original))
+		got := readRequestBody(req)
+		if string(got) != original {
+			t.Errorf("got %q, want %q", string(got), original)
+		}
+		// Verify body is restored.
+		restored, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("re-read error: %v", err)
+		}
+		if string(restored) != original {
+			t.Errorf("restored body = %q, want %q", string(restored), original)
+		}
+	})
+}
+
+func TestResolveTemplateHeaders_EmptyHeaders(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	got, err := ResolveTemplateHeaders(http.Header{}, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty header map, got %v", got)
+	}
+}
+
+func TestResolveTemplateBody_QueryMultipleValues(t *testing.T) {
+	// Query().Get returns the first value.
+	req := httptest.NewRequest("GET", "/test?color=red&color=blue", nil)
+	body := []byte(`{{request.query.color}}`)
+	got, err := ResolveTemplateBody(body, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "red" {
+		t.Errorf("got %q, want %q (first value)", string(got), "red")
+	}
+}
+
+func TestResolveTemplateBody_HeaderCaseInsensitive(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-Custom-Header", "value-123")
+
+	// Template uses different casing.
+	body := []byte(`{{request.headers.x-custom-header}}`)
+	got, err := ResolveTemplateBody(body, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "value-123" {
+		t.Errorf("got %q, want %q", string(got), "value-123")
+	}
+}
+
+func TestResolveTemplateBody_AdjacentExpressions(t *testing.T) {
+	req := httptest.NewRequest("GET", "/path", nil)
+	body := []byte(`{{request.method}}{{request.path}}`)
+	got, err := ResolveTemplateBody(body, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "GET/path" {
+		t.Errorf("got %q, want %q", string(got), "GET/path")
+	}
+}
+
+func TestResolveTemplateBody_MixedResolvableAndUnresolvable(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	body := []byte(`a={{request.method}},b={{request.headers.Missing}},c={{request.path}}`)
+
+	// Lenient mode.
+	got, err := ResolveTemplateBody(body, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "a=GET,b=,c=/test" {
+		t.Errorf("got %q, want %q", string(got), "a=GET,b=,c=/test")
+	}
+}
+
+func TestResolveTemplateBody_UnclosedDelimiterTreatedAsLiteral(t *testing.T) {
+	req := httptest.NewRequest("GET", "/test", nil)
+	body := []byte(`hello {{request.method}} and {{ unclosed`)
+	got, err := ResolveTemplateBody(body, req, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The {{ unclosed part stays as literal since there's no closing }}.
+	if string(got) != "hello GET and {{ unclosed" {
+		t.Errorf("got %q, want %q", string(got), "hello GET and {{ unclosed")
+	}
+}


### PR DESCRIPTION
Closes #45

## Summary

- Adds response templating support that resolves `{{request.*}}` Mustache-style expressions in response bodies and headers against the incoming HTTP request at serve time
- Hand-rolled `{{...}}` scanner (~80 lines of Go, single `bytes.Index` loop) -- no `text/template` dependency
- Two exported resolver functions: `ResolveTemplateBody` and `ResolveTemplateHeaders` -- callable from `Server.ServeHTTP` and by advanced users composing custom servers
- Two new `ServerOption` functions: `WithTemplating(bool)` and `WithStrictTemplating(bool)`
- Reuses `parsePath()` from `sanitizer.go` and `extractAtPath()` from `matcher.go` for JSON body field resolution
- Templating enabled by default; fast-path `bytes.Contains` skip for bodies without `{{`

### Supported expressions

| Expression | Example |
|---|---|
| `{{request.method}}` | `GET`, `POST` |
| `{{request.path}}` | `/users/42/orders` |
| `{{request.url}}` | `/users?page=2` |
| `{{request.headers.<Name>}}` | Header value (case-insensitive via `http.CanonicalHeaderKey`) |
| `{{request.query.<name>}}` | First value of query parameter |
| `{{request.body.<json.path>}}` | Scalar JSON field (dots = path segments) |

### Example: idempotency key echo

```json
{
  "response": {
    "status_code": 200,
    "headers": {
      "X-Idempotency-Key": ["{{request.headers.Idempotency-Key}}"]
    },
    "body": "{\"id\": \"pay_123\", \"idempotency_key\": \"{{request.headers.Idempotency-Key}}\"}"
  }
}
```

## Files changed

- **`templating.go`** (new) -- scanner, resolver, `ResolveTemplateBody`, `ResolveTemplateHeaders`, `scalarToString`
- **`templating_test.go`** (new) -- 30+ table-driven test cases covering all expression types, edge cases, strict/lenient modes
- **`server.go`** (modified) -- 2 new fields (`templating`, `strictTemplating`), 2 new option functions, resolution hook in `ServeHTTP` step 8 (between delay and response write)
- **`server_test.go`** (modified) -- 14 new server-level integration tests for templating

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -race -count=1` passes (all tests green, race-clean)
- [x] `go vet ./...` passes
- [x] `gofmt` clean
- [x] Overall coverage 93.9%, templating.go functions 85-100% per function (target: 90%)
- [x] All 23 acceptance criteria from issue #45 addressed
- [x] No external dependencies (stdlib only)
- [x] No panics in hot paths
- [x] Stored fixtures not modified (pure serve-time transformation)
- [x] Non-`request.` namespaces left as literal text (forward-compat for `state.*` in #46)
- [x] `{{request.path.<param>}}` treated as unresolvable (forward-compat for future path-template matcher)

Generated with [Claude Code](https://claude.com/claude-code)