### PR TITLE
feat: Server-Sent Events support -- record, replay, proxy passthrough (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@
 
 ---
 
-httptape captures HTTP request/response pairs, redacts sensitive data on write,
-and replays them as a mock server. Think WireMock, but with a 3 MB Docker image,
-an embeddable Go library, and a redaction pipeline built into the core.
+httptape captures HTTP request/response pairs (including SSE streams), redacts
+sensitive data on write, and replays them as a mock server. Think WireMock, but
+with a 3 MB Docker image, an embeddable Go library, SSE record/replay with
+per-event timing, and a redaction pipeline built into the core.
 
 **Docs**: [vibewarden.dev/docs/httptape](https://vibewarden.dev/docs/httptape/) · **From**: [VibeWarden](https://vibewarden.dev)
 
@@ -37,6 +38,7 @@ an embeddable Go library, and a redaction pipeline built into the core.
 - **Go mocking libraries** (`gock`, `httpmock`) only work inside test code -- no standalone server, no recording, no fixture management
 - **json-server / Mockoon** -- no recording, no redaction, manual fixture writing only
 - **Nobody does redaction** -- existing tools record raw traffic including secrets and PII. httptape redacts on write -- sensitive data never hits disk
+- **SSE record and replay** -- record Server-Sent Event streams (LLM completions, real-time feeds) with per-event timing, replay them with configurable speed (realtime, accelerated, or instant), and redact PII from individual event payloads. No other Go mocking tool does this
 
 ## Use cases
 
@@ -91,6 +93,42 @@ httptape proxy --upstream https://api.example.com \
 ```
 
 When the upstream is reachable, requests are forwarded and responses are cached in two tiers (L1 in-memory, L2 on disk). When the upstream is down, httptape transparently serves cached responses. See [Proxy Mode](https://vibewarden.dev/docs/httptape/proxy/) for details.
+
+### Recording LLM streaming responses
+Record SSE streams from OpenAI, Anthropic, or any SSE-based API. Each event is stored individually with timing metadata, so replay can simulate the original streaming behavior.
+
+```go
+store := httptape.NewMemoryStore()
+
+// Record -- SSE detection is automatic for text/event-stream responses.
+sanitizer := httptape.NewPipeline(
+    httptape.RedactHeaders("Authorization"),
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+)
+rec := httptape.NewRecorder(store,
+    httptape.WithSanitizer(sanitizer),
+    httptape.WithRoute("openai"),
+)
+defer rec.Close()
+
+client := &http.Client{Transport: rec}
+// Hit the real LLM API -- SSE events are captured with per-event timing.
+resp, _ := client.Post("https://api.openai.com/v1/chat/completions",
+    "application/json", strings.NewReader(`{
+        "model": "gpt-4", "stream": true,
+        "messages": [{"role": "user", "content": "Hello"}]
+    }`))
+io.Copy(io.Discard, resp.Body)
+resp.Body.Close()
+
+// Replay with instant timing for fast tests.
+srv := httptape.NewServer(store, httptape.WithSSETiming(httptape.SSETimingInstant()))
+ts := httptest.NewServer(srv)
+defer ts.Close()
+// Point your code at ts.URL -- streaming responses replay instantly.
+```
+
+See [Recording](https://vibewarden.dev/docs/httptape/recording/) and [Replay](https://vibewarden.dev/docs/httptape/replay/) for details on SSE support.
 
 ## Install
 
@@ -224,6 +262,23 @@ curl -N http://localhost:8081/__httptape/health/stream
 
 `state` mirrors the existing `X-Httptape-Source` header (`live`, `l1-cache`, `l2-cache`). With both flags absent, no endpoints are mounted and no probe goroutine is started — behavior is byte-for-byte unchanged.
 
+### SSE replay
+
+Replay recorded SSE streams with configurable timing. Use `SSETimingInstant()` for fast tests:
+
+```go
+srv := httptape.NewServer(store,
+    httptape.WithSSETiming(httptape.SSETimingInstant()),
+)
+ts := httptest.NewServer(srv)
+defer ts.Close()
+
+resp, _ := http.Get(ts.URL + "/v1/chat/completions")
+// Events are streamed back instantly -- no waiting for original timing.
+```
+
+Other timing modes: `SSETimingRealtime()` preserves original inter-event gaps, `SSETimingAccelerated(10)` replays 10x faster.
+
 ### Import / Export
 
 ```go
@@ -308,6 +363,7 @@ More examples coming. See [`examples/README.md`](examples/README.md) for the ind
 | Redaction on write | **yes** | no | no | no | no |
 | Deterministic faking | **yes** | no | no | no | no |
 | Proxy with fallback | **yes** | no | no | no | no |
+| SSE record/replay | **yes** | no | no | partial | no |
 | Frontend mock backend | **yes** | yes | yes | yes (browser) | no |
 | Fixture import/export | **yes** | partial | no | no | no |
 | Dependencies | **zero** | JVM | npm | npm | 1 |

--- a/decisions.md
+++ b/decisions.md
@@ -8783,6 +8783,157 @@ issue):
 
 ---
 
+### ADR-35: Server-Sent Events (SSE) record / replay / proxy passthrough
+
+**Date**: 2026-04-16
+**Issue**: #124
+**Status**: Accepted
+
+#### Context
+
+LLM APIs (OpenAI, Anthropic, etc.) stream completions via Server-Sent Events
+(SSE). Developers recording these interactions with httptape received a single
+opaque `Body` blob containing concatenated SSE frames with no timing metadata.
+Replay delivered the entire stream instantly, making it useless for testing
+streaming UIs, back-pressure, or timing-dependent logic.
+
+No existing Go HTTP mocking library (gock, httpmock) or standalone tool
+(WireMock, json-server, Mockoon) provides SSE record + replay with per-event
+timing and per-event sanitization. MSW offers mock-side SSE construction but
+not recording of real upstream streams. mitmproxy captures but cannot replay.
+
+This is httptape's strongest competitive differentiator.
+
+#### Decision
+
+##### Type design
+
+**`SSEEvent`** (in `sse.go`): pure value type representing one parsed SSE event.
+
+```go
+type SSEEvent struct {
+    OffsetMS int64  `json:"offset_ms"`        // ms since response headers
+    Type     string `json:"type,omitempty"`    // "event:" field
+    Data     string `json:"data"`             // "data:" field(s), joined with "\n"
+    ID       string `json:"id,omitempty"`     // "id:" field
+    Retry    int    `json:"retry,omitempty"`  // "retry:" field (ms)
+}
+```
+
+**`SSETimingMode`** (in `sse.go`): sealed interface controlling replay timing.
+Three constructors:
+
+- `SSETimingRealtime()` -- replays with original inter-event gaps
+- `SSETimingAccelerated(factor float64)` -- divides gaps by factor (must be > 0;
+  panics otherwise as a constructor guard)
+- `SSETimingInstant()` -- emits all events back-to-back with zero delay
+
+The interface is sealed (unexported `sseTimingMode()` method) so the set of
+implementations is closed. Each type computes its delay from `OffsetMS` deltas.
+
+##### Schema migration
+
+`RecordedResp` gains an `SSEEvents []SSEEvent` field with `json:"sse_events,omitempty"`.
+Body and SSEEvents are mutually exclusive by construction:
+
+- The Recorder populates one or the other, never both.
+- During replay, `IsSSE()` (non-nil, non-empty SSEEvents) takes precedence.
+- Old tapes (before SSE support) have `SSEEvents` nil/empty and continue to
+  work unchanged -- the field is `omitempty`, so existing JSON fixtures round-trip
+  without modification.
+
+No schema version bump is needed. The field is purely additive.
+
+##### Recording approach
+
+`sseRecordingReader` (in `sse.go`) wraps the upstream response body:
+
+1. `io.TeeReader` feeds bytes to both the caller and an `io.Pipe`.
+2. A background goroutine reads from the pipe through `parseSSEStream`,
+   calling `onEvent` for each dispatched event.
+3. `parseSSEStream` follows the W3C SSE specification: blank-line dispatch,
+   comment-line skip, field parsing with colon+space stripping, multi-line
+   data joining, retry as digits-only.
+4. When the caller closes the body (or upstream hits EOF), the pipe is closed,
+   the parser exits, and `onDone` is called.
+
+**Critical ordering**: `onDone` (which persists the tape) is called *before*
+`close(r.done)`, so the tape is saved before `Close()` returns. This is
+essential for synchronous recording mode where the caller expects the tape to
+be in the store immediately after closing the body.
+
+SSE detection is based on `Content-Type: text/event-stream` (case-insensitive,
+parameter-tolerant via `mime.ParseMediaType`). Detection is enabled by default
+(`sseRecording: true` on Recorder) and can be disabled with
+`WithSSERecording(false)`, in which case SSE responses are buffered as regular
+bodies.
+
+##### Replay timing modes
+
+The `Server` gains a `WithSSETiming(mode SSETimingMode)` option (default:
+`SSETimingRealtime`). When serving an SSE tape, `serveSSE` checks for
+`http.Flusher` support, sets SSE-required headers (`Content-Type`,
+`Cache-Control`, `Connection`), writes the status code, then calls
+`replaySSEEvents` which iterates over events, applying the timing mode's
+`delay()` before each write. Each event is written with `writeSSEEvent`
+and flushed individually. Context cancellation (client disconnect) is
+respected between events.
+
+The `Proxy` gains `WithProxySSETiming(mode SSETimingMode)` for L2 fallback
+(default: `SSETimingInstant`). Proxy L2 fallback synthesizes an `*http.Response`
+with a piped body and streams events through it.
+
+##### Sanitization composition
+
+Two new `SanitizeFunc` constructors (in `sanitizer.go`):
+
+- `RedactSSEEventData(paths ...string)` -- applies body-path redaction to each
+  event's Data field independently (treats each Data as a JSON body).
+- `FakeSSEEventData(seed string, paths ...string)` -- applies deterministic
+  faking to each event's Data field.
+
+Both are no-ops for non-SSE tapes. They compose naturally with existing
+pipeline functions -- no new interface or protocol needed. They copy the
+SSEEvents slice before mutation to preserve immutability.
+
+##### Shared `writeSSEEvent` helper
+
+The `writeSSEEvent` function in `sse.go` writes a single SSE event in wire
+format. It is used by:
+
+- `replaySSEEvents` (server replay)
+- `Proxy.sseResponseFromTape` (proxy L2 fallback)
+- `health.go` SSE stream handler (refactored from inline formatting)
+
+This eliminates duplicated SSE wire-format code across the codebase.
+
+#### Consequences
+
+**Positive**
+
+- httptape can record, replay, and sanitize SSE streams from any upstream
+  (LLM APIs, real-time feeds, notification streams) with per-event granularity.
+- Replay timing modes let users choose between realistic simulation
+  (Realtime), faster tests (Accelerated), and instant tests (Instant).
+- Sanitization applies to individual event payloads, so PII in streamed
+  LLM completions is redacted before it touches disk.
+- Backward compatible: no schema version bump, old tapes work unchanged.
+- No new dependencies (stdlib only).
+
+**Negative / trade-offs**
+
+- SSE events are fully parsed and stored individually, increasing fixture file
+  size compared to a raw body blob for streams with many small events. This is
+  acceptable because it enables per-event timing and sanitization.
+- The `sseRecordingReader` adds a background goroutine per SSE response during
+  recording. This is the same pattern used by the async recorder channel and
+  has negligible overhead for the expected use case (a handful of concurrent
+  SSE connections in test/dev).
+- `parseSSEStream` buffers up to 1 MB per line (configurable scanner buffer).
+  Pathological SSE streams with very long lines could hit this limit.
+
+---
+
 ## PM Log
 
 ### 2026-04-16

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -226,6 +226,41 @@ cd frontend && npm run dev
 
 Check the `X-Httptape-Source` response header in browser dev tools to see whether each response is live or cached.
 
+## SSE passthrough and fallback
+
+SSE (`text/event-stream`) responses pass through proxy mode transparently. When the upstream is reachable:
+
+1. The SSE stream is forwarded to the caller unchanged.
+2. A background goroutine parses the stream into discrete `SSEEvent` entries with timing metadata.
+3. When the stream ends, the parsed events are saved to L1 (raw) and L2 (redacted, if a sanitizer is configured).
+
+When the upstream is unavailable, the proxy falls back to cached SSE tapes. L2 fallback synthesizes a streaming response from the stored events using the configured timing mode.
+
+### Proxy SSE timing for fallback
+
+Control the replay timing of cached SSE responses with `WithProxySSETiming`:
+
+```go
+proxy := httptape.NewProxy(l1, l2,
+    httptape.WithProxySSETiming(httptape.SSETimingInstant()), // default
+)
+```
+
+The default is `SSETimingInstant()` -- cached SSE responses are delivered as fast as possible. This is appropriate because proxy fallback is a resilience mechanism, not a simulation tool. Use `SSETimingRealtime()` or `SSETimingAccelerated(N)` if you need realistic streaming behavior during fallback.
+
+### SSE redaction in proxy mode
+
+SSE event redaction is applied only to L2 writes (the persistent, disk-backed cache). L1 always stores raw events for within-session fidelity.
+
+```go
+sanitizer := httptape.NewPipeline(
+    httptape.RedactHeaders("Authorization"),
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+    httptape.FakeSSEEventData("my-seed", "$.user.email"),
+)
+proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
+```
+
 ## Thread safety
 
 `Proxy` is safe for concurrent use by multiple goroutines. `RoundTrip` may be called from multiple goroutines simultaneously.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -122,6 +122,68 @@ Always call `Close` when recording is complete. In async mode, `Close` flushes a
 
 After `Close` returns, any further `RoundTrip` calls pass through to the inner transport without recording.
 
+## SSE (Server-Sent Events) recording
+
+When the upstream responds with `Content-Type: text/event-stream`, the Recorder automatically detects the SSE stream and records it as discrete events rather than a single body blob.
+
+### How SSE detection works
+
+SSE detection triggers on `Content-Type: text/event-stream` (case-insensitive, parameter-tolerant). When detected, the Recorder:
+
+1. Wraps the response body in an internal `sseRecordingReader`.
+2. The caller reads from the wrapper as normal -- bytes pass through unchanged.
+3. A background goroutine parses the SSE stream according to the W3C specification, collecting individual events with timing metadata (`OffsetMS` -- milliseconds since the response headers were received).
+4. When the body is closed (or the upstream hits EOF), all collected events are stored as `RecordedResp.SSEEvents` and the regular `Body` field is left nil. The two fields are mutually exclusive.
+
+### Tape format for SSE responses
+
+SSE tapes store events individually instead of as a raw body:
+
+```json
+{
+  "response": {
+    "status_code": 200,
+    "headers": {"Content-Type": ["text/event-stream"]},
+    "sse_events": [
+      {"offset_ms": 0, "data": "{\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}"},
+      {"offset_ms": 150, "data": "{\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\" world\"}}]}"},
+      {"offset_ms": 310, "type": "done", "data": "[DONE]"}
+    ]
+  }
+}
+```
+
+Each event captures:
+- `offset_ms` -- timing relative to stream start (used for replay timing)
+- `type` -- the SSE event type (omitted when it is the default `message` type)
+- `data` -- the event payload (multi-line data is joined with `\n`)
+- `id` -- the event ID (omitted when absent)
+- `retry` -- reconnection time in ms (omitted when absent)
+
+### Disabling SSE detection
+
+SSE recording is enabled by default. To record SSE responses as regular bodies (one large blob):
+
+```go
+rec := httptape.NewRecorder(store, httptape.WithSSERecording(false))
+```
+
+### SSE recording with redaction
+
+Combine SSE recording with per-event redaction to strip PII from streaming LLM responses:
+
+```go
+sanitizer := httptape.NewPipeline(
+    httptape.RedactHeaders("Authorization"),
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+)
+rec := httptape.NewRecorder(store, httptape.WithSanitizer(sanitizer))
+```
+
+Each event's `Data` field is treated as an independent JSON body, so the same path syntax works as `RedactBodyPaths`. Non-JSON event data is left unchanged.
+
+See [Redaction](sanitization.md) for more on SSE redaction and faking.
+
 ## Thread safety
 
 `Recorder` is safe for concurrent use. Multiple goroutines can call `RoundTrip` simultaneously. `Close` must be called exactly once when recording is complete (though calling it multiple times is safe due to `sync.Once`).

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -135,6 +135,88 @@ For each incoming request, the `Server`:
 
 The `Content-Length` header from the recorded response is removed and re-calculated by `net/http` to ensure it matches the actual body (which may have been modified by sanitization).
 
+## SSE replay
+
+When the `Server` encounters a tape with `SSEEvents` (i.e., `IsSSE()` returns true), it switches to SSE replay mode instead of writing a regular body.
+
+### How SSE replay works
+
+For an SSE tape, `ServeHTTP`:
+
+1. Checks that the `http.ResponseWriter` supports `http.Flusher` (required for streaming). If not, returns 500.
+2. Writes the tape's response headers, setting `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and `Connection: keep-alive`.
+3. Removes `Content-Length` (SSE streams are chunked).
+4. Writes the status code and flushes.
+5. Iterates over `SSEEvents`, applying the configured `SSETimingMode` delay before each event, then writing and flushing it.
+6. Respects context cancellation (client disconnect) between events.
+
+### SSE timing modes
+
+Control inter-event timing with `WithSSETiming`:
+
+```go
+// Replay with original recorded timing (default).
+srv := httptape.NewServer(store, httptape.WithSSETiming(httptape.SSETimingRealtime()))
+
+// Replay 10x faster -- useful for integration tests that need some timing
+// realism without waiting for the full duration.
+srv := httptape.NewServer(store, httptape.WithSSETiming(httptape.SSETimingAccelerated(10)))
+
+// Replay instantly -- all events emitted back-to-back with no delay.
+// Best for unit tests where timing is irrelevant.
+srv := httptape.NewServer(store, httptape.WithSSETiming(httptape.SSETimingInstant()))
+```
+
+| Mode | Behavior | Use case |
+|------|----------|----------|
+| `SSETimingRealtime()` | Original inter-event gaps from `OffsetMS` | UI testing, back-pressure simulation |
+| `SSETimingAccelerated(N)` | Gaps divided by N | Integration tests (fast but still sequential) |
+| `SSETimingInstant()` | Zero delay between events | Unit tests, CI pipelines |
+
+### Example: replaying LLM streaming in tests
+
+```go
+func TestStreamingChat(t *testing.T) {
+    store, _ := httptape.NewFileStore(
+        httptape.WithDirectory("testdata/fixtures"),
+    )
+
+    // Use instant timing so the test completes immediately.
+    srv := httptape.NewServer(store,
+        httptape.WithSSETiming(httptape.SSETimingInstant()),
+    )
+    ts := httptest.NewServer(srv)
+    defer ts.Close()
+
+    // Point your LLM client at the mock server.
+    resp, err := http.Post(ts.URL+"/v1/chat/completions",
+        "application/json",
+        strings.NewReader(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"Hi"}]}`),
+    )
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.Header.Get("Content-Type") != "text/event-stream" {
+        t.Fatal("expected SSE content type")
+    }
+
+    // Read events and verify your streaming logic.
+    scanner := bufio.NewScanner(resp.Body)
+    var eventCount int
+    for scanner.Scan() {
+        line := scanner.Text()
+        if strings.HasPrefix(line, "data: ") {
+            eventCount++
+        }
+    }
+    if eventCount == 0 {
+        t.Error("expected at least one SSE event")
+    }
+}
+```
+
 ## Using with httptest
 
 The most common pattern for tests:

--- a/docs/sanitization.md
+++ b/docs/sanitization.md
@@ -453,6 +453,68 @@ Instead of building pipelines in code, you can define redaction rules in a JSON 
 
 The `fake` action also accepts a `fields` map that selects a typed faker per path -- the JSON-config equivalent of `FakeFieldsWith`. See [Config](config.md#typed-fake-fields) for syntax and the full list of shorthands.
 
+## SSE event redaction
+
+For SSE (Server-Sent Events) responses, httptape provides two `SanitizeFunc` constructors that operate on individual event payloads. Each event's `Data` field is treated as an independent JSON body, so the same path syntax applies as `RedactBodyPaths` and `FakeFields`.
+
+These functions are no-ops for non-SSE tapes, so they compose safely in a pipeline that handles both regular and SSE responses.
+
+### RedactSSEEventData
+
+Redacts fields within each SSE event's JSON data:
+
+```go
+httptape.RedactSSEEventData("$.choices[*].delta.content", "$.usage.prompt_tokens")
+```
+
+Example: an LLM streaming response where each event looks like:
+
+```json
+{"id":"chatcmpl-1","choices":[{"delta":{"content":"The user's SSN is 123-45-6789"}}]}
+```
+
+After `RedactSSEEventData("$.choices[*].delta.content")`:
+
+```json
+{"id":"chatcmpl-1","choices":[{"delta":{"content":"[REDACTED]"}}]}
+```
+
+Each event is redacted independently. Non-JSON event data (e.g., `[DONE]`) is left unchanged.
+
+### FakeSSEEventData
+
+Replaces fields within each SSE event's JSON data with deterministic fakes:
+
+```go
+httptape.FakeSSEEventData("my-seed", "$.user.email", "$.user.name")
+```
+
+This uses the same HMAC-SHA256 faking strategy as `FakeFields`. The same seed and input always produce the same fake, so cross-event consistency is preserved.
+
+### Complete pipeline for LLM streaming
+
+A typical pipeline for recording LLM API traffic with streaming redaction:
+
+```go
+sanitizer := httptape.NewPipeline(
+    // Step 1: Redact auth headers.
+    httptape.RedactHeaders("Authorization", "X-Api-Key"),
+
+    // Step 2: Redact sensitive fields in regular (non-SSE) response bodies.
+    httptape.RedactBodyPaths("$.api_key"),
+
+    // Step 3: Redact PII from SSE event payloads.
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+
+    // Step 4: Fake user identifiers in SSE events with deterministic values.
+    httptape.FakeSSEEventData("my-seed", "$.user.email", "$.user.id"),
+)
+
+rec := httptape.NewRecorder(store, httptape.WithSanitizer(sanitizer))
+```
+
+The order is: headers first, regular body paths, SSE event redaction, SSE event faking. SSE-specific functions are no-ops for non-SSE tapes, and `RedactBodyPaths`/`FakeFields` are no-ops for SSE tapes (since SSE tapes have nil `Body`), so all functions coexist safely in one pipeline.
+
 ## Custom sanitize functions
 
 You can write your own `SanitizeFunc` and add it to the pipeline:

--- a/health.go
+++ b/health.go
@@ -566,7 +566,8 @@ func (h *HealthMonitor) serveStream(w http.ResponseWriter, r *http.Request) {
 				h.reportError(fmt.Errorf("httptape: stream encode: %w", err))
 				return
 			}
-			if _, werr := fmt.Fprintf(w, "data: %s\n\n", payload); werr != nil {
+			ev := SSEEvent{Data: string(payload)}
+			if werr := writeSSEEvent(w, ev); werr != nil {
 				h.reportError(fmt.Errorf("httptape: stream write: %w", werr))
 				return
 			}

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,6 +3,7 @@ package httptape
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -650,7 +651,9 @@ func TestIntegration_RecordReplay_PostWithBody(t *testing.T) {
 // flow using MemoryStore: an upstream SSE server is recorded through the
 // Recorder, then replayed by the Server with instant timing.
 func TestIntegration_SSE_RecordReplay_E2E(t *testing.T) {
-	// Start an upstream that serves SSE.
+	const eventCount = 5
+
+	// Start an upstream that serves SSE with valid JSON event data.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		flusher, ok := w.(http.Flusher)
 		if !ok {
@@ -661,10 +664,8 @@ func TestIntegration_SSE_RecordReplay_E2E(t *testing.T) {
 		w.WriteHeader(200)
 		flusher.Flush()
 
-		for i := 0; i < 5; i++ {
-			body := strings.NewReader("")
-			_ = body
-			w.Write([]byte("data: {\"n\":" + strings.TrimRight(strings.Repeat("0", i+1), "0") + "}\n\n"))
+		for i := 0; i < eventCount; i++ {
+			fmt.Fprintf(w, "data: {\"n\":%d}\n\n", i)
 			flusher.Flush()
 		}
 	}))
@@ -682,9 +683,13 @@ func TestIntegration_SSE_RecordReplay_E2E(t *testing.T) {
 	origBody, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 
-	// The caller should have received the raw SSE bytes.
-	if !strings.Contains(string(origBody), "data:") {
-		t.Error("caller should see raw SSE data")
+	// The caller should have received the raw SSE bytes with valid JSON payloads.
+	origStr := string(origBody)
+	for i := 0; i < eventCount; i++ {
+		want := fmt.Sprintf("data: {\"n\":%d}", i)
+		if !strings.Contains(origStr, want) {
+			t.Errorf("original body missing %q", want)
+		}
 	}
 
 	// Replay.
@@ -709,9 +714,13 @@ func TestIntegration_SSE_RecordReplay_E2E(t *testing.T) {
 		t.Errorf("Content-Type = %q, want text/event-stream", ct)
 	}
 
-	// The replayed body should contain SSE data lines.
-	if !strings.Contains(string(replayBody), "data:") {
-		t.Error("replayed response should contain SSE data")
+	// Verify each event's data was replayed with the correct JSON payload.
+	replayStr := string(replayBody)
+	for i := 0; i < eventCount; i++ {
+		want := fmt.Sprintf("data: {\"n\":%d}", i)
+		if !strings.Contains(replayStr, want) {
+			t.Errorf("replayed body missing %q; got:\n%s", want, replayStr)
+		}
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -2,11 +2,13 @@ package httptape
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // --------------------------------------------------------------------
@@ -641,5 +643,154 @@ func TestIntegration_RecordReplay_PostWithBody(t *testing.T) {
 	}
 	if string(replayBody) != string(origBody) {
 		t.Errorf("replay body = %q, want %q", string(replayBody), string(origBody))
+	}
+}
+
+// TestIntegration_SSE_RecordReplay_E2E tests the full SSE record-and-replay
+// flow using MemoryStore: an upstream SSE server is recorded through the
+// Recorder, then replayed by the Server with instant timing.
+func TestIntegration_SSE_RecordReplay_E2E(t *testing.T) {
+	// Start an upstream that serves SSE.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher.Flush()
+
+		for i := 0; i < 5; i++ {
+			body := strings.NewReader("")
+			_ = body
+			w.Write([]byte("data: {\"n\":" + strings.TrimRight(strings.Repeat("0", i+1), "0") + "}\n\n"))
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store, WithAsync(false))
+	client := &http.Client{Transport: rec}
+
+	// Record.
+	resp, err := client.Get(upstream.URL + "/events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	origBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// The caller should have received the raw SSE bytes.
+	if !strings.Contains(string(origBody), "data:") {
+		t.Error("caller should see raw SSE data")
+	}
+
+	// Replay.
+	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	replayTS := httptest.NewServer(srv)
+	defer replayTS.Close()
+
+	replayResp, err := http.Get(replayTS.URL + "/events")
+	if err != nil {
+		t.Fatalf("replay GET: %v", err)
+	}
+	replayBody, _ := io.ReadAll(replayResp.Body)
+	replayResp.Body.Close()
+
+	if replayResp.StatusCode != 200 {
+		t.Errorf("replay status = %d, want 200", replayResp.StatusCode)
+	}
+
+	// Check Content-Type.
+	ct := replayResp.Header.Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	// The replayed body should contain SSE data lines.
+	if !strings.Contains(string(replayBody), "data:") {
+		t.Error("replayed response should contain SSE data")
+	}
+}
+
+// TestIntegration_SSE_Proxy_E2E tests the SSE proxy passthrough and L2
+// fallback flow end-to-end.
+func TestIntegration_SSE_Proxy_E2E(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher.Flush()
+
+		w.Write([]byte("data: proxy-event-1\n\n"))
+		flusher.Flush()
+		w.Write([]byte("data: proxy-event-2\n\n"))
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	proxy := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+
+	// Passthrough: forward to upstream.
+	req, _ := http.NewRequest("GET", upstream.URL+"/sse", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if !strings.Contains(string(body), "proxy-event-1") {
+		t.Error("proxy should deliver live SSE events")
+	}
+
+	// Wait for onDone save.
+	deadline := time.After(2 * time.Second)
+	for {
+		l2Tapes, _ := l2.List(t.Context(), Filter{})
+		if len(l2Tapes) > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("L2 tape not saved within timeout")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// L2 fallback: upstream is now "down".
+	proxy2 := NewProxy(l1, l2,
+		WithProxyTransport(roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+			return nil, errors.New("down")
+		})),
+		WithProxySSETiming(SSETimingInstant()),
+	)
+
+	req2, _ := http.NewRequest("GET", upstream.URL+"/sse", nil)
+	resp2, err := proxy2.RoundTrip(req2)
+	if err != nil {
+		t.Fatalf("RoundTrip fallback: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	src := resp2.Header.Get("X-Httptape-Source")
+	if src != "l1-cache" && src != "l2-cache" {
+		t.Errorf("X-Httptape-Source = %q, want l1-cache or l2-cache", src)
+	}
+
+	// Read and verify the fallback SSE body.
+	fallbackBody, _ := io.ReadAll(resp2.Body)
+	if !strings.Contains(string(fallbackBody), "proxy-event-1") {
+		t.Errorf("fallback should contain cached events, got: %q", string(fallbackBody))
 	}
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,16 +1,20 @@
 # httptape
 
 > Record, Redact, Replay -- HTTP traffic recording, redaction, and replay.
-> Embeddable Go library, CLI, and Docker image.
+> Embeddable Go library, CLI, and Docker image. SSE (Server-Sent Events) record/replay built in.
 
 ## Overview
 
 httptape captures HTTP request/response pairs ("tapes"), redacts sensitive data
 on write, and replays them as a mock server. Zero dependencies (stdlib only).
+SSE streams (e.g., LLM streaming completions) are recorded as discrete events
+with per-event timing metadata and replayed with configurable speed.
 
 ## Core Types
 
 - Tape: recorded HTTP request/response pair (JSON-serializable)
+- SSEEvent: a single Server-Sent Event with offset timing (OffsetMS, Type, Data, ID, Retry)
+- SSETimingMode: sealed interface controlling SSE replay timing (Realtime, Accelerated, Instant)
 - Recorder: http.RoundTripper that records traffic to a Store
 - Server: http.Handler that replays tapes from a Store
 - Proxy: http.RoundTripper with L1/L2 caching and fallback
@@ -28,7 +32,10 @@ client := &http.Client{Transport: rec}
 ```
 
 Options: WithTransport, WithRoute, WithSanitizer, WithAsync, WithBufferSize,
