### PR TITLE
feat(cli): add --sse-timing flag to serve and proxy (#162)

### DIFF
--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -121,6 +122,33 @@ func run(args []string) int {
 	return exitOK
 }
 
+// parseSSETiming parses the --sse-timing flag value into an SSETimingMode.
+// Accepted values: "realtime", "instant", "accelerated=<factor>".
+// Returns an error (suitable for wrapping in *usageError) on invalid input.
+func parseSSETiming(s string) (httptape.SSETimingMode, error) {
+	switch {
+	case s == "realtime":
+		return httptape.SSETimingRealtime(), nil
+	case s == "instant":
+		return httptape.SSETimingInstant(), nil
+	case strings.HasPrefix(s, "accelerated="):
+		raw := strings.TrimPrefix(s, "accelerated=")
+		if raw == "" {
+			return nil, fmt.Errorf("invalid --sse-timing %q: accelerated requires a factor (e.g., accelerated=5). Valid modes: realtime, instant, accelerated=<factor>", s)
+		}
+		factor, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --sse-timing %q: factor is not a valid number. Valid modes: realtime, instant, accelerated=<factor>", s)
+		}
+		if factor <= 0 {
+			return nil, fmt.Errorf("invalid --sse-timing %q: factor must be greater than 0. Valid modes: realtime, instant, accelerated=<factor>", s)
+		}
+		return httptape.SSETimingAccelerated(factor), nil
+	default:
+		return nil, fmt.Errorf("invalid --sse-timing %q: valid modes are realtime, instant, accelerated=<factor>", s)
+	}
+}
+
 func runServe(args []string) error {
 	fs := flag.NewFlagSet("httptape serve", flag.ContinueOnError)
 	fixtures := fs.String("fixtures", "", "Path to fixture directory (required)")
@@ -132,6 +160,7 @@ func runServe(args []string) error {
 	errorRate := fs.Float64("error-rate", 0, "Fraction of requests that return 500 (0.0-1.0)")
 	var replayHeaders repeatableFlag
 	fs.Var(&replayHeaders, "replay-header", "Header to inject into responses (Key=Value, repeatable)")
+	sseTiming := fs.String("sse-timing", "", "SSE replay timing mode: realtime, instant, accelerated=<factor>")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -149,6 +178,13 @@ func runServe(args []string) error {
 
 	var serverOpts []httptape.ServerOption
 	serverOpts = append(serverOpts, httptape.WithFallbackStatus(*fallbackStatus))
+	if *sseTiming != "" {
+		mode, err := parseSSETiming(*sseTiming)
+		if err != nil {
+			return &usageError{err}
+		}
+		serverOpts = append(serverOpts, httptape.WithSSETiming(mode))
+	}
 	if *cors {
 		serverOpts = append(serverOpts, httptape.WithCORS())
 	}
@@ -340,6 +376,7 @@ func runProxy(args []string) error {
 	upstreamProbeInterval := fs.Duration("upstream-probe-interval", 0,
 		"Active upstream probe cadence. 0 = disabled. When --health-endpoint is set "+
 			"and this is unset, defaults to 2s.")
+	sseTiming := fs.String("sse-timing", "", "SSE replay timing mode: realtime, instant, accelerated=<factor>")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -402,6 +439,14 @@ func runProxy(args []string) error {
 			}
 			return resp != nil && resp.StatusCode >= 500
 		}))
+	}
+
+	if *sseTiming != "" {
+		mode, err := parseSSETiming(*sseTiming)
+		if err != nil {
+			return &usageError{err}
+		}
+		proxyOpts = append(proxyOpts, httptape.WithProxySSETiming(mode))
 	}
 
 	if *healthEndpoint {

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -362,6 +362,115 @@ func TestProxyHealthEndpointMounted(t *testing.T) {
 	}
 }
 
