### PR TITLE
chore(examples): bump ts-frontend-first to httptape v0.10.0

### DIFF
--- a/examples/ts-frontend-first/README.md
+++ b/examples/ts-frontend-first/README.md
@@ -65,11 +65,11 @@ No polling, no manual refresh. See [`src/useHealthStream.ts`](src/useHealthStrea
 docker compose up
 ```
 
-Pulls `ghcr.io/vibewarden/httptape:0.9.0` (the version that introduced the health endpoint) and builds the React frontend. No local Go build needed.
+Pulls `ghcr.io/vibewarden/httptape:0.10.0` (the version that introduced SSE record/replay) and builds the React frontend. No local Go build needed.
 
 Open [http://localhost:3000](http://localhost:3000).
 
-> Pinned to `0.9.0` for reproducibility. To track latest, change the image to `ghcr.io/vibewarden/httptape:latest`.
+> Pinned to `0.10.0` for reproducibility. To track latest, change the image to `ghcr.io/vibewarden/httptape:latest`.
 
 ## Try it
 
@@ -130,6 +130,6 @@ ts-frontend-first/
     toggle-upstream.sh           # one-liner to flip upstream up/down
   .httptape-cache/               # L2 cache — generated, gitignored
     fixtures/                    # populated on first request, used as L2 fallback
-  docker-compose.yml             # 3 services, pinned to httptape v0.9.0 from GHCR
+  docker-compose.yml             # 3 services, pinned to httptape v0.10.0 from GHCR
   Dockerfile                     # multi-stage build for the React frontend
 ```

--- a/examples/ts-frontend-first/docker-compose.yml
+++ b/examples/ts-frontend-first/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   upstream:
-    image: ghcr.io/vibewarden/httptape:0.9.0
+    image: ghcr.io/vibewarden/httptape:0.10.0
     command: ["serve", "--fixtures", "/fixtures"]
     volumes:
       - ./mocks/upstream-fixtures:/fixtures:ro
 
   proxy:
-    image: ghcr.io/vibewarden/httptape:0.9.0
+    image: ghcr.io/vibewarden/httptape:0.10.0
     command:
       - proxy
       - --upstream


### PR DESCRIPTION
## Summary

Bumps the pinned httptape image in `examples/ts-frontend-first/docker-compose.yml` (and related README references) from `0.10.0` (wait, was 0.9.0) to `0.10.0` — the version shipping SSE record/replay (#124), response templating (#45), and fixture diffing (#51).

## Changes

- `docker-compose.yml`: image tag `0.9.0` → `0.10.0` on both upstream and proxy services.
- `README.md`: version references updated in quick-start text, pinning callout, and project-layout tree.

## Verified

Brought up the full stack against the newly-bumped image:
- `docker compose up` brings all 3 services healthy.
- `curl http://localhost:3000/` → 200.
- `curl http://localhost:3001/__httptape/health` returns current JSON state.
- `curl -N http://localhost:3001/__httptape/health/stream` emits SSE events (the feature that was the impetus for #121 in v0.9.0 — still working cleanly in v0.10.0).

## Next steps (out of scope)

- #158 adds an SSE chat assistant feature to this demo as a v0.10.0 showcase. That's queued for dedicated PM/dev work.