-WithSampling, WithMaxBodySize, WithSkipRedirects, WithOnError
+WithSampling, WithMaxBodySize, WithSkipRedirects, WithOnError, WithSSERecording
+
+SSE detection: automatic for Content-Type: text/event-stream. Events are parsed
+and stored individually with timing metadata. Disable with WithSSERecording(false).
 
 ## Redaction (Go type: Sanitizer/Pipeline)
 
@@ -37,22 +44,31 @@ sanitizer := httptape.NewPipeline(
     httptape.RedactHeaders("Authorization", "Cookie"),
     httptape.RedactBodyPaths("$.password", "$.ssn"),
     httptape.FakeFields("seed", "$.email", "$.user_id"),
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+    httptape.FakeSSEEventData("seed", "$.user.email"),
 )
 ```
 
 - RedactHeaders: replace header values with "[REDACTED]"
 - RedactBodyPaths: type-aware JSON field redaction
 - FakeFields: deterministic HMAC-SHA256 fakes (emails, UUIDs, numbers, strings)
+- RedactSSEEventData: redact fields within each SSE event's JSON data
+- FakeSSEEventData: deterministic faking within each SSE event's JSON data
 
 ## Replay
 
 ```go
-srv := httptape.NewServer(store)
+srv := httptape.NewServer(store, httptape.WithSSETiming(httptape.SSETimingInstant()))
 ts := httptest.NewServer(srv)
 ```
 
 Options: WithMatcher, WithFallbackStatus, WithFallbackBody, WithOnNoMatch,
-WithCORS, WithDelay, WithErrorRate, WithReplayHeaders
+WithCORS, WithDelay, WithErrorRate, WithReplayHeaders, WithSSETiming
+
+SSE timing modes:
+- SSETimingRealtime(): original inter-event gaps
+- SSETimingAccelerated(factor): gaps divided by factor
+- SSETimingInstant(): all events emitted immediately
 
 ## Proxy (fallback-to-cache)
 
@@ -64,6 +80,8 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 ```
 
 X-Httptape-Source header: "l1-cache" or "l2-cache" when serving from cache.