+func TestParseSSETiming(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string // substring expected in the error message
+	}{
+		{name: "realtime", input: "realtime", wantErr: false},
+		{name: "instant", input: "instant", wantErr: false},
+		{name: "accelerated integer", input: "accelerated=5", wantErr: false},
+		{name: "accelerated float", input: "accelerated=2.5", wantErr: false},
+		{name: "accelerated fractional", input: "accelerated=0.1", wantErr: false},
+		{name: "empty string", input: "", wantErr: true, errMsg: "valid modes are"},
+		{name: "unknown mode", input: "turbo", wantErr: true, errMsg: "valid modes are"},
+		{name: "accelerated missing factor", input: "accelerated=", wantErr: true, errMsg: "accelerated requires a factor"},
+		{name: "accelerated non-numeric", input: "accelerated=fast", wantErr: true, errMsg: "not a valid number"},
+		{name: "accelerated zero", input: "accelerated=0", wantErr: true, errMsg: "must be greater than 0"},
+		{name: "accelerated negative", input: "accelerated=-1", wantErr: true, errMsg: "must be greater than 0"},
+		{name: "accelerated no equals", input: "accelerated", wantErr: true, errMsg: "valid modes are"},
+		{name: "case sensitive realtime", input: "Realtime", wantErr: true, errMsg: "valid modes are"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mode, err := parseSSETiming(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseSSETiming(%q) = %v, want error", tt.input, mode)
+				}
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("parseSSETiming(%q) error = %q, want substring %q", tt.input, err.Error(), tt.errMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSSETiming(%q) unexpected error: %v", tt.input, err)
+			}
+			if mode == nil {
+				t.Fatalf("parseSSETiming(%q) returned nil mode", tt.input)
+			}
+		})
+	}
+}
+
+func TestSSETimingFlagIntegration(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantCode int
+	}{
+		{
+			name:     "serve valid realtime",
+			args:     []string{"serve", "--fixtures", tmpDir, "--sse-timing", "realtime", "-h"},
+			wantCode: exitOK,
+		},
+		{
+			name:     "serve valid instant",
+			args:     []string{"serve", "--fixtures", tmpDir, "--sse-timing", "instant", "-h"},
+			wantCode: exitOK,
+		},
+		{
+			name:     "serve valid accelerated",
+			args:     []string{"serve", "--fixtures", tmpDir, "--sse-timing", "accelerated=10", "-h"},
+			wantCode: exitOK,
+		},
+		{
+			name:     "serve invalid mode",
+			args:     []string{"serve", "--fixtures", tmpDir, "--sse-timing", "bogus"},
+			wantCode: exitUsage,
+		},
+		{
+			name:     "serve accelerated zero",
+			args:     []string{"serve", "--fixtures", tmpDir, "-sse-timing", "accelerated=0"},
+			wantCode: exitUsage,
+		},
+		{
+			name:     "serve accelerated missing factor",
+			args:     []string{"serve", "--fixtures", tmpDir, "--sse-timing", "accelerated="},
+			wantCode: exitUsage,
+		},
+		{
+			name:     "proxy invalid mode",
+			args:     []string{"proxy", "--upstream", "http://example.com", "--fixtures", tmpDir, "--sse-timing", "nope"},
+			wantCode: exitUsage,
+		},
+		{
+			name:     "proxy valid instant",
+			args:     []string{"proxy", "--upstream", "http://example.com", "--fixtures", tmpDir, "--sse-timing", "instant", "-h"},
+			wantCode: exitOK,
+		},
+		{
+			name:     "serve no sse-timing flag",
+			args:     []string{"serve", "--fixtures", tmpDir, "-h"},
+			wantCode: exitOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := run(tt.args)
+			if got != tt.wantCode {
+				t.Errorf("run(%v) = %d, want %d", tt.args, got, tt.wantCode)
+			}
+		})
+	}
+}
+
 func itoa(i int) string {
 	const digits = "0123456789"
 	if i == 0 {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,7 @@ httptape serve --fixtures ./fixtures [flags]
 | `--delay` | `0` | Fixed delay before every response (e.g., `200ms`, `1s`) |
 | `--error-rate` | `0` | Fraction of requests that return 500 (0.0-1.0) |
 | `--replay-header` | (none) | Header to inject into responses (`Key=Value`, repeatable) |
+| `--sse-timing` | (none) | SSE replay timing mode: `realtime`, `instant`, `accelerated=<factor>`. When unset, the library default (`realtime`) is used. |
 | `--config` | (none) | Path to redaction config JSON. Accepted but not currently used by `serve` (reserved for future use). |
 
 The server uses `DefaultMatcher` (method + path matching) and loads fixtures from the specified directory. It shuts down gracefully on SIGINT/SIGTERM.
@@ -91,6 +92,7 @@ httptape proxy --upstream <url> --fixtures <dir> [flags]
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
 | `--fallback-on-5xx` | `false` | Also fall back on 5xx responses from upstream |
+| `--sse-timing` | (none) | SSE replay timing mode for L2 fallback: `realtime`, `instant`, `accelerated=<factor>`. When unset, the library default (`instant`) is used. |
 | `--tls-cert` | (none) | Path to PEM client certificate for mTLS. See [TLS](tls.md). |
 | `--tls-key` | (none) | Path to PEM client private key for mTLS. See [TLS](tls.md). |
 | `--tls-ca` | (none) | Path to PEM CA certificate(s) for upstream verification. See [TLS](tls.md). |


### PR DESCRIPTION
Closes #162

## Summary

- Added `parseSSETiming` helper in `cmd/httptape/main.go` that parses `--sse-timing` flag values (`realtime`, `instant`, `accelerated=<factor>`) into `httptape.SSETimingMode`.
- Registered `--sse-timing` flag on both `serve` (wired to `WithSSETiming`) and `proxy` (wired to `WithProxySSETiming`) subcommands.
- When the flag is unset (empty string), no option is appended and library defaults are preserved (`realtime` for Server, `instant` for Proxy L2 fallback).
- All validation errors are wrapped in `*usageError` (exit code 1) with descriptive messages listing valid modes.
- Updated `docs/cli.md` with the new flag on both subcommand tables.

## Example invocations

```bash
httptape serve --fixtures ./mocks --sse-timing=realtime
httptape serve --fixtures ./mocks --sse-timing=instant
httptape serve --fixtures ./mocks --sse-timing=accelerated=5
httptape proxy --upstream=https://api.example.com --fixtures ./cache --sse-timing=realtime
```

## Test plan

- [x] `TestParseSSETiming` — 13 table-driven cases covering all valid modes, empty input, unknown modes, missing/invalid/zero/negative factors, case sensitivity
- [x] `TestSSETimingFlagIntegration` — 9 end-to-end cases via `run()` verifying exit codes for valid and invalid flag values on both `serve` and `proxy`
- [x] `go test ./... -race` clean
- [x] `go vet ./...` clean
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)