+SSE responses pass through and are cached with per-event timing. L2 fallback
+replays cached SSE events using WithProxySSETiming (default: instant).
 
 ## Matching
 
@@ -127,6 +145,11 @@ func LoadFixturesFS(fsys fs.FS, dir string) (*MemoryStore, error)
 func ExportBundle(ctx, store, opts...) (io.Reader, error)
 func ImportBundle(ctx, store, reader) error
 func LoadConfigFile(path string) (*Config, error)
+func SSETimingRealtime() SSETimingMode
+func SSETimingAccelerated(factor float64) SSETimingMode
+func SSETimingInstant() SSETimingMode
+func RedactSSEEventData(paths ...string) SanitizeFunc
+func FakeSSEEventData(seed string, paths ...string) SanitizeFunc
 ```
 
 ## Links
@@ -155,11 +178,14 @@ httptape captures HTTP request/response pairs, redacts sensitive data on write, 
 
 **Nobody does redaction.** Existing tools record raw traffic including secrets and PII. Redaction is always an afterthought. httptape redacts on write -- sensitive data never hits disk.
 
+**Nobody does SSE record/replay.** LLM streaming (OpenAI, Anthropic, etc.) uses Server-Sent Events. httptape records SSE streams with per-event timing, replays them with configurable speed, and redacts PII from individual event payloads. WireMock, gock, httpmock, and MSW do not support this.
+
 ## Key features
 
 - **Record** -- wrap any `http.RoundTripper` to capture real HTTP traffic
 - **Redact on write** -- strip headers, body fields, or replace values with deterministic fakes before storage
 - **Replay** -- serve recorded fixtures as a mock `http.Handler`
+- **SSE record/replay** -- record Server-Sent Event streams with per-event timing, replay with configurable speed (realtime, accelerated, instant), redact PII from individual event payloads
 - **Proxy with fallback** -- forward to upstream with automatic fallback to cached responses when the backend is down
 - **Composable matching** -- match requests by method, path, query params, headers, body hash, or fuzzy body fields
 - **Pluggable storage** -- in-memory for tests, filesystem for fixtures, or implement your own `Store`
@@ -583,6 +609,22 @@ Always call `Close` when recording is complete. In async mode, `Close` flushes a
 
 After `Close` returns, any further `RoundTrip` calls pass through to the inner transport without recording.
 
+## SSE (Server-Sent Events) recording
+
+When the upstream responds with `Content-Type: text/event-stream`, the Recorder automatically detects the SSE stream and records it as discrete events (stored in `RecordedResp.SSEEvents`) rather than a single body blob. Each event includes timing metadata (`OffsetMS`) for replay.
+
+SSE recording is enabled by default. Disable with `WithSSERecording(false)`.
+
+Combine with per-event redaction:
+
+```go
+sanitizer := httptape.NewPipeline(
+    httptape.RedactHeaders("Authorization"),
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+)
+rec := httptape.NewRecorder(store, httptape.WithSanitizer(sanitizer))
+```
+
 ## Thread safety
 
 `Recorder` is safe for concurrent use. Multiple goroutines can call `RoundTrip` simultaneously. `Close` must be called exactly once when recording is complete (though calling it multiple times is safe due to `sync.Once`).
@@ -705,6 +747,22 @@ For each incoming request, the `Server`:
 4. If no match is found, calls `OnNoMatch` (if set) and writes the fallback response
 
 The `Content-Length` header from the recorded response is removed and re-calculated by `net/http` to ensure it matches the actual body (which may have been modified by sanitization).
+
+## SSE replay
+
+When the Server encounters a tape with `SSEEvents` (i.e., `IsSSE()` returns true), it switches to SSE replay mode. Events are streamed using the configured `SSETimingMode`.
+
+SSE timing modes (set with `WithSSETiming`):
+
+| Mode | Behavior |
+|------|----------|
+| `SSETimingRealtime()` | Original inter-event gaps (default) |
+| `SSETimingAccelerated(N)` | Gaps divided by N |
+| `SSETimingInstant()` | Zero delay between events |
+
+```go
+srv := httptape.NewServer(store, httptape.WithSSETiming(httptape.SSETimingInstant()))
+```
 
 ## Using with httptest
 
@@ -946,6 +1004,23 @@ With `FakeFields("my-seed", "$.user.email", "$.user.id", "$.user.name")`:
 ```
 
 The key property: if `alice@company.com` appears in another fixture, it will be faked to the same value. This preserves relational consistency across your fixture set.
+
+## SSE event redaction
+
+For SSE responses, two SanitizeFunc constructors operate on individual event payloads:
+
+- `RedactSSEEventData(paths...)` -- redact fields within each SSE event's JSON data
+- `FakeSSEEventData(seed, paths...)` -- deterministic faking within each SSE event's JSON data
+
+Both are no-ops for non-SSE tapes. Each event's Data is treated as an independent JSON body.
+
+```go
+sanitizer := httptape.NewPipeline(
+    httptape.RedactHeaders("Authorization"),
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+    httptape.FakeSSEEventData("my-seed", "$.user.email"),
+)
+```
 
 ## Combining redaction and faking
 
@@ -1249,6 +1324,17 @@ cd frontend && npm run dev
 ```
 
 Check the `X-Httptape-Source` response header in browser dev tools to see whether each response is live or cached.
+
+## SSE passthrough and fallback
+
+SSE responses pass through proxy mode transparently. When the upstream is reachable, the SSE stream is forwarded to the caller while events are parsed and cached to L1/L2. When the upstream is unavailable, L2 fallback replays cached SSE events using `WithProxySSETiming` (default: `SSETimingInstant()`).
+
+```go
+proxy := httptape.NewProxy(l1, l2,
+    httptape.WithProxySanitizer(sanitizer),
+    httptape.WithProxySSETiming(httptape.SSETimingInstant()),
+)
+```
 
 ## Thread safety
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,16 +1,20 @@
 # httptape
 
 > Record, Redact, Replay -- HTTP traffic recording, redaction, and replay.
-> Embeddable Go library, CLI, and Docker image.
+> Embeddable Go library, CLI, and Docker image. SSE (Server-Sent Events) record/replay built in.
 
 ## Overview
 
 httptape captures HTTP request/response pairs ("tapes"), redacts sensitive data
 on write, and replays them as a mock server. Zero dependencies (stdlib only).
+SSE streams (e.g., LLM streaming completions) are recorded as discrete events
+with per-event timing metadata and replayed with configurable speed.
 
 ## Core Types
 
 - Tape: recorded HTTP request/response pair (JSON-serializable)
+- SSEEvent: a single Server-Sent Event with offset timing (OffsetMS, Type, Data, ID, Retry)
+- SSETimingMode: sealed interface controlling SSE replay timing (Realtime, Accelerated, Instant)
 - Recorder: http.RoundTripper that records traffic to a Store
 - Server: http.Handler that replays tapes from a Store
 - Proxy: http.RoundTripper with L1/L2 caching and fallback
@@ -28,7 +32,10 @@ client := &http.Client{Transport: rec}
 ```
 
 Options: WithTransport, WithRoute, WithSanitizer, WithAsync, WithBufferSize,
-WithSampling, WithMaxBodySize, WithSkipRedirects, WithOnError
+WithSampling, WithMaxBodySize, WithSkipRedirects, WithOnError, WithSSERecording
+
+SSE detection: automatic for Content-Type: text/event-stream. Events are parsed
+and stored individually with timing metadata. Disable with WithSSERecording(false).
 
 ## Redaction (Go type: Sanitizer/Pipeline)
 
@@ -37,22 +44,31 @@ sanitizer := httptape.NewPipeline(
     httptape.RedactHeaders("Authorization", "Cookie"),
     httptape.RedactBodyPaths("$.password", "$.ssn"),
     httptape.FakeFields("seed", "$.email", "$.user_id"),
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+    httptape.FakeSSEEventData("seed", "$.user.email"),
 )
 ```
 
 - RedactHeaders: replace header values with "[REDACTED]"
 - RedactBodyPaths: type-aware JSON field redaction
 - FakeFields: deterministic HMAC-SHA256 fakes (emails, UUIDs, numbers, strings)
+- RedactSSEEventData: redact fields within each SSE event's JSON data
+- FakeSSEEventData: deterministic faking within each SSE event's JSON data
 
 ## Replay
 
 ```go
-srv := httptape.NewServer(store)
+srv := httptape.NewServer(store, httptape.WithSSETiming(httptape.SSETimingInstant()))
 ts := httptest.NewServer(srv)
 ```
 
 Options: WithMatcher, WithFallbackStatus, WithFallbackBody, WithOnNoMatch,
-WithCORS, WithDelay, WithErrorRate, WithReplayHeaders
+WithCORS, WithDelay, WithErrorRate, WithReplayHeaders, WithSSETiming
+
+SSE timing modes:
+- SSETimingRealtime(): original inter-event gaps
+- SSETimingAccelerated(factor): gaps divided by factor
+- SSETimingInstant(): all events emitted immediately
 
 ## Proxy (fallback-to-cache)
 
@@ -64,6 +80,8 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 ```
 
 X-Httptape-Source header: "l1-cache" or "l2-cache" when serving from cache.
+SSE responses pass through and are cached with per-event timing. L2 fallback
+replays cached SSE events using WithProxySSETiming (default: instant).
 
 ## Matching
 
@@ -113,6 +131,15 @@ docker pull ghcr.io/vibewarden/httptape:latest
 ]}
 ```
 
+## How it compares
+
+| Feature | httptape | WireMock | gock/httpmock | MSW |
+|---|---|---|---|---|
+| SSE record/replay | **yes** | no | no | partial (mock-only) |
+| Redaction on write | **yes** | no | no | no |
+| Embeddable in Go | **yes** | no (Java) | yes | no (browser) |
+| Proxy with fallback | **yes** | no | no | no |
+
 ## Key APIs
 
 ```go
@@ -127,6 +154,11 @@ func LoadFixturesFS(fsys fs.FS, dir string) (*MemoryStore, error)
 func ExportBundle(ctx, store, opts...) (io.Reader, error)
 func ImportBundle(ctx, store, reader) error
 func LoadConfigFile(path string) (*Config, error)
+func SSETimingRealtime() SSETimingMode
+func SSETimingAccelerated(factor float64) SSETimingMode
+func SSETimingInstant() SSETimingMode
+func RedactSSEEventData(paths ...string) SanitizeFunc
+func FakeSSEEventData(seed string, paths ...string) SanitizeFunc
 ```
 
 ## Links

--- a/proxy.go
+++ b/proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -34,6 +35,9 @@ type Proxy struct {
 	route      string                                    // logical route label
 	onError    func(error)                               // error callback
 	isFallback func(err error, resp *http.Response) bool // determines when to fall back
+
+	// sseReplayTiming controls SSE replay timing for L2 fallback.
+	sseReplayTiming SSETimingMode
 
 	// health is the optional HealthMonitor enabled via WithProxyHealthEndpoint.
 	// nil when the option is absent — every call site is nil-receiver-safe so
@@ -108,6 +112,15 @@ func WithProxyOnError(fn func(error)) ProxyOption {
 func WithProxyFallbackOn(fn func(err error, resp *http.Response) bool) ProxyOption {
 	return func(p *Proxy) {
 		p.isFallback = fn
+	}
+}
+
+// WithProxySSETiming sets the SSE timing mode used when replaying cached
+// SSE tapes from L2 fallback. Defaults to SSETimingInstant (emit all
+// events immediately in degraded mode).
+func WithProxySSETiming(mode SSETimingMode) ProxyOption {
+	return func(p *Proxy) {
+		p.sseReplayTiming = mode
 	}
 }
 
@@ -224,11 +237,12 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) *Proxy {
 	}
 
 	p := &Proxy{
-		transport: http.DefaultTransport,
-		l1:        l1,
-		l2:        l2,
-		sanitizer: NewPipeline(),
-		matcher:   DefaultMatcher(),
+		transport:       http.DefaultTransport,
+		l1:              l1,
+		l2:              l2,
+		sanitizer:       NewPipeline(),
+		matcher:         DefaultMatcher(),
+		sseReplayTiming: SSETimingInstant(),
 		isFallback: func(err error, _ *http.Response) bool {
 			return err != nil
 		},
@@ -365,7 +379,12 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 		return p.fallback(req, resp, transportErr)
 	}
 
-	// 4. Success path: capture response body.
+	// 4. SSE detection on success path.
+	if isSSEContentType(resp.Header.Get("Content-Type")) {
+		return p.roundTripSSE(req, resp, reqBody)
+	}
+
+	// 5. Success path: capture response body (non-SSE).
 	var respBody []byte
 	if resp.Body != nil {
 		var err error
@@ -378,11 +397,11 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	// 5. Detect body encodings.
+	// 6. Detect body encodings.
 	reqBodyEncoding := detectBodyEncoding(req.Header.Get("Content-Type"))
 	respBodyEncoding := detectBodyEncoding(resp.Header.Get("Content-Type"))
 
-	// 6. Build raw tape.
+	// 7. Build raw tape.
 	recordedReq := RecordedReq{
 		Method:       req.Method,
 		URL:          req.URL.String(),
@@ -400,21 +419,21 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	rawTape := NewTape(p.route, recordedReq, recordedResp)
 
-	// 7. Save raw to L1 (synchronous, in-memory, fast).
+	// 8. Save raw to L1 (synchronous, in-memory, fast).
 	if saveErr := p.l1.Save(req.Context(), rawTape); saveErr != nil {
 		p.onErrorSafe(saveErr)
 	}
 
-	// 8. Sanitize and save to L2 (synchronous).
+	// 9. Sanitize and save to L2 (synchronous).
 	sanitizedTape := p.sanitizer.Sanitize(rawTape)
 	if saveErr := p.l2.Save(req.Context(), sanitizedTape); saveErr != nil {
 		p.onErrorSafe(saveErr)
 	}
 
-	// 9. Update health state (no-op when health surface disabled).
+	// 10. Update health state (no-op when health surface disabled).
 	p.health.observe(StateLive)
 
-	// 10. Return real response (with body restored).
+	// 11. Return real response (with body restored).
 	return resp, nil
 }
 
@@ -465,6 +484,76 @@ func (p *Proxy) matchFromStore(ctx context.Context, req *http.Request, store Sto
 	return p.matcher.Match(req, tapes)
 }
 
+// roundTripSSE handles SSE responses in the proxy success path. The body
+// is wrapped in an sseRecordingReader that delivers bytes to the caller
+// unchanged while a background goroutine parses SSE events. When the
+// stream completes, the tape is saved to L1 and L2.
+func (p *Proxy) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte) (*http.Response, error) {
+	startTime := time.Now()
+	respHeaders := resp.Header.Clone()
+
+	reqBodyEncoding := detectBodyEncoding(req.Header.Get("Content-Type"))
+
+	recordedReq := RecordedReq{
+		Method:       req.Method,
+		URL:          req.URL.String(),
+		Headers:      req.Header.Clone(),
+		Body:         reqBody,
+		BodyHash:     BodyHashFromBytes(reqBody),
+		BodyEncoding: reqBodyEncoding,
+	}
+
+	var mu sync.Mutex
+	var events []SSEEvent
+
+	onEvent := func(ev SSEEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}
+
+	onDone := func(parseErr error) {
+		mu.Lock()
+		collectedEvents := make([]SSEEvent, len(events))
+		copy(collectedEvents, events)
+		mu.Unlock()
+
+		truncated := parseErr != nil
+		if truncated {
+			p.onErrorSafe(fmt.Errorf("httptape: proxy SSE stream truncated: %w", parseErr))
+		}
+
+		recordedResp := RecordedResp{
+			StatusCode: resp.StatusCode,
+			Headers:    respHeaders,
+			Body:       nil,
+			SSEEvents:  collectedEvents,
+			Truncated:  truncated,
+		}
+
+		rawTape := NewTape(p.route, recordedReq, recordedResp)
+
+		// Save raw to L1.
+		if saveErr := p.l1.Save(context.Background(), rawTape); saveErr != nil {
+			p.onErrorSafe(saveErr)
+		}
+
+		// Sanitize and save to L2.
+		sanitizedTape := p.sanitizer.Sanitize(rawTape)
+		if saveErr := p.l2.Save(context.Background(), sanitizedTape); saveErr != nil {
+			p.onErrorSafe(saveErr)
+		}
+
+		// Update health state.
+		p.health.observe(StateLive)
+	}
+
+	wrapper := newSSERecordingReader(resp.Body, startTime, onEvent, onDone)
+	resp.Body = wrapper
+
+	return resp, nil
+}
+
 // tapeToResponse synthesizes an *http.Response from a cached Tape.
 // The source parameter is set as the X-Httptape-Source header to indicate
 // where the response came from ("l1-cache" or "l2-cache"). The same value
@@ -479,19 +568,55 @@ func (p *Proxy) tapeToResponse(tape Tape, source string) *http.Response {
 	// due to sanitization. Let the HTTP stack set it from actual body size.
 	header.Del("Content-Length")
 
+	// Update the health state machine (no-op when the health surface is
+	// disabled). A nil-receiver call here keeps the default-off path free.
+	p.health.observe(SourceState(source))
+
+	// SSE tape: build a streaming body via an io.Pipe.
+	if tape.Response.IsSSE() {
+		return p.sseResponseFromTape(tape, header)
+	}
+
 	body := tape.Response.Body
 	if body == nil {
 		body = []byte{}
 	}
 
-	// Update the health state machine (no-op when the health surface is
-	// disabled). A nil-receiver call here keeps the default-off path free.
-	p.health.observe(SourceState(source))
-
 	return &http.Response{
 		StatusCode: tape.Response.StatusCode,
 		Header:     header,
 		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}
+
+// sseResponseFromTape synthesizes an *http.Response with a streaming body
+// for an SSE tape. A goroutine writes events into a pipe using the
+// configured sseReplayTiming mode.
+func (p *Proxy) sseResponseFromTape(tape Tape, header http.Header) *http.Response {
+	header.Set("Content-Type", "text/event-stream")
+
+	pr, pw := io.Pipe()
+
+	go func() {
+		// Create a no-op flusher for pipe writes (flushing is meaningless
+		// for a pipe -- the reader sees bytes immediately).
+		for i, ev := range tape.Response.SSEEvents {
+			d := p.sseReplayTiming.delay(tape.Response.SSEEvents, i)
+			if d > 0 {
+				time.Sleep(d)
+			}
+			if err := writeSSEEvent(pw, ev); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}
+		pw.Close()
+	}()
+
+	return &http.Response{
+		StatusCode: tape.Response.StatusCode,
+		Header:     header,
+		Body:       pr,
 	}
 }
 

--- a/race_test.go
+++ b/race_test.go
@@ -260,3 +260,105 @@ func TestServer_ConcurrentServeHTTP(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestRecorder_ConcurrentSSERecording exercises concurrent SSE recording
+// under the race detector, verifying the goroutine + io.Pipe path is safe.
+func TestRecorder_ConcurrentSSERecording(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		fmt.Fprint(w, "data: event1\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "data: event2\n\n")
+		flusher.Flush()
+	}))
+	defer backend.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store,
+		WithTransport(backend.Client().Transport),
+		WithRoute("sse-race"),
+	)
+
+	const n = 20
+	var wg sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req, err := http.NewRequest("GET", backend.URL+fmt.Sprintf("/stream/%d", i), nil)
+			if err != nil {
+				t.Errorf("NewRequest error: %v", err)
+				return
+			}
+			resp, err := rec.RoundTrip(req)
+			if err != nil {
+				t.Errorf("RoundTrip(%d) error: %v", i, err)
+				return
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}(i)
+	}
+	wg.Wait()
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+}
+
+// TestServer_ConcurrentSSEReplay exercises concurrent SSE replay under the
+// race detector.
+func TestServer_ConcurrentSSEReplay(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Pre-load SSE tapes.
+	for i := 0; i < 5; i++ {
+		tape := NewTape("sse-race", RecordedReq{
+			Method:  "GET",
+			URL:     fmt.Sprintf("/stream/%d", i),
+			Headers: http.Header{},
+		}, RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"text/event-stream"}},
+			SSEEvents: []SSEEvent{
+				{OffsetMS: 0, Data: fmt.Sprintf("event-%d-a", i)},
+				{OffsetMS: 10, Data: fmt.Sprintf("event-%d-b", i)},
+			},
+		})
+		if err := store.Save(ctx, tape); err != nil {
+			t.Fatalf("Save() error: %v", err)
+		}
+	}
+
+	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	const n = 50
+	var wg sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			path := fmt.Sprintf("/stream/%d", i%5)
+			resp, err := http.Get(ts.URL + path)
+			if err != nil {
+				t.Errorf("GET %s error: %v", path, err)
+				return
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}(i)
+	}
+	wg.Wait()
+}

--- a/recorder.go
+++ b/recorder.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // Sanitizer transforms a Tape before it is persisted, redacting or faking
@@ -33,24 +34,25 @@ type Sanitizer interface {
 // called from multiple goroutines simultaneously. Close must be called exactly
 // once when recording is complete.
 type Recorder struct {
-	transport http.RoundTripper // inner transport to delegate to
-	store     Store             // where to persist tapes
-	route     string            // logical route label for all tapes produced
-	sanitizer Sanitizer         // always set; defaults to no-op Pipeline
-	async     bool              // true = non-blocking writes via channel
-	sampleRate float64          // 0.0–1.0; 1.0 = record everything
-	randFloat func() float64   // returns [0.0, 1.0); injectable for testing
-	bufSize   int               // channel buffer size (only used when async=true)
-	onError       func(error)   // callback for async write errors; defaults to no-op
-	maxBodySize   int           // max body size in bytes; 0 = no limit
-	skipRedirects bool          // when true, skip recording 3xx responses
+	transport     http.RoundTripper // inner transport to delegate to
+	store         Store             // where to persist tapes
+	route         string            // logical route label for all tapes produced
+	sanitizer     Sanitizer         // always set; defaults to no-op Pipeline
+	async         bool              // true = non-blocking writes via channel
+	sampleRate    float64           // 0.0–1.0; 1.0 = record everything
+	randFloat     func() float64    // returns [0.0, 1.0); injectable for testing
+	bufSize       int               // channel buffer size (only used when async=true)
+	onError       func(error)       // callback for async write errors; defaults to no-op
+	maxBodySize   int               // max body size in bytes; 0 = no limit
+	skipRedirects bool              // when true, skip recording 3xx responses
+	sseRecording  bool              // true = detect and record SSE streams (default true)
 
 	// async internals
-	sendMu    sync.Mutex   // coordinates closed-check-then-send with close-channel
-	closed    atomic.Bool  // set to true when Close is called; guards against send-on-closed-channel
+	sendMu    sync.Mutex    // coordinates closed-check-then-send with close-channel
+	closed    atomic.Bool   // set to true when Close is called; guards against send-on-closed-channel
 	tapeCh    chan Tape     // buffered channel for async mode
 	done      chan struct{} // closed when background goroutine exits
-	closeOnce sync.Once    // ensures Close is idempotent
+	closeOnce sync.Once     // ensures Close is idempotent
 }
 
 // RecorderOption configures a Recorder.
@@ -140,6 +142,16 @@ func WithMaxBodySize(n int) RecorderOption {
 	}
 }
 
+// WithSSERecording controls whether SSE detection and stream-aware
+// recording is enabled. When true (default), responses with Content-Type
+// text/event-stream are parsed into discrete SSEEvent entries with timing
+// metadata. When false, SSE responses are buffered as regular bodies.
+func WithSSERecording(enabled bool) RecorderOption {
+	return func(r *Recorder) {
+		r.sseRecording = enabled
+	}
+}
+
 // WithSkipRedirects controls whether intermediate redirect responses (3xx)
 // are skipped during recording. When true, 3xx responses are not recorded --
 // only the final non-redirect response is stored. When false (default),
@@ -195,13 +207,14 @@ func NewRecorder(store Store, opts ...RecorderOption) *Recorder {
 	}
 
 	r := &Recorder{
-		transport:  http.DefaultTransport,
-		store:      store,
-		sanitizer:  NewPipeline(), // default no-op sanitizer
-		async:      true,
-		sampleRate: 1.0,
-		randFloat:  rand.Float64,
-		bufSize:    1024,
+		transport:    http.DefaultTransport,
+		store:        store,
+		sanitizer:    NewPipeline(), // default no-op sanitizer
+		async:        true,
+		sampleRate:   1.0,
+		randFloat:    rand.Float64,
+		bufSize:      1024,
+		sseRecording: true,
 	}
 
 	for _, opt := range opts {
@@ -271,6 +284,12 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, nil
 	}
 
+	// SSE detection: if the response is text/event-stream and SSE recording
+	// is enabled, use the streaming recording path instead of buffering.
+	if r.sseRecording && isSSEContentType(resp.Header.Get("Content-Type")) {
+		return r.roundTripSSE(req, resp, reqBody)
+	}
+
 	// Capture response body.
 	var respBody []byte
 	if resp.Body != nil {
@@ -338,17 +357,101 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	tape = r.sanitizer.Sanitize(tape)
 
 	// Persist the tape.
+	r.persistTape(req.Context(), tape)
+
+	return resp, nil
+}
+
+// roundTripSSE handles the SSE recording path. The response body is wrapped
+// in an sseRecordingReader that delivers bytes to the caller unchanged while
+// parsing SSE events in a background goroutine. Tape persistence is deferred
+// until the caller finishes consuming the body (Close or EOF).
+func (r *Recorder) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte) (*http.Response, error) {
+	startTime := time.Now()
+	respHeaders := resp.Header.Clone()
+
+	var mu sync.Mutex
+	var events []SSEEvent
+
+	reqBodyEncoding := detectBodyEncoding(req.Header.Get("Content-Type"))
+
+	// Apply body truncation to request body if configured.
+	var reqTruncated bool
+	var reqOrigSize int64
+	if r.maxBodySize > 0 && len(reqBody) > r.maxBodySize {
+		reqOrigSize = int64(len(reqBody))
+		reqBody = reqBody[:r.maxBodySize]
+		reqTruncated = true
+		if r.onError != nil {
+			r.onError(fmt.Errorf("httptape: request body truncated from %d to %d bytes", reqOrigSize, r.maxBodySize))
+		}
+	}
+
+	// Build the request portion of the tape now (it won't change).
+	recordedReq := RecordedReq{
+		Method:           req.Method,
+		URL:              req.URL.String(),
+		Headers:          req.Header.Clone(),
+		Body:             reqBody,
+		BodyHash:         BodyHashFromBytes(reqBody),
+		BodyEncoding:     reqBodyEncoding,
+		Truncated:        reqTruncated,
+		OriginalBodySize: reqOrigSize,
+	}
+
+	// Capture the request context for use in onDone. The context may be
+	// cancelled by the time the body is fully consumed, so we use
+	// context.Background for the save operation.
+	onEvent := func(ev SSEEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}
+
+	onDone := func(parseErr error) {
+		mu.Lock()
+		collectedEvents := make([]SSEEvent, len(events))
+		copy(collectedEvents, events)
+		mu.Unlock()
+
+		truncated := parseErr != nil
+		if truncated && r.onError != nil {
+			r.onError(fmt.Errorf("httptape: SSE stream truncated: %w", parseErr))
+		}
+
+		recordedResp := RecordedResp{
+			StatusCode: resp.StatusCode,
+			Headers:    respHeaders,
+			Body:       nil,
+			SSEEvents:  collectedEvents,
+			Truncated:  truncated,
+		}
+
+		tape := NewTape(r.route, recordedReq, recordedResp)
+		tape = r.sanitizer.Sanitize(tape)
+		r.persistTape(context.Background(), tape)
+	}
+
+	wrapper := newSSERecordingReader(resp.Body, startTime, onEvent, onDone)
+	resp.Body = wrapper
+
+	return resp, nil
+}
+
+// persistTape saves a tape to the store, using the async channel if
+// configured, or synchronously otherwise.
+func (r *Recorder) persistTape(ctx context.Context, tape Tape) {
 	if r.async {
 		r.sendMu.Lock()
 		if r.closed.Load() {
 			r.sendMu.Unlock()
-			// recorder closed — drop tape silently
+			// recorder closed -- drop tape silently
 		} else {
 			select {
 			case r.tapeCh <- tape:
 				// sent
 			default:
-				// channel full — drop tape, call onError if set
+				// channel full -- drop tape, call onError if set
 				if r.onError != nil {
 					r.onError(fmt.Errorf("httptape: recorder buffer full, tape dropped"))
 				}
@@ -356,13 +459,11 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 			r.sendMu.Unlock()
 		}
 	} else {
-		saveErr := r.store.Save(req.Context(), tape)
+		saveErr := r.store.Save(ctx, tape)
 		if saveErr != nil && r.onError != nil {
 			r.onError(saveErr)
 		}
 	}
-
-	return resp, nil
 }
 
 // Close flushes all pending asynchronous recordings and waits for the

--- a/sanitizer.go
+++ b/sanitizer.go
@@ -572,3 +572,63 @@ func fakeNumericID(hash []byte) float64 {
 func fakeString(hash []byte) string {
 	return "fake_" + hex.EncodeToString(hash[:4])
 }
+
+// RedactSSEEventData returns a SanitizeFunc that applies body-path
+// redaction to each SSE event's Data field in the response. Each event's
+// Data is treated as an independent JSON body. Non-JSON Data is left
+// unchanged.
+//
+// For non-SSE tapes (SSEEvents is nil/empty), this function is a no-op.
+//
+// Paths use the same JSONPath-like syntax as RedactBodyPaths.
+func RedactSSEEventData(paths ...string) SanitizeFunc {
+	var parsed []parsedPath
+	for _, p := range paths {
+		if pp, ok := parsePath(p); ok {
+			parsed = append(parsed, pp)
+		}
+	}
+
+	return func(t Tape) Tape {
+		if !t.Response.IsSSE() {
+			return t
+		}
+		events := make([]SSEEvent, len(t.Response.SSEEvents))
+		copy(events, t.Response.SSEEvents)
+		for i := range events {
+			events[i].Data = string(redactBodyFields([]byte(events[i].Data), parsed))
+		}
+		t.Response.SSEEvents = events
+		return t
+	}
+}
+
+// FakeSSEEventData returns a SanitizeFunc that applies deterministic
+// faking to each SSE event's Data field in the response. Each event's
+// Data is treated as an independent JSON body. Non-JSON Data is left
+// unchanged.
+//
+// For non-SSE tapes (SSEEvents is nil/empty), this function is a no-op.
+//
+// Paths use the same JSONPath-like syntax as FakeFields.
+func FakeSSEEventData(seed string, paths ...string) SanitizeFunc {
+	var parsed []parsedPath
+	for _, p := range paths {
+		if pp, ok := parsePath(p); ok {
+			parsed = append(parsed, pp)
+		}
+	}
+
+	return func(t Tape) Tape {
+		if !t.Response.IsSSE() {
+			return t
+		}
+		events := make([]SSEEvent, len(t.Response.SSEEvents))
+		copy(events, t.Response.SSEEvents)
+		for i := range events {
+			events[i].Data = string(fakeBodyFields([]byte(events[i].Data), parsed, seed))
+		}
+		t.Response.SSEEvents = events
+		return t
+	}
+}

--- a/server.go
+++ b/server.go
@@ -327,5 +327,5 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, tape Tape) {
 	flusher.Flush()
 
 	// Replay events with the configured timing.
-	_ = replaySSEEvents(r.Context(), w, flusher, tape.Response.SSEEvents, s.sseTiming)
+	_ = replaySSEEvents(r.Context(), w, flusher, tape.Response.SSEEvents, s.sseTiming) //nolint:errcheck // SSE replay write failure is not actionable
 }

--- a/server.go
+++ b/server.go
@@ -16,14 +16,15 @@ import (
 type Server struct {
 	store          Store
 	matcher        Matcher
-	fallbackStatus int              // HTTP status when no tape matches
-	fallbackBody   []byte           // response body when no tape matches
+	fallbackStatus int                 // HTTP status when no tape matches
+	fallbackBody   []byte              // response body when no tape matches
 	onNoMatch      func(*http.Request) // optional callback when no tape matches
-	cors           bool             // if true, add CORS headers to all responses
-	delay          time.Duration    // fixed delay before every response; zero means no delay
-	errorRate      float64          // fraction of requests that return 500 (0.0-1.0)
-	randFloat      func() float64   // random number generator (injectable for testing)
-	replayHeaders  map[string]string // headers injected into every replayed response
+	cors           bool                // if true, add CORS headers to all responses
+	delay          time.Duration       // fixed delay before every response; zero means no delay
+	errorRate      float64             // fraction of requests that return 500 (0.0-1.0)
+	randFloat      func() float64      // random number generator (injectable for testing)
+	replayHeaders  map[string]string   // headers injected into every replayed response
+	sseTiming      SSETimingMode       // controls SSE replay inter-event timing
 }
 
 // ServerOption configures a Server.
@@ -109,6 +110,17 @@ func WithReplayHeaders(key, value string) ServerOption {
 	}
 }
 
+// WithSSETiming sets the inter-event timing mode for SSE tape replay.
+// Defaults to SSETimingRealtime (replay with original inter-event gaps).
+//
+// Modes:
+//   - SSETimingRealtime(): replay with original timing
+//   - SSETimingAccelerated(factor): divide gaps by factor (must be > 0)
+//   - SSETimingInstant(): emit all events immediately, no delay
+func WithSSETiming(mode SSETimingMode) ServerOption {
+	return func(s *Server) { s.sseTiming = mode }
+}
+
 // withRandFloat overrides the random number generator for testing.
 // This is unexported -- only used in tests to make error simulation
 // deterministic.
@@ -139,6 +151,7 @@ func NewServer(store Store, opts ...ServerOption) *Server {
 		matcher:        DefaultMatcher(),
 		fallbackStatus: http.StatusNotFound,
 		fallbackBody:   []byte("httptape: no matching tape found"),
+		sseTiming:      SSETimingRealtime(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -258,20 +271,61 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 8. Write the matched tape's response.
-	// 8a: copy response headers (clone slices to prevent aliasing with tape data).
+	// 8. Check if this is an SSE tape.
+	if tape.Response.IsSSE() {
+		s.serveSSE(w, r, tape)
+		return
+	}
+
+	// 9. Write the matched tape's response (non-SSE path).
+	// 9a: copy response headers (clone slices to prevent aliasing with tape data).
 	for key, values := range tape.Response.Headers {
 		w.Header()[key] = append([]string(nil), values...)
 	}
-	// 8b: apply replay header overrides (if any).
+	// 9b: apply replay header overrides (if any).
 	for key, value := range s.replayHeaders {
 		w.Header().Set(key, value)
 	}
-	// 8c: remove Content-Length — the recorded value may be stale if the body
+	// 9c: remove Content-Length — the recorded value may be stale if the body
 	// was modified by sanitization. Let net/http set it from the actual body.
 	w.Header().Del("Content-Length")
-	// 8d: write status code.
+	// 9d: write status code.
 	w.WriteHeader(tape.Response.StatusCode)
-	// 8e: write body.
+	// 9e: write body.
 	w.Write(tape.Response.Body) //nolint:errcheck // response write failure is not actionable
+}
+
+// serveSSE handles SSE tape replay. It writes response headers, then
+// streams events using the configured SSETimingMode.
+func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, tape Tape) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "httptape: streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy tape response headers.
+	for key, values := range tape.Response.Headers {
+		w.Header()[key] = append([]string(nil), values...)
+	}
+
+	// Ensure SSE-required headers are set.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Apply replay header overrides (if any).
+	for key, value := range s.replayHeaders {
+		w.Header().Set(key, value)
+	}
+
+	// Remove Content-Length — SSE streams are chunked.
+	w.Header().Del("Content-Length")
+
+	// Write status code.
+	w.WriteHeader(tape.Response.StatusCode)
+	flusher.Flush()
+
+	// Replay events with the configured timing.
+	_ = replaySSEEvents(r.Context(), w, flusher, tape.Response.SSEEvents, s.sseTiming)
 }

--- a/sse.go
+++ b/sse.go
@@ -1,0 +1,376 @@
+package httptape
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SSEEvent represents a single Server-Sent Event parsed from a
+// text/event-stream response. It is a pure value type with no I/O.
+type SSEEvent struct {
+	// OffsetMS is the number of milliseconds from the moment the response
+	// headers were received to when this event was fully dispatched
+	// (blank line seen). Monotonically non-decreasing across a stream.
+	OffsetMS int64 `json:"offset_ms"`
+
+	// Type is the SSE event type (from the "event:" field).
+	// Empty string means the default "message" type per the SSE spec.
+	Type string `json:"type,omitempty"`
+
+	// Data is the event payload. Multiple "data:" lines are joined with
+	// "\n" per the SSE specification. Always present (may be empty).
+	Data string `json:"data"`
+
+	// ID is the event ID (from the "id:" field). Empty when absent.
+	ID string `json:"id,omitempty"`
+
+	// Retry is the reconnection time in milliseconds (from the "retry:"
+	// field). Zero when absent.
+	Retry int `json:"retry,omitempty"`
+}
+
+// SSETimingMode controls how inter-event timing is applied during SSE
+// replay. It is a sealed interface implemented by three unexported types.
+type SSETimingMode interface {
+	// delay returns the duration to wait before emitting the event at
+	// index i, given the full list of events. The implementation
+	// computes the inter-event gap from OffsetMS values.
+	delay(events []SSEEvent, i int) time.Duration
+	sseTimingMode() // seal
+}
+
+// sseTimingRealtime replays events with the original recorded inter-event timing.
+type sseTimingRealtime struct{}
+
+func (sseTimingRealtime) sseTimingMode() {}
+func (sseTimingRealtime) delay(events []SSEEvent, i int) time.Duration {
+	if i == 0 {
+		return 0
+	}
+	gap := events[i].OffsetMS - events[i-1].OffsetMS
+	if gap < 0 {
+		gap = 0
+	}
+	return time.Duration(gap) * time.Millisecond
+}
+
+// sseTimingAccelerated divides all inter-event gaps by the given factor.
+type sseTimingAccelerated struct {
+	factor float64
+}
+
+func (sseTimingAccelerated) sseTimingMode() {}
+func (a sseTimingAccelerated) delay(events []SSEEvent, i int) time.Duration {
+	if i == 0 {
+		return 0
+	}
+	gap := events[i].OffsetMS - events[i-1].OffsetMS
+	if gap < 0 {
+		gap = 0
+	}
+	return time.Duration(float64(gap)/a.factor) * time.Millisecond
+}
+
+// sseTimingInstant emits all events back-to-back with no deliberate delay.
+type sseTimingInstant struct{}
+
+func (sseTimingInstant) sseTimingMode() {}
+func (sseTimingInstant) delay(_ []SSEEvent, _ int) time.Duration {
+	return 0
+}
+
+// SSETimingRealtime returns an SSETimingMode that replays events with the
+// original recorded inter-event timing.
+func SSETimingRealtime() SSETimingMode {
+	return sseTimingRealtime{}
+}
+
+// SSETimingAccelerated returns an SSETimingMode that divides all
+// inter-event gaps by the given factor. Factor must be > 0; panics
+// otherwise (constructor guard).
+func SSETimingAccelerated(factor float64) SSETimingMode {
+	if factor <= 0 {
+		panic("httptape: SSETimingAccelerated factor must be > 0")
+	}
+	return sseTimingAccelerated{factor: factor}
+}
+
+// SSETimingInstant returns an SSETimingMode that emits all events
+// back-to-back with no deliberate delay.
+func SSETimingInstant() SSETimingMode {
+	return sseTimingInstant{}
+}
+
+// isSSEContentType reports whether the Content-Type header value indicates
+// a text/event-stream response. Case-insensitive on type/subtype,
+// parameter-tolerant (e.g., "text/event-stream; charset=utf-8").
+func isSSEContentType(contentType string) bool {
+	if contentType == "" {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		// Fallback: try a simple case-insensitive prefix check.
+		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(contentType)), "text/event-stream")
+	}
+	return strings.EqualFold(mediaType, "text/event-stream")
+}
+
+// parseSSEStream reads an io.Reader line-by-line and parses SSE events
+// per the W3C Server-Sent Events specification. It calls onEvent for each
+// fully dispatched event (blank line seen). The startTime is used to
+// compute OffsetMS for each event.
+//
+// Comment lines (starting with ':') are silently ignored.
+// Unknown field names are silently ignored per the SSE spec.
+// The function returns when the reader returns io.EOF or an error.
+// On io.EOF, it returns nil. On other errors, it returns the error.
+// A partially accumulated event (no blank line before EOF) is discarded.
+func parseSSEStream(r io.Reader, startTime time.Time, onEvent func(SSEEvent)) error {
+	scanner := bufio.NewScanner(r)
+	// Increase the scanner buffer to handle large data lines (e.g., LLM completions).
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		eventType string
+		data      []string
+		id        string
+		retry     int
+		hasData   bool
+	)
+
+	dispatch := func() {
+		if !hasData && eventType == "" && id == "" && retry == 0 {
+			// Nothing accumulated -- skip (per spec: blank lines between events).
+			return
+		}
+		ev := SSEEvent{
+			OffsetMS: time.Since(startTime).Milliseconds(),
+			Type:     eventType,
+			Data:     strings.Join(data, "\n"),
+			ID:       id,
+			Retry:    retry,
+		}
+		onEvent(ev)
+		// Reset per-event state.
+		eventType = ""
+		data = nil
+		id = ""
+		retry = 0
+		hasData = false
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Blank line dispatches the event.
+		if line == "" {
+			dispatch()
+			continue
+		}
+
+		// Comment line: ignore.
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		// Parse field name and value.
+		var field, value string
+		if idx := strings.IndexByte(line, ':'); idx >= 0 {
+			field = line[:idx]
+			value = line[idx+1:]
+			// Per spec: if the character following the colon is a space,
+			// remove it.
+			if strings.HasPrefix(value, " ") {
+				value = value[1:]
+			}
+		} else {
+			// No colon: field name is the entire line, value is empty.
+			field = line
+			value = ""
+		}
+
+		switch field {
+		case "event":
+			eventType = value
+		case "data":
+			data = append(data, value)
+			hasData = true
+		case "id":
+			// Per spec: if the value contains U+0000 NULL, ignore the field.
+			if !strings.ContainsRune(value, 0) {
+				id = value
+			}
+		case "retry":
+			// Per spec: if the value consists of ASCII digits only, set retry.
+			if n, err := strconv.Atoi(value); err == nil && n >= 0 {
+				retry = n
+			}
+		default:
+			// Unknown field: silently ignored per spec.
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	// Partial event at EOF is discarded (no blank line to dispatch it).
+	return nil
+}
+
+// writeSSEEvent writes a single SSEEvent to w in SSE wire format.
+// Multi-line Data is re-emitted as multiple "data:" lines.
+// Returns any write error.
+func writeSSEEvent(w io.Writer, ev SSEEvent) error {
+	if ev.Type != "" {
+		if _, err := fmt.Fprintf(w, "event: %s\n", ev.Type); err != nil {
+			return fmt.Errorf("write event field: %w", err)
+		}
+	}
+	if ev.ID != "" {
+		if _, err := fmt.Fprintf(w, "id: %s\n", ev.ID); err != nil {
+			return fmt.Errorf("write id field: %w", err)
+		}
+	}
+	if ev.Retry > 0 {
+		if _, err := fmt.Fprintf(w, "retry: %d\n", ev.Retry); err != nil {
+			return fmt.Errorf("write retry field: %w", err)
+		}
+	}
+
+	// Data: split on newlines and emit each as a separate "data:" line.
+	lines := strings.Split(ev.Data, "\n")
+	for _, line := range lines {
+		if _, err := fmt.Fprintf(w, "data: %s\n", line); err != nil {
+			return fmt.Errorf("write data field: %w", err)
+		}
+	}
+
+	// Terminating blank line.
+	if _, err := fmt.Fprint(w, "\n"); err != nil {
+		return fmt.Errorf("write event terminator: %w", err)
+	}
+
+	return nil
+}
+
+// replaySSEEvents writes a sequence of SSEEvents to an http.ResponseWriter
+// using the given SSETimingMode. It flushes after each event. It respects
+// ctx cancellation and returns promptly when the client disconnects.
+// Returns nil on success, context.Canceled on client disconnect, or a
+// write error.
+func replaySSEEvents(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, events []SSEEvent, timing SSETimingMode) error {
+	for i, ev := range events {
+		d := timing.delay(events, i)
+		if d > 0 {
+			timer := time.NewTimer(d)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+
+		// Check context after waking up from delay.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if err := writeSSEEvent(w, ev); err != nil {
+			return err
+		}
+		flusher.Flush()
+	}
+	return nil
+}
+
+// sseRecordingReader wraps the upstream response body and tees SSE events
+// to a callback as they are parsed, while still delivering the original
+// bytes to the caller unchanged. It implements io.ReadCloser.
+//
+// The caller reads from sseRecordingReader as they would from the original
+// body. Internally, an io.TeeReader feeds bytes to both the caller and a
+// pipe whose read end is consumed by parseSSEStream in a background
+// goroutine. When the caller closes the reader (or the upstream hits EOF),
+// the pipe is closed and the background goroutine exits.
+//
+// Thread safety: the callback (onEvent) is called from the background
+// goroutine. The caller must synchronize access to any shared state.
+type sseRecordingReader struct {
+	tee       io.Reader     // reads from upstream, writes to pipe
+	upstream  io.ReadCloser // original body
+	pipeW     *io.PipeWriter
+	closeOnce sync.Once
+	done      chan struct{} // closed when parser goroutine exits
+	parseErr  error         // set by parser goroutine before closing done
+	readErr   error         // last non-EOF error from Read, propagated to pipe on Close
+}
+
+// newSSERecordingReader creates an sseRecordingReader that parses SSE
+// events from upstream in parallel with the caller's reads. onEvent is
+// called for each dispatched event. onDone is called exactly once when
+// the background parser exits (with nil on clean EOF, or the error).
+func newSSERecordingReader(upstream io.ReadCloser, startTime time.Time, onEvent func(SSEEvent), onDone func(error)) *sseRecordingReader {
+	pr, pw := io.Pipe()
+	tee := io.TeeReader(upstream, pw)
+
+	r := &sseRecordingReader{
+		tee:      tee,
+		upstream: upstream,
+		pipeW:    pw,
+		done:     make(chan struct{}),
+	}
+
+	go func() {
+		err := parseSSEStream(pr, startTime, onEvent)
+		r.parseErr = err
+		if onDone != nil {
+			onDone(err)
+		}
+		close(r.done)
+	}()
+
+	return r
+}
+
+// Read implements io.Reader. Bytes pass through the TeeReader, which
+// copies them to the pipe for the background parser. If the upstream
+// returns a non-EOF error, it is recorded so Close can propagate it
+// to the parser via the pipe.
+func (r *sseRecordingReader) Read(p []byte) (int, error) {
+	n, err := r.tee.Read(p)
+	if err != nil && err != io.EOF {
+		r.readErr = err
+	}
+	return n, err
+}
+
+// Close closes the upstream body and the pipe writer, causing the
+// background parser to see EOF (or an error) and exit. It waits for the
+// parser goroutine to finish before returning.
+//
+// If the upstream returned a non-EOF error during reading, that error is
+// propagated to the parser via PipeWriter.CloseWithError so the parser
+// treats the stream as truncated.
+func (r *sseRecordingReader) Close() error {
+	var upstreamErr error
+	r.closeOnce.Do(func() {
+		upstreamErr = r.upstream.Close()
+		if r.readErr != nil {
+			r.pipeW.CloseWithError(r.readErr)
+		} else {
+			r.pipeW.Close()
+		}
+	})
+	<-r.done
+	return upstreamErr
+}

--- a/sse_test.go
+++ b/sse_test.go
@@ -1,0 +1,1752 @@
+package httptape
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// SSEEvent type tests
+// ---------------------------------------------------------------------------
+
+func TestSSEEvent_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   SSEEvent
+	}{
+		{
+			name: "full event",
+			ev:   SSEEvent{OffsetMS: 100, Type: "update", Data: `{"key":"val"}`, ID: "42", Retry: 3000},
+		},
+		{
+			name: "data only",
+			ev:   SSEEvent{OffsetMS: 0, Data: "hello"},
+		},
+		{
+			name: "empty data",
+			ev:   SSEEvent{OffsetMS: 50, Data: ""},
+		},
+		{
+			name: "multiline data",
+			ev:   SSEEvent{OffsetMS: 200, Data: "line1\nline2\nline3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(tt.ev)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var got SSEEvent
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if got != tt.ev {
+				t.Errorf("round-trip mismatch: got %+v, want %+v", got, tt.ev)
+			}
+		})
+	}
+}
+
+func TestSSEEvent_OmitEmpty(t *testing.T) {
+	ev := SSEEvent{OffsetMS: 0, Data: "hello"}
+	b, _ := json.Marshal(ev)
+	s := string(b)
+	// Type, ID, Retry should be omitted.
+	if strings.Contains(s, "type") {
+		t.Errorf("expected type to be omitted, got %s", s)
+	}
+	if strings.Contains(s, "\"id\"") {
+		t.Errorf("expected id to be omitted, got %s", s)
+	}
+	if strings.Contains(s, "retry") {
+		t.Errorf("expected retry to be omitted, got %s", s)
+	}
+	// Data should always be present (even if empty).
+	if !strings.Contains(s, "\"data\"") {
+		t.Errorf("expected data to be present, got %s", s)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isSSEContentType tests
+// ---------------------------------------------------------------------------
+
+func TestIsSSEContentType(t *testing.T) {
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{"text/event-stream", true},
+		{"text/event-stream; charset=utf-8", true},
+		{"TEXT/EVENT-STREAM", true},
+		{"Text/Event-Stream", true},
+		{"application/json", false},
+		{"text/plain", false},
+		{"", false},
+		{"text/event-stream-extra", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ct, func(t *testing.T) {
+			if got := isSSEContentType(tt.ct); got != tt.want {
+				t.Errorf("isSSEContentType(%q) = %v, want %v", tt.ct, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseSSEStream tests
+// ---------------------------------------------------------------------------
+
+func TestParseSSEStream(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []SSEEvent
+	}{
+		{
+			name:  "single simple event",
+			input: "data: hello\n\n",
+			want: []SSEEvent{
+				{Data: "hello"},
+			},
+		},
+		{
+			name:  "event with type",
+			input: "event: update\ndata: payload\n\n",
+			want: []SSEEvent{
+				{Type: "update", Data: "payload"},
+			},
+		},
+		{
+			name:  "event with id",
+			input: "id: 42\ndata: payload\n\n",
+			want: []SSEEvent{
+				{ID: "42", Data: "payload"},
+			},
+		},
+		{
+			name:  "event with retry",
+			input: "retry: 3000\ndata: payload\n\n",
+			want: []SSEEvent{
+				{Retry: 3000, Data: "payload"},
+			},
+		},
+		{
+			name:  "multiline data",
+			input: "data: line1\ndata: line2\ndata: line3\n\n",
+			want: []SSEEvent{
+				{Data: "line1\nline2\nline3"},
+			},
+		},
+		{
+			name:  "multiple events",
+			input: "data: first\n\ndata: second\n\n",
+			want: []SSEEvent{
+				{Data: "first"},
+				{Data: "second"},
+			},
+		},
+		{
+			name:  "comment lines ignored",
+			input: ": this is a comment\ndata: hello\n\n",
+			want: []SSEEvent{
+				{Data: "hello"},
+			},
+		},
+		{
+			name:  "unknown field ignored",
+			input: "foo: bar\ndata: hello\n\n",
+			want: []SSEEvent{
+				{Data: "hello"},
+			},
+		},
+		{
+			name:  "line without colon treated as unknown field",
+			input: "novalue\ndata: hello\n\n",
+			want: []SSEEvent{
+				{Data: "hello"},
+			},
+		},
+		{
+			name:  "blank lines between events",
+			input: "\n\ndata: hello\n\n\n\n",
+			want: []SSEEvent{
+				{Data: "hello"},
+			},
+		},
+		{
+			name:  "partial event at EOF discarded",
+			input: "data: complete\n\ndata: incomplete",
+			want: []SSEEvent{
+				{Data: "complete"},
+			},
+		},
+		{
+			name:  "data with no space after colon",
+			input: "data:nospace\n\n",
+			want: []SSEEvent{
+				{Data: "nospace"},
+			},
+		},
+		{
+			name:  "empty data line",
+			input: "data:\n\n",
+			want: []SSEEvent{
+				{Data: ""},
+			},
+		},
+		{
+			name:  "data with only space after colon",
+			input: "data: \n\n",
+			want: []SSEEvent{
+				{Data: ""},
+			},
+		},
+		{
+			name:  "full event with all fields",
+			input: "event: msg\nid: 1\nretry: 5000\ndata: payload\n\n",
+			want: []SSEEvent{
+				{Type: "msg", ID: "1", Retry: 5000, Data: "payload"},
+			},
+		},
+		{
+			name:  "negative retry ignored",
+			input: "retry: -1\ndata: hello\n\n",
+			want: []SSEEvent{
+				{Data: "hello"},
+			},
+		},
+		{
+			name:  "non-numeric retry ignored",
+			input: "retry: abc\ndata: hello\n\n",
+			want: []SSEEvent{
+				{Data: "hello"},
+			},
+		},
+		{
+			name:  "id with null character ignored",
+			input: "id: ab\x00cd\ndata: hello\n\n",
+			want: []SSEEvent{
+				{Data: "hello"},
+			},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := time.Now()
+			var events []SSEEvent
+			err := parseSSEStream(strings.NewReader(tt.input), start, func(ev SSEEvent) {
+				// Zero out OffsetMS for comparison (timing-dependent).
+				ev.OffsetMS = 0
+				events = append(events, ev)
+			})
+			if err != nil {
+				t.Fatalf("parseSSEStream error: %v", err)
+			}
+			if len(events) != len(tt.want) {
+				t.Fatalf("got %d events, want %d", len(events), len(tt.want))
+			}
+			for i := range events {
+				if events[i] != tt.want[i] {
+					t.Errorf("event[%d] = %+v, want %+v", i, events[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseSSEStream_OffsetMS(t *testing.T) {
+	// Verify that OffsetMS is computed from startTime.
+	start := time.Now().Add(-100 * time.Millisecond)
+	var events []SSEEvent
+	input := "data: hello\n\n"
+	err := parseSSEStream(strings.NewReader(input), start, func(ev SSEEvent) {
+		events = append(events, ev)
+	})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	// OffsetMS should be >= 100ms since start was 100ms ago.
+	if events[0].OffsetMS < 100 {
+		t.Errorf("OffsetMS = %d, expected >= 100", events[0].OffsetMS)
+	}
+}
+
+func TestParseSSEStream_ReaderError(t *testing.T) {
+	errReader := &errReaderAt{after: 5, err: errors.New("read failed")}
+	var events []SSEEvent
+	err := parseSSEStream(errReader, time.Now(), func(ev SSEEvent) {
+		events = append(events, ev)
+	})
+	if err == nil {
+		t.Fatal("expected error from reader")
+	}
+}
+
+// errReaderAt returns an error after reading `after` bytes.
+type errReaderAt struct {
+	after int
+	read  int
+	err   error
+}
+
+func (r *errReaderAt) Read(p []byte) (int, error) {
+	remaining := r.after - r.read
+	if remaining <= 0 {
+		return 0, r.err
+	}
+	n := len(p)
+	if n > remaining {
+		n = remaining
+	}
+	for i := 0; i < n; i++ {
+		p[i] = 'x'
+	}
+	r.read += n
+	return n, nil
+}
+
+// ---------------------------------------------------------------------------
+// writeSSEEvent tests
+// ---------------------------------------------------------------------------
+
+func TestWriteSSEEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   SSEEvent
+		want string
+	}{
+		{
+			name: "simple data",
+			ev:   SSEEvent{Data: "hello"},
+			want: "data: hello\n\n",
+		},
+		{
+			name: "with type",
+			ev:   SSEEvent{Type: "update", Data: "payload"},
+			want: "event: update\ndata: payload\n\n",
+		},
+		{
+			name: "with id",
+			ev:   SSEEvent{ID: "42", Data: "payload"},
+			want: "id: 42\ndata: payload\n\n",
+		},
+		{
+			name: "with retry",
+			ev:   SSEEvent{Retry: 3000, Data: "payload"},
+			want: "retry: 3000\ndata: payload\n\n",
+		},
+		{
+			name: "multiline data",
+			ev:   SSEEvent{Data: "line1\nline2"},
+			want: "data: line1\ndata: line2\n\n",
+		},
+		{
+			name: "all fields",
+			ev:   SSEEvent{Type: "msg", ID: "1", Retry: 5000, Data: "hello"},
+			want: "event: msg\nid: 1\nretry: 5000\ndata: hello\n\n",
+		},
+		{
+			name: "empty data",
+			ev:   SSEEvent{Data: ""},
+			want: "data: \n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := writeSSEEvent(&buf, tt.ev)
+			if err != nil {
+				t.Fatalf("writeSSEEvent error: %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteSSEEvent_WriteError(t *testing.T) {
+	ew := &errWriter{err: errors.New("write failed")}
+	err := writeSSEEvent(ew, SSEEvent{Data: "hello"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+type errWriter struct {
+	err error
+}
+
+func (w *errWriter) Write(p []byte) (int, error) {
+	return 0, w.err
+}
+
+// ---------------------------------------------------------------------------
+// SSETimingMode tests
+// ---------------------------------------------------------------------------
+
+func TestSSETimingRealtime(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0},
+		{OffsetMS: 100},
+		{OffsetMS: 300},
+	}
+	mode := SSETimingRealtime()
+
+	if d := mode.delay(events, 0); d != 0 {
+		t.Errorf("delay(0) = %v, want 0", d)
+	}
+	if d := mode.delay(events, 1); d != 100*time.Millisecond {
+		t.Errorf("delay(1) = %v, want 100ms", d)
+	}
+	if d := mode.delay(events, 2); d != 200*time.Millisecond {
+		t.Errorf("delay(2) = %v, want 200ms", d)
+	}
+}
+
+func TestSSETimingAccelerated(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0},
+		{OffsetMS: 200},
+		{OffsetMS: 600},
+	}
+	mode := SSETimingAccelerated(2.0)
+
+	if d := mode.delay(events, 0); d != 0 {
+		t.Errorf("delay(0) = %v, want 0", d)
+	}
+	if d := mode.delay(events, 1); d != 100*time.Millisecond {
+		t.Errorf("delay(1) = %v, want 100ms", d)
+	}
+	if d := mode.delay(events, 2); d != 200*time.Millisecond {
+		t.Errorf("delay(2) = %v, want 200ms", d)
+	}
+}
+
+func TestSSETimingAccelerated_PanicOnZero(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for factor 0")
+		}
+	}()
+	SSETimingAccelerated(0)
+}
+
+func TestSSETimingAccelerated_PanicOnNegative(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for negative factor")
+		}
+	}()
+	SSETimingAccelerated(-1.0)
+}
+
+func TestSSETimingInstant(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0},
+		{OffsetMS: 1000},
+		{OffsetMS: 5000},
+	}
+	mode := SSETimingInstant()
+
+	for i := range events {
+		if d := mode.delay(events, i); d != 0 {
+			t.Errorf("delay(%d) = %v, want 0", i, d)
+		}
+	}
+}
+
+func TestSSETimingNonDecreasingOffset(t *testing.T) {
+	// Events with non-decreasing (but equal) OffsetMS.
+	events := []SSEEvent{
+		{OffsetMS: 100},
+		{OffsetMS: 100},
+		{OffsetMS: 200},
+	}
+	mode := SSETimingRealtime()
+	if d := mode.delay(events, 1); d != 0 {
+		t.Errorf("delay(1) = %v, want 0 for equal offsets", d)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sseRecordingReader tests
+// ---------------------------------------------------------------------------
+
+func TestSSERecordingReader_BasicParsing(t *testing.T) {
+	input := "data: event1\n\ndata: event2\n\n"
+	upstream := io.NopCloser(strings.NewReader(input))
+
+	var mu sync.Mutex
+	var events []SSEEvent
+	var doneErr error
+	doneCh := make(chan struct{})
+
+	reader := newSSERecordingReader(upstream, time.Now(), func(ev SSEEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}, func(err error) {
+		doneErr = err
+		close(doneCh)
+	})
+
+	// Read all bytes through the reader.
+	buf, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	reader.Close()
+
+	// Wait for parser to complete.
+	<-doneCh
+
+	// Original bytes should pass through unchanged.
+	if string(buf) != input {
+		t.Errorf("passthrough bytes = %q, want %q", string(buf), input)
+	}
+
+	// Parser should find 2 events.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	if events[0].Data != "event1" {
+		t.Errorf("events[0].Data = %q, want %q", events[0].Data, "event1")
+	}
+	if events[1].Data != "event2" {
+		t.Errorf("events[1].Data = %q, want %q", events[1].Data, "event2")
+	}
+	if doneErr != nil {
+		t.Errorf("onDone error = %v, want nil", doneErr)
+	}
+}
+
+func TestSSERecordingReader_UpstreamDisconnect(t *testing.T) {
+	// Simulate upstream sending one complete event then error.
+	input := "data: complete\n\n"
+	pr, pw := io.Pipe()
+
+	go func() {
+		pw.Write([]byte(input))
+		pw.CloseWithError(errors.New("upstream disconnected"))
+	}()
+
+	var mu sync.Mutex
+	var events []SSEEvent
+	var doneErr error
+	doneCh := make(chan struct{})
+
+	reader := newSSERecordingReader(pr, time.Now(), func(ev SSEEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}, func(err error) {
+		doneErr = err
+		close(doneCh)
+	})
+
+	// The read should eventually error.
+	_, _ = io.ReadAll(reader)
+	reader.Close()
+
+	<-doneCh
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1 (the complete one)", len(events))
+	}
+	if events[0].Data != "complete" {
+		t.Errorf("events[0].Data = %q, want %q", events[0].Data, "complete")
+	}
+	// doneErr should carry the upstream error through the pipe.
+	if doneErr == nil {
+		t.Error("expected error from onDone, got nil")
+	}
+}
+
+func TestSSERecordingReader_EmptyStream(t *testing.T) {
+	upstream := io.NopCloser(strings.NewReader(""))
+
+	var events []SSEEvent
+	doneCh := make(chan struct{})
+
+	reader := newSSERecordingReader(upstream, time.Now(), func(ev SSEEvent) {
+		events = append(events, ev)
+	}, func(err error) {
+		close(doneCh)
+	})
+
+	buf, _ := io.ReadAll(reader)
+	reader.Close()
+	<-doneCh
+
+	if len(buf) != 0 {
+		t.Errorf("expected empty bytes, got %q", string(buf))
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+}
+
+func TestSSERecordingReader_CloseIdempotent(t *testing.T) {
+	upstream := io.NopCloser(strings.NewReader("data: hello\n\n"))
+	doneCh := make(chan struct{})
+
+	reader := newSSERecordingReader(upstream, time.Now(), func(ev SSEEvent) {}, func(err error) {
+		close(doneCh)
+	})
+
+	io.ReadAll(reader)
+	reader.Close()
+	<-doneCh
+
+	// Second close should not panic.
+	reader.Close()
+}
+
+// ---------------------------------------------------------------------------
+// replaySSEEvents tests
+// ---------------------------------------------------------------------------
+
+func TestReplaySSEEvents_Instant(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0, Data: "first"},
+		{OffsetMS: 100, Data: "second"},
+		{OffsetMS: 200, Data: "third"},
+	}
+
+	rec := httptest.NewRecorder()
+	var w http.ResponseWriter = rec
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("httptest.ResponseRecorder does not implement Flusher")
+	}
+
+	start := time.Now()
+	err := replaySSEEvents(context.Background(), rec, flusher, events, SSETimingInstant())
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("replaySSEEvents error: %v", err)
+	}
+
+	// Instant should complete quickly (within 100ms for any number of events).
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("instant replay took %v, expected < 100ms", elapsed)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "data: first") {
+		t.Error("missing 'data: first' in output")
+	}
+	if !strings.Contains(body, "data: second") {
+		t.Error("missing 'data: second' in output")
+	}
+	if !strings.Contains(body, "data: third") {
+		t.Error("missing 'data: third' in output")
+	}
+}
+
+func TestReplaySSEEvents_ContextCancellation(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0, Data: "first"},
+		{OffsetMS: 10000, Data: "second"}, // 10s delay
+	}
+
+	rec := httptest.NewRecorder()
+	var w http.ResponseWriter = rec
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("httptest.ResponseRecorder does not implement Flusher")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := replaySSEEvents(ctx, rec, flusher, events, SSETimingRealtime())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+
+	// Should cancel well before 10s.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("context cancellation took %v, expected < 500ms", elapsed)
+	}
+}
+
+func TestReplaySSEEvents_Realtime(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0, Data: "a"},
+		{OffsetMS: 100, Data: "b"},
+	}
+
+	rec := httptest.NewRecorder()
+	flusher := http.ResponseWriter(rec).(http.Flusher)
+
+	start := time.Now()
+	err := replaySSEEvents(context.Background(), rec, flusher, events, SSETimingRealtime())
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	// Should take ~100ms for the gap between events.
+	assertTimingInRange(t, elapsed, 100*time.Millisecond)
+}
+
+func TestReplaySSEEvents_Accelerated(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0, Data: "a"},
+		{OffsetMS: 200, Data: "b"},
+	}
+
+	rec := httptest.NewRecorder()
+	flusher := http.ResponseWriter(rec).(http.Flusher)
+
+	start := time.Now()
+	err := replaySSEEvents(context.Background(), rec, flusher, events, SSETimingAccelerated(2.0))
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	// With 2x acceleration, 200ms gap should become ~100ms.
+	assertTimingInRange(t, elapsed, 100*time.Millisecond)
+}
+
+// assertTimingInRange checks that elapsed is within an acceptable range of
+// expected, following ADR-35's tolerance spec: +/- 50ms or +/- 20% of
+// expected, whichever is larger.
+func assertTimingInRange(t *testing.T, elapsed, expected time.Duration) {
+	t.Helper()
+	tolerance := 50 * time.Millisecond
+	pctTolerance := time.Duration(float64(expected) * 0.20)
+	if pctTolerance > tolerance {
+		tolerance = pctTolerance
+	}
+	low := expected - tolerance
+	if low < 0 {
+		low = 0
+	}
+	high := expected + tolerance
+	if elapsed < low || elapsed > high {
+		t.Errorf("elapsed %v not in range [%v, %v] (expected %v)", elapsed, low, high, expected)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecordedResp.IsSSE tests
+// ---------------------------------------------------------------------------
+
+func TestRecordedResp_IsSSE(t *testing.T) {
+	tests := []struct {
+		name string
+		resp RecordedResp
+		want bool
+	}{
+		{"nil events", RecordedResp{SSEEvents: nil}, false},
+		{"empty events", RecordedResp{SSEEvents: []SSEEvent{}}, false},
+		{"with events", RecordedResp{SSEEvents: []SSEEvent{{Data: "hi"}}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.resp.IsSSE(); got != tt.want {
+				t.Errorf("IsSSE() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Schema backward compatibility
+// ---------------------------------------------------------------------------
+
+func TestSSEEvent_BackwardCompat_OldTape(t *testing.T) {
+	// A tape JSON from before SSE support has no sse_events field.
+	oldJSON := `{
+		"status_code": 200,
+		"headers": {},
+		"body": "aGVsbG8="
+	}`
+	var resp RecordedResp
+	if err := json.Unmarshal([]byte(oldJSON), &resp); err != nil {
+		t.Fatalf("Unmarshal old tape: %v", err)
+	}
+	if resp.IsSSE() {
+		t.Error("old tape without sse_events should not be treated as SSE")
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Recorder SSE recording integration
+// ---------------------------------------------------------------------------
+
+func TestRecorder_SSERecording(t *testing.T) {
+	// Upstream that serves an SSE stream.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(200)
+		flusher.Flush()
+
+		fmt.Fprint(w, "data: event1\n\n")
+		flusher.Flush()
+		time.Sleep(50 * time.Millisecond)
+		fmt.Fprint(w, "event: custom\ndata: event2\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store, WithAsync(false))
+	client := &http.Client{Transport: rec}
+
+	resp, err := client.Get(upstream.URL + "/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+
+	// Read the response body (this drives the SSE recording).
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	resp.Body.Close()
+
+	// The caller should have received the raw SSE bytes.
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "data: event1") {
+		t.Error("caller should see raw SSE bytes: missing 'data: event1'")
+	}
+	if !strings.Contains(bodyStr, "data: event2") {
+		t.Error("caller should see raw SSE bytes: missing 'data: event2'")
+	}
+
+	// Check the stored tape.
+	tapes, err := store.List(context.Background(), Filter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(tapes) != 1 {
+		t.Fatalf("got %d tapes, want 1", len(tapes))
+	}
+	tape := tapes[0]
+
+	if !tape.Response.IsSSE() {
+		t.Fatal("stored tape should be SSE")
+	}
+	if tape.Response.Body != nil {
+		t.Error("SSE tape should have nil Body")
+	}
+	if len(tape.Response.SSEEvents) != 2 {
+		t.Fatalf("got %d events, want 2", len(tape.Response.SSEEvents))
+	}
+	if tape.Response.SSEEvents[0].Data != "event1" {
+		t.Errorf("event[0].Data = %q, want %q", tape.Response.SSEEvents[0].Data, "event1")
+	}
+	if tape.Response.SSEEvents[1].Data != "event2" {
+		t.Errorf("event[1].Data = %q, want %q", tape.Response.SSEEvents[1].Data, "event2")
+	}
+	if tape.Response.SSEEvents[1].Type != "custom" {
+		t.Errorf("event[1].Type = %q, want %q", tape.Response.SSEEvents[1].Type, "custom")
+	}
+
+	// Verify timing: second event should be ~50ms after first.
+	gap := tape.Response.SSEEvents[1].OffsetMS - tape.Response.SSEEvents[0].OffsetMS
+	if gap < 30 || gap > 200 {
+		t.Errorf("inter-event gap = %dms, expected ~50ms", gap)
+	}
+}
+
+func TestRecorder_SSERecordingDisabled(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "data: hello\n\n")
+	}))
+	defer upstream.Close()
+
+	store := NewMemoryStore()
+	rec := NewRecorder(store, WithAsync(false), WithSSERecording(false))
+	client := &http.Client{Transport: rec}
+
+	resp, err := client.Get(upstream.URL + "/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("got %d tapes, want 1", len(tapes))
+	}
+	// With SSE recording disabled, it should be a regular tape with Body.
+	if tapes[0].Response.IsSSE() {
+		t.Error("with SSE recording disabled, tape should not be SSE")
+	}
+	if tapes[0].Response.Body == nil {
+		t.Error("with SSE recording disabled, tape should have Body")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Server SSE replay integration
+// ---------------------------------------------------------------------------
+
+func TestServer_SSEReplay_Instant(t *testing.T) {
+	store := NewMemoryStore()
+
+	// Create an SSE tape manually.
+	tape := NewTape("", RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/stream",
+		Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/event-stream"}},
+		SSEEvents: []SSEEvent{
+			{OffsetMS: 0, Data: "first"},
+			{OffsetMS: 100, Data: "second"},
+			{OffsetMS: 200, Type: "custom", Data: "third", ID: "3"},
+		},
+	})
+	store.Save(context.Background(), tape)
+
+	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want %q", ct, "text/event-stream")
+	}
+
+	// Parse the SSE events from the response.
+	var received []SSEEvent
+	err = parseSSEStream(resp.Body, time.Now(), func(ev SSEEvent) {
+		ev.OffsetMS = 0 // normalize
+		received = append(received, ev)
+	})
+	if err != nil {
+		t.Fatalf("parseSSEStream: %v", err)
+	}
+
+	if len(received) != 3 {
+		t.Fatalf("got %d events, want 3", len(received))
+	}
+	if received[0].Data != "first" {
+		t.Errorf("event[0].Data = %q, want %q", received[0].Data, "first")
+	}
+	if received[1].Data != "second" {
+		t.Errorf("event[1].Data = %q, want %q", received[1].Data, "second")
+	}
+	if received[2].Data != "third" || received[2].Type != "custom" || received[2].ID != "3" {
+		t.Errorf("event[2] = %+v, want Type=custom Data=third ID=3", received[2])
+	}
+}
+
+func TestServer_SSEReplay_WithHeaders(t *testing.T) {
+	store := NewMemoryStore()
+
+	tape := NewTape("", RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/stream",
+		Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"X-Custom": {"original"}},
+		SSEEvents:  []SSEEvent{{Data: "hi"}},
+	})
+	store.Save(context.Background(), tape)
+
+	srv := NewServer(store,
+		WithSSETiming(SSETimingInstant()),
+		WithReplayHeaders("X-Override", "injected"),
+	)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// Check SSE-required headers.
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", cc)
+	}
+	// Check custom header.
+	if v := resp.Header.Get("X-Custom"); v != "original" {
+		t.Errorf("X-Custom = %q, want original", v)
+	}
+	// Check replay header override.
+	if v := resp.Header.Get("X-Override"); v != "injected" {
+		t.Errorf("X-Override = %q, want injected", v)
+	}
+}
+
+func TestServer_NonSSETapeUnchanged(t *testing.T) {
+	// Verify that non-SSE tapes are still served as before.
+	store := NewMemoryStore()
+
+	tape := NewTape("", RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/api",
+		Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"ok":true}`),
+	})
+	store.Save(context.Background(), tape)
+
+	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %q, want %q", string(body), `{"ok":true}`)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy SSE tests
+// ---------------------------------------------------------------------------
+
+func TestProxy_SSE_SuccessPath(t *testing.T) {
+	// Upstream serves SSE.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher.Flush()
+		fmt.Fprint(w, "data: hello\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "data: world\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+	proxy := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+
+	req, _ := http.NewRequest("GET", upstream.URL+"/stream", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+
+	// Read the body to trigger SSE recording completion.
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if !strings.Contains(string(body), "data: hello") {
+		t.Error("caller should see raw SSE: missing 'data: hello'")
+	}
+	if !strings.Contains(string(body), "data: world") {
+		t.Error("caller should see raw SSE: missing 'data: world'")
+	}
+
+	// Give the onDone a moment to save (it runs in the parser goroutine).
+	time.Sleep(50 * time.Millisecond)
+
+	// L1 and L2 should each have one SSE tape.
+	l1Tapes, _ := l1.List(context.Background(), Filter{})
+	if len(l1Tapes) != 1 {
+		t.Fatalf("L1 has %d tapes, want 1", len(l1Tapes))
+	}
+	if !l1Tapes[0].Response.IsSSE() {
+		t.Error("L1 tape should be SSE")
+	}
+	if len(l1Tapes[0].Response.SSEEvents) != 2 {
+		t.Errorf("L1 tape has %d events, want 2", len(l1Tapes[0].Response.SSEEvents))
+	}
+
+	l2Tapes, _ := l2.List(context.Background(), Filter{})
+	if len(l2Tapes) != 1 {
+		t.Fatalf("L2 has %d tapes, want 1", len(l2Tapes))
+	}
+	if !l2Tapes[0].Response.IsSSE() {
+		t.Error("L2 tape should be SSE")
+	}
+}
+
+func TestProxy_SSE_L2Fallback(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	// Pre-populate L2 with an SSE tape.
+	tape := NewTape("", RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/stream",
+		Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/event-stream"}},
+		SSEEvents: []SSEEvent{
+			{OffsetMS: 0, Data: "cached1"},
+			{OffsetMS: 100, Data: "cached2"},
+		},
+	})
+	l2.Save(context.Background(), tape)
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("down"))),
+		WithProxySSETiming(SSETimingInstant()),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if src := resp.Header.Get("X-Httptape-Source"); src != "l2-cache" {
+		t.Errorf("X-Httptape-Source = %q, want l2-cache", src)
+	}
+
+	// Parse the SSE events from the fallback response.
+	var received []SSEEvent
+	parseSSEStream(resp.Body, time.Now(), func(ev SSEEvent) {
+		ev.OffsetMS = 0
+		received = append(received, ev)
+	})
+
+	if len(received) != 2 {
+		t.Fatalf("got %d events, want 2", len(received))
+	}
+	if received[0].Data != "cached1" {
+		t.Errorf("event[0].Data = %q, want cached1", received[0].Data)
+	}
+	if received[1].Data != "cached2" {
+		t.Errorf("event[1].Data = %q, want cached2", received[1].Data)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sanitizer SSE tests
+// ---------------------------------------------------------------------------
+
+func TestRedactSSEEventData(t *testing.T) {
+	tape := Tape{
+		Response: RecordedResp{
+			SSEEvents: []SSEEvent{
+				{Data: `{"token":"secret","name":"Alice"}`},
+				{Data: `{"token":"other-secret","name":"Bob"}`},
+				{Data: "not json"},
+			},
+		},
+	}
+
+	fn := RedactSSEEventData("$.token")
+	result := fn(tape)
+
+	if len(result.Response.SSEEvents) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(result.Response.SSEEvents))
+	}
+
+	// Token should be redacted.
+	if strings.Contains(result.Response.SSEEvents[0].Data, "secret") {
+		t.Error("event[0] token should be redacted")
+	}
+	if !strings.Contains(result.Response.SSEEvents[0].Data, Redacted) {
+		t.Error("event[0] should contain redacted value")
+	}
+	if strings.Contains(result.Response.SSEEvents[1].Data, "other-secret") {
+		t.Error("event[1] token should be redacted")
+	}
+
+	// Name should NOT be redacted.
+	if !strings.Contains(result.Response.SSEEvents[0].Data, "Alice") {
+		t.Error("event[0] name should be preserved")
+	}
+
+	// Non-JSON data should be left unchanged.
+	if result.Response.SSEEvents[2].Data != "not json" {
+		t.Errorf("non-JSON data changed: %q", result.Response.SSEEvents[2].Data)
+	}
+}
+
+func TestRedactSSEEventData_NoopForNonSSE(t *testing.T) {
+	tape := Tape{
+		Response: RecordedResp{
+			Body: []byte(`{"token":"secret"}`),
+		},
+	}
+	fn := RedactSSEEventData("$.token")
+	result := fn(tape)
+	// Body should not be modified.
+	if string(result.Response.Body) != `{"token":"secret"}` {
+		t.Errorf("non-SSE tape body was modified: %q", string(result.Response.Body))
+	}
+}
+
+func TestFakeSSEEventData(t *testing.T) {
+	tape := Tape{
+		Response: RecordedResp{
+			SSEEvents: []SSEEvent{
+				{Data: `{"email":"alice@corp.example","name":"Alice"}`},
+				{Data: `{"email":"bob@corp.example","name":"Bob"}`},
+			},
+		},
+	}
+
+	fn := FakeSSEEventData("test-seed", "$.email")
+	result := fn(tape)
+
+	// Emails should be faked.
+	if strings.Contains(result.Response.SSEEvents[0].Data, "alice@corp.example") {
+		t.Error("event[0] email should be faked")
+	}
+	if !strings.Contains(result.Response.SSEEvents[0].Data, "@example.com") {
+		t.Error("event[0] should have faked email")
+	}
+
+	// Names should be preserved.
+	if !strings.Contains(result.Response.SSEEvents[0].Data, "Alice") {
+		t.Error("event[0] name should be preserved")
+	}
+
+	// Deterministic: same seed + same input = same output.
+	fn2 := FakeSSEEventData("test-seed", "$.email")
+	result2 := fn2(tape)
+	if result.Response.SSEEvents[0].Data != result2.Response.SSEEvents[0].Data {
+		t.Error("faking should be deterministic")
+	}
+}
+
+func TestFakeSSEEventData_NoopForNonSSE(t *testing.T) {
+	tape := Tape{
+		Response: RecordedResp{
+			Body: []byte(`{"email":"alice@corp.example"}`),
+		},
+	}
+	fn := FakeSSEEventData("seed", "$.email")
+	result := fn(tape)
+	if string(result.Response.Body) != `{"email":"alice@corp.example"}` {
+		t.Errorf("non-SSE tape body was modified: %q", string(result.Response.Body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full record-replay integration (SSE)
+// ---------------------------------------------------------------------------
+
+func TestIntegration_SSE_RecordReplay(t *testing.T) {
+	// Upstream serves an SSE stream with JSON payloads.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher.Flush()
+
+		events := []string{
+			`{"chunk":"Hello"}`,
+			`{"chunk":" world"}`,
+			`{"chunk":"!"}`,
+		}
+		for _, ev := range events {
+			fmt.Fprintf(w, "data: %s\n\n", ev)
+			flusher.Flush()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}))
+	defer upstream.Close()
+
+	// Record.
+	store := NewMemoryStore()
+	rec := NewRecorder(store, WithAsync(false))
+	client := &http.Client{Transport: rec}
+
+	resp, err := client.Get(upstream.URL + "/llm/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	origBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// Verify caller got the raw bytes.
+	if !strings.Contains(string(origBody), `"chunk":"Hello"`) {
+		t.Error("caller should see raw SSE bytes")
+	}
+
+	// Replay.
+	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	replayResp, err := http.Get(ts.URL + "/llm/stream")
+	if err != nil {
+		t.Fatalf("replay GET: %v", err)
+	}
+	defer replayResp.Body.Close()
+
+	if replayResp.StatusCode != 200 {
+		t.Errorf("replay status = %d, want 200", replayResp.StatusCode)
+	}
+	if ct := replayResp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	var replayed []SSEEvent
+	parseSSEStream(replayResp.Body, time.Now(), func(ev SSEEvent) {
+		ev.OffsetMS = 0
+		replayed = append(replayed, ev)
+	})
+
+	if len(replayed) != 3 {
+		t.Fatalf("replayed %d events, want 3", len(replayed))
+	}
+
+	wantData := []string{`{"chunk":"Hello"}`, `{"chunk":" world"}`, `{"chunk":"!"}`}
+	for i, ev := range replayed {
+		if ev.Data != wantData[i] {
+			t.Errorf("replayed[%d].Data = %q, want %q", i, ev.Data, wantData[i])
+		}
+	}
+}
+
+func TestIntegration_SSE_RecordReplay_WithSanitization(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher.Flush()
+
+		fmt.Fprint(w, "data: {\"token\":\"secret-123\",\"user\":\"Alice\"}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "data: {\"token\":\"secret-456\",\"user\":\"Bob\"}\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	store := NewMemoryStore()
+	sanitizer := NewPipeline(
+		RedactSSEEventData("$.token"),
+	)
+	rec := NewRecorder(store, WithAsync(false), WithSanitizer(sanitizer))
+	client := &http.Client{Transport: rec}
+
+	resp, err := client.Get(upstream.URL + "/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// Verify the tape has redacted tokens.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("got %d tapes, want 1", len(tapes))
+	}
+
+	for i, ev := range tapes[0].Response.SSEEvents {
+		if strings.Contains(ev.Data, "secret") {
+			t.Errorf("event[%d] should have redacted token: %s", i, ev.Data)
+		}
+		if !strings.Contains(ev.Data, Redacted) {
+			t.Errorf("event[%d] should contain redacted marker: %s", i, ev.Data)
+		}
+	}
+
+	// Replay and verify redacted values are served.
+	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	replayResp, err := http.Get(ts.URL + "/stream")
+	if err != nil {
+		t.Fatalf("replay GET: %v", err)
+	}
+	replayBody, _ := io.ReadAll(replayResp.Body)
+	replayResp.Body.Close()
+
+	if strings.Contains(string(replayBody), "secret") {
+		t.Error("replayed SSE should not contain raw secret")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy SSE passthrough integration
+// ---------------------------------------------------------------------------
+
+func TestIntegration_SSE_ProxyPassthrough(t *testing.T) {
+	// Upstream SSE server.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher.Flush()
+
+		fmt.Fprint(w, "data: live1\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "data: live2\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+	proxy := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+
+	// Use the proxy as an HTTP handler via httptest.
+	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Build outgoing request to upstream.
+		outReq, _ := http.NewRequestWithContext(r.Context(), r.Method, upstream.URL+r.URL.Path, r.Body)
+		resp, err := proxy.RoundTrip(outReq)
+		if err != nil {
+			http.Error(w, err.Error(), 502)
+			return
+		}
+		defer resp.Body.Close()
+
+		// Copy response headers and body.
+		for k, vs := range resp.Header {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	})
+
+	ts := httptest.NewServer(proxyHandler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/sse-stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// Verify the client received live events.
+	if !strings.Contains(string(body), "data: live1") {
+		t.Error("client should receive live1")
+	}
+	if !strings.Contains(string(body), "data: live2") {
+		t.Error("client should receive live2")
+	}
+
+	// Give onDone a moment.
+	time.Sleep(50 * time.Millisecond)
+
+	// L1 and L2 should have the tape.
+	l1Tapes, _ := l1.List(context.Background(), Filter{})
+	if len(l1Tapes) != 1 {
+		t.Fatalf("L1 tapes = %d, want 1", len(l1Tapes))
+	}
+	if !l1Tapes[0].Response.IsSSE() {
+		t.Error("L1 tape should be SSE")
+	}
+
+	l2Tapes, _ := l2.List(context.Background(), Filter{})
+	if len(l2Tapes) != 1 {
+		t.Fatalf("L2 tapes = %d, want 1", len(l2Tapes))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// health.go writeSSEEvent refactor verification
+// ---------------------------------------------------------------------------
+
+func TestHealth_StreamUsesWriteSSEEvent(t *testing.T) {
+	// Verify that health streaming still works after the refactor to use
+	// the shared writeSSEEvent helper.
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(successTransport(200, "ok")),
+		WithProxyUpstreamURL("http://upstream.example"),
+		WithProxyHealthEndpoint(),
+		WithProxyProbeInterval(0),
+	)
+	defer proxy.Close()
+
+	srv := httptest.NewServer(proxy.HealthHandler())
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+"/__httptape/health/stream", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	// Read the initial seed event.
+	br := bufio.NewReader(resp.Body)
+	payload, err := readSSEEvent(br, 2*time.Second)
+	if err != nil {
+		t.Fatalf("readSSEEvent: %v", err)
+	}
+
+	var snap HealthSnapshot
+	if err := json.Unmarshal([]byte(payload), &snap); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if snap.State != StateLive {
+		t.Errorf("state = %q, want live", snap.State)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Timing mode round-trip verification
+// ---------------------------------------------------------------------------
+
+func TestSSETimingRealtime_PreservesGaps(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0, Data: "a"},
+		{OffsetMS: 150, Data: "b"},
+	}
+
+	rec := httptest.NewRecorder()
+	flusher := http.ResponseWriter(rec).(http.Flusher)
+
+	start := time.Now()
+	replaySSEEvents(context.Background(), rec, flusher, events, SSETimingRealtime())
+	elapsed := time.Since(start)
+
+	// 150ms gap expected.
+	assertTimingInRange(t, elapsed, 150*time.Millisecond)
+}
+
+// ---------------------------------------------------------------------------
+// deepCopyTape SSEEvents test
+// ---------------------------------------------------------------------------
+
+func TestDeepCopyTape_SSEEvents(t *testing.T) {
+	original := Tape{
+		Response: RecordedResp{
+			SSEEvents: []SSEEvent{
+				{OffsetMS: 0, Data: "original"},
+			},
+		},
+	}
+
+	cp := deepCopyTape(original)
+	cp.Response.SSEEvents[0].Data = "modified"
+
+	if original.Response.SSEEvents[0].Data != "original" {
+		t.Error("deepCopyTape should not alias SSEEvents slice")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseSSEStream round-trip (parse -> write -> parse)
+// ---------------------------------------------------------------------------
+
+func TestSSE_ParseWriteRoundTrip(t *testing.T) {
+	input := "event: msg\nid: 42\nretry: 5000\ndata: line1\ndata: line2\n\n"
+
+	// Parse.
+	var events []SSEEvent
+	parseSSEStream(strings.NewReader(input), time.Now(), func(ev SSEEvent) {
+		ev.OffsetMS = 0
+		events = append(events, ev)
+	})
+
+	if len(events) != 1 {
+		t.Fatalf("parsed %d events, want 1", len(events))
+	}
+
+	// Write.
+	var buf bytes.Buffer
+	writeSSEEvent(&buf, events[0])
+
+	// Parse again.
+	var events2 []SSEEvent
+	parseSSEStream(strings.NewReader(buf.String()), time.Now(), func(ev SSEEvent) {
+		ev.OffsetMS = 0
+		events2 = append(events2, ev)
+	})
+
+	if len(events2) != 1 {
+		t.Fatalf("round-trip parsed %d events, want 1", len(events2))
+	}
+
+	if events[0] != events2[0] {
+		t.Errorf("round-trip mismatch: %+v != %+v", events[0], events2[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Edge case: negative offset clamp
+// ---------------------------------------------------------------------------
+
+func TestSSETimingRealtime_NegativeGapClamped(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 200},
+		{OffsetMS: 100}, // out of order (shouldn't happen, but defensive)
+	}
+	mode := SSETimingRealtime()
+	d := mode.delay(events, 1)
+	if d != 0 {
+		t.Errorf("negative gap should be clamped to 0, got %v", d)
+	}
+}
+
+func TestSSETimingAccelerated_NegativeGapClamped(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 200},
+		{OffsetMS: 100},
+	}
+	mode := SSETimingAccelerated(2.0)
+	d := mode.delay(events, 1)
+	if d != 0 {
+		t.Errorf("negative gap should be clamped to 0, got %v", d)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SSETimingAccelerated fractional factor
+// ---------------------------------------------------------------------------
+
+func TestSSETimingAccelerated_FractionalFactor(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0},
+		{OffsetMS: 100},
+	}
+	mode := SSETimingAccelerated(0.5)
+	d := mode.delay(events, 1)
+	expected := 200 * time.Millisecond
+	if math.Abs(float64(d-expected)) > float64(5*time.Millisecond) {
+		t.Errorf("delay = %v, want ~%v", d, expected)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent SSE recording race test
+// ---------------------------------------------------------------------------
+
+func TestSSERecordingReader_ConcurrentReads(t *testing.T) {
+	// Simulate concurrent reads on the recording reader.
+	input := ""
+	for i := 0; i < 100; i++ {
+		input += fmt.Sprintf("data: event%d\n\n", i)
+	}
+	upstream := io.NopCloser(strings.NewReader(input))
+
+	var mu sync.Mutex
+	var events []SSEEvent
+	doneCh := make(chan struct{})
+
+	reader := newSSERecordingReader(upstream, time.Now(), func(ev SSEEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}, func(err error) {
+		close(doneCh)
+	})
+
+	// Read in small chunks to stress the TeeReader.
+	buf := make([]byte, 16)
+	for {
+		_, err := reader.Read(buf)
+		if err != nil {
+			break
+		}
+	}
+	reader.Close()
+	<-doneCh
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 100 {
+		t.Errorf("got %d events, want 100", len(events))
+	}
+}

--- a/store_memory.go
+++ b/store_memory.go
@@ -110,6 +110,10 @@ func deepCopyTape(t Tape) Tape {
 	cp.Request.Body = copyBytes(t.Request.Body)
 	cp.Response.Headers = copyHeaders(t.Response.Headers)
 	cp.Response.Body = copyBytes(t.Response.Body)
+	if t.Response.SSEEvents != nil {
+		cp.Response.SSEEvents = make([]SSEEvent, len(t.Response.SSEEvents))
+		copy(cp.Response.SSEEvents, t.Response.SSEEvents)
+	}
 	return cp
 }
 

--- a/tape.go
+++ b/tape.go
@@ -83,6 +83,12 @@ type RecordedReq struct {
 }
 
 // RecordedResp captures the essential parts of an HTTP response for replay.
+//
+// For SSE (text/event-stream) responses, the discrete events are stored in
+// SSEEvents and Body is nil. The two fields are mutually exclusive by
+// construction: the Recorder populates one or the other, never both.
+// During replay, if SSEEvents is non-nil and non-empty the tape is treated
+// as an SSE tape and Body is ignored (even if present).
 type RecordedResp struct {
 	// StatusCode is the HTTP response status code.
 	StatusCode int `json:"status_code"`
@@ -98,12 +104,26 @@ type RecordedResp struct {
 	BodyEncoding BodyEncoding `json:"body_encoding,omitempty"`
 
 	// Truncated is true if the body was truncated due to exceeding the
-	// configured maximum body size.
+	// configured maximum body size, or if an SSE stream was disconnected
+	// before a clean termination.
 	Truncated bool `json:"truncated,omitempty"`
 
 	// OriginalBodySize is the original body size in bytes before truncation.
 	// Only set when Truncated is true.
 	OriginalBodySize int64 `json:"original_body_size,omitempty"`
+
+	// SSEEvents holds the parsed Server-Sent Events for text/event-stream
+	// responses. When non-nil and non-empty, this tape represents an SSE
+	// response and Body is ignored during replay.
+	// When nil or empty (including for tapes created before SSE support was
+	// added), the tape is treated as a regular HTTP response.
+	SSEEvents []SSEEvent `json:"sse_events,omitempty"`
+}
+
+// IsSSE reports whether this response represents an SSE stream.
+// It returns true when SSEEvents is non-nil and non-empty.
+func (r RecordedResp) IsSSE() bool {
+	return len(r.SSEEvents) > 0
 }
 
 // NewTape creates a new Tape with a generated ID and the current UTC timestamp.


### PR DESCRIPTION
Closes #124

## Summary

- **New `SSEEvent` type** in `sse.go` -- per-event value type with `OffsetMS`, `Type`, `Data`, `ID`, `Retry` fields
- **New `SSETimingMode` sealed interface** with three constructors: `SSETimingRealtime()`, `SSETimingAccelerated(factor)`, `SSETimingInstant()`
- **Recording**: Recorder detects `text/event-stream` responses and uses `sseRecordingReader` (io.TeeReader + background parser) to deliver original bytes to caller unchanged while parsing events in parallel. Tape persisted on body close. Opt-out via `WithSSERecording(false)`
- **Replay**: Server detects SSE tapes via `IsSSE()` and streams events with configurable timing (`WithSSETiming`). Sets SSE headers, flushes after each event, respects context cancellation
- **Proxy passthrough**: SSE responses are streamed live to the client while recording events to L1/L2 in the background. L2 fallback synthesizes a streaming response via `io.Pipe` with configurable timing (default instant via `WithProxySSETiming`)
- **Sanitization**: `RedactSSEEventData(paths...)` and `FakeSSEEventData(seed, paths...)` compose into existing `Pipeline`, applying body-path operations to each event's `Data` field independently
- **Schema change**: `RecordedResp` gains `SSEEvents []SSEEvent` with `json:"sse_events,omitempty"` -- fully backward compatible
- **Refactored** `health.go` to use shared `writeSSEEvent` helper from `sse.go`
- **Updated** `deepCopyTape` to copy `SSEEvents` slice

## Test plan

- [x] SSEEvent JSON round-trip and omitempty behavior
- [x] `isSSEContentType` detection (case-insensitive, parameter-tolerant)
- [x] `parseSSEStream` -- single events, multi-line data, event/id/retry fields, comments, unknown fields, malformed lines, partial events at EOF, empty input, reader errors
- [x] `writeSSEEvent` -- all field combinations, multiline data, write errors
- [x] `sseRecordingReader` -- basic parsing, upstream disconnect mid-stream, empty stream, close idempotency, concurrent reads
- [x] SSE timing modes -- Realtime preserves inter-event gaps, Accelerated divides them, Instant fires immediately, negative gap clamping, fractional factors
- [x] Replay timing verification with ADR-35 tolerance (+/- 50ms or 20%)
- [x] Server SSE replay end-to-end with instant and realtime timing
- [x] Server non-SSE tapes unchanged after SSE changes
- [x] Recorder SSE recording integration (full HTTP round-trip)
- [x] Recorder SSE recording disabled via `WithSSERecording(false)`
- [x] Proxy SSE success path -- events recorded to L1/L2
- [x] Proxy L2 fallback -- cached SSE tape replayed with instant timing
- [x] Sanitization -- `RedactSSEEventData` and `FakeSSEEventData` with JSON and non-JSON data
- [x] Schema backward compat -- old tape JSON without `sse_events` field deserializes cleanly
- [x] `RecordedResp.IsSSE()` with nil, empty, and populated events
- [x] `deepCopyTape` copies SSEEvents without aliasing
- [x] Parse-write round-trip fidelity
- [x] `health.go` streaming still works after `writeSSEEvent` refactor
- [x] Race detector clean: `go test -race -count=10` passes
- [x] Integration tests in `integration_test.go` for SSE record-replay and proxy E2E
- [x] Race tests in `race_test.go` for concurrent SSE recording and replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)