### PR TITLE
feat(examples): SSE chat assistant showcase for ts-frontend-first (#158)

### DIFF
--- a/examples/ts-frontend-first/README.md
+++ b/examples/ts-frontend-first/README.md
@@ -85,11 +85,11 @@ httptape's `RedactSSEEventData` and `FakeSSEEventData` sanitization functions op
 docker compose up
 ```
 
-Pulls `ghcr.io/vibewarden/httptape:0.10.0` (the version that introduced SSE record/replay) and builds the React frontend. No local Go build needed.
+Pulls `ghcr.io/vibewarden/httptape:0.10.1` (v0.10.0 introduced SSE record/replay; v0.10.1 added the `--sse-timing` CLI flag this demo uses to preserve typewriter cadence on cache fallback). Also builds the React frontend. No local Go build needed.
 
 Open [http://localhost:3000](http://localhost:3000).
 
-> Pinned to `0.10.0` for reproducibility. To track latest, change the image to `ghcr.io/vibewarden/httptape:latest`.
+> Pinned to `0.10.1` for reproducibility. To track latest, change the image to `ghcr.io/vibewarden/httptape:latest`.
 
 ## Try it
 
@@ -155,6 +155,6 @@ ts-frontend-first/
     toggle-upstream.sh           # one-liner to flip upstream up/down
   .httptape-cache/               # L2 cache — generated, gitignored
     fixtures/                    # populated on first request, used as L2 fallback
-  docker-compose.yml             # 3 services, pinned to httptape v0.10.0 from GHCR
+  docker-compose.yml             # 3 services, pinned to httptape v0.10.1 from GHCR
   Dockerfile                     # multi-stage build for the React frontend
 ```

--- a/examples/ts-frontend-first/README.md
+++ b/examples/ts-frontend-first/README.md
@@ -59,6 +59,26 @@ The proxy exposes `GET /__httptape/health/stream` (Server-Sent Events) when star
 
 No polling, no manual refresh. See [`src/useHealthStream.ts`](src/useHealthStream.ts).
 
+## Ask the assistant
+
+Below the product grid, the demo includes an **AI shopping assistant** section with three pre-defined questions. Click a button and watch the response stream in word-by-word, exactly like a real LLM chat completion.
+
+### How it works (and why it's the same as recording an OpenAI streaming call)
+
+The three assistant fixtures in `mocks/upstream-fixtures/` (`get-assist-headphones.json`, `get-assist-keyboard.json`, `get-assist-hub.json`) are hand-authored httptape `Tape` recordings with `sse_events` arrays. Each fixture contains 25 SSE events using OpenAI-style `{"delta": "..."}` JSON payloads, with a final `[DONE]` sentinel to signal stream completion.
+
+The wire format is **identical** to what you would get by recording a real `chat.completions.create(stream=True)` call with httptape:
+
+1. The Recorder detects `Content-Type: text/event-stream` and parses individual SSE frames.
+2. Each frame is stored as an `SSEEvent` with its `offset_ms` timestamp (milliseconds since response headers).
+3. On replay, `WithSSETiming(SSETimingRealtime())` (the default) re-introduces the original inter-event delays, producing the typewriter effect in the browser.
+
+The only difference is that these fixtures were written by hand rather than captured from a live API -- the recording flow, storage format, and replay behavior are exactly the same. You could replace these fixtures with real recorded LLM responses and the demo would work identically.
+
+### Per-event sanitization
+
+httptape's `RedactSSEEventData` and `FakeSSEEventData` sanitization functions operate on individual SSE event payloads, so PII inside streamed LLM completions is redacted before it touches disk. To see this in action, configure the proxy with `RedactSSEEventData` in the sanitization pipeline and watch the L2 cache in `.httptape-cache/`. The JSON config parser does not yet support SSE-specific rules, so this requires programmatic (Go API) configuration.
+
 ## Quick start
 
 ```bash
@@ -117,14 +137,19 @@ Each file is a single httptape `Tape` (request/response pair).
 ts-frontend-first/
   src/
     api.ts                       # fetch wrapper
-    App.tsx                      # main app: profile + product grid + add-to-cart
+    App.tsx                      # main app: profile + product grid + assistant + add-to-cart
     useHealthStream.ts           # SSE hook driving the badge + refetch
+    useAssistantStream.ts        # SSE hook for AI assistant streaming (OpenAI-style deltas)
     components/
       ProfileCard.tsx            # identity + credit-card visualization (shows redaction)
+      Assistant.tsx              # AI assistant: query buttons + streaming output
       ArchitectureDiagram.tsx    # live diagram of upstream/cache state
       Instructions.tsx           # the "Try it" copy-button list
   mocks/
     upstream-fixtures/           # source of truth — committed
+      get-assist-headphones.json # SSE fixture: headphones recommendation (25 events)
+      get-assist-keyboard.json   # SSE fixture: keyboard recommendation (25 events)
+      get-assist-hub.json        # SSE fixture: hub recommendation (25 events)
     sanitize.json                # httptape redaction config (typed fakers)
   scripts/
     toggle-upstream.sh           # one-liner to flip upstream up/down

--- a/examples/ts-frontend-first/docker-compose.yml
+++ b/examples/ts-frontend-first/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   upstream:
-    image: ghcr.io/vibewarden/httptape:0.10.0
+    image: ghcr.io/vibewarden/httptape:0.10.1
     command: ["serve", "--fixtures", "/fixtures"]
     volumes:
       - ./mocks/upstream-fixtures:/fixtures:ro
 
   proxy:
-    image: ghcr.io/vibewarden/httptape:0.10.0
+    image: ghcr.io/vibewarden/httptape:0.10.1
     command:
       - proxy
       - --upstream
@@ -21,6 +21,7 @@ services:
       - --fallback-on-5xx
       - --health-endpoint
       - --upstream-probe-interval=2s
+      - --sse-timing=realtime
     volumes:
       - ./.httptape-cache/fixtures:/fixtures
       - ./mocks/sanitize.json:/config/sanitize.json:ro

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-headphones.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-headphones.json
@@ -1,0 +1,48 @@
+{
+  "id": "a1b2c3d4-0004-4000-8000-000000000004",
+  "route": "assist",
+  "recorded_at": "2026-04-16T10:00:00Z",
+  "request": {
+    "method": "GET",
+    "url": "/api/assist/headphones",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["text/event-stream"],
+      "Cache-Control": ["no-cache"],
+      "Connection": ["keep-alive"]
+    },
+    "body": null,
+    "sse_events": [
+      { "offset_ms": 100, "data": "{\"delta\":\"For office\"}" },
+      { "offset_ms": 180, "data": "{\"delta\":\" use, the\"}" },
+      { "offset_ms": 255, "data": "{\"delta\":\" Noise-Cancelling Headphones\"}" },
+      { "offset_ms": 340, "data": "{\"delta\":\" are the\"}" },
+      { "offset_ms": 410, "data": "{\"delta\":\" best pick.\"}" },
+      { "offset_ms": 495, "data": "{\"delta\":\" With 30-hour\"}" },
+      { "offset_ms": 575, "data": "{\"delta\":\" battery life\"}" },
+      { "offset_ms": 650, "data": "{\"delta\":\" and hybrid\"}" },
+      { "offset_ms": 740, "data": "{\"delta\":\" ANC, you\"}" },
+      { "offset_ms": 820, "data": "{\"delta\":\" can focus\"}" },
+      { "offset_ms": 895, "data": "{\"delta\":\" through meetings\"}" },
+      { "offset_ms": 985, "data": "{\"delta\":\" or commutes\"}" },
+      { "offset_ms": 1055, "data": "{\"delta\":\" without hearing\"}" },
+      { "offset_ms": 1140, "data": "{\"delta\":\" coworkers, planes,\"}" },
+      { "offset_ms": 1215, "data": "{\"delta\":\" or cafe\"}" },
+      { "offset_ms": 1300, "data": "{\"delta\":\" noise. They\"}" },
+      { "offset_ms": 1380, "data": "{\"delta\":\" fold flat\"}" },
+      { "offset_ms": 1455, "data": "{\"delta\":\" for travel\"}" },
+      { "offset_ms": 1545, "data": "{\"delta\":\" and the\"}" },
+      { "offset_ms": 1620, "data": "{\"delta\":\" multipoint Bluetooth\"}" },
+      { "offset_ms": 1710, "data": "{\"delta\":\" lets you\"}" },
+      { "offset_ms": 1785, "data": "{\"delta\":\" switch between\"}" },
+      { "offset_ms": 1870, "data": "{\"delta\":\" laptop and\"}" },
+      { "offset_ms": 1940, "data": "{\"delta\":\" phone seamlessly.\"}" },
+      { "offset_ms": 1950, "data": "[DONE]" }
+    ]
+  }
+}

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-hub.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-hub.json
@@ -1,0 +1,48 @@
+{
+  "id": "a1b2c3d4-0006-4000-8000-000000000006",
+  "route": "assist",
+  "recorded_at": "2026-04-16T10:02:00Z",
+  "request": {
+    "method": "GET",
+    "url": "/api/assist/hub",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["text/event-stream"],
+      "Cache-Control": ["no-cache"],
+      "Connection": ["keep-alive"]
+    },
+    "body": null,
+    "sse_events": [
+      { "offset_ms": 100, "data": "{\"delta\":\"The USB-C\"}" },
+      { "offset_ms": 175, "data": "{\"delta\":\" Hub handles\"}" },
+      { "offset_ms": 260, "data": "{\"delta\":\" both needs\"}" },
+      { "offset_ms": 340, "data": "{\"delta\":\" perfectly. The\"}" },
+      { "offset_ms": 415, "data": "{\"delta\":\" 4K HDMI\"}" },
+      { "offset_ms": 500, "data": "{\"delta\":\" output drives\"}" },
+      { "offset_ms": 575, "data": "{\"delta\":\" external monitors\"}" },
+      { "offset_ms": 660, "data": "{\"delta\":\" at full\"}" },
+      { "offset_ms": 735, "data": "{\"delta\":\" resolution, while\"}" },
+      { "offset_ms": 820, "data": "{\"delta\":\" 100W passthrough\"}" },
+      { "offset_ms": 900, "data": "{\"delta\":\" charging keeps\"}" },
+      { "offset_ms": 975, "data": "{\"delta\":\" your laptop\"}" },
+      { "offset_ms": 1060, "data": "{\"delta\":\" powered all\"}" },
+      { "offset_ms": 1135, "data": "{\"delta\":\" day. The\"}" },
+      { "offset_ms": 1220, "data": "{\"delta\":\" built-in SD\"}" },
+      { "offset_ms": 1300, "data": "{\"delta\":\" card reader\"}" },
+      { "offset_ms": 1380, "data": "{\"delta\":\" and three\"}" },
+      { "offset_ms": 1460, "data": "{\"delta\":\" USB-A ports\"}" },
+      { "offset_ms": 1535, "data": "{\"delta\":\" connect all\"}" },
+      { "offset_ms": 1620, "data": "{\"delta\":\" your peripherals\"}" },
+      { "offset_ms": 1700, "data": "{\"delta\":\" without any\"}" },
+      { "offset_ms": 1775, "data": "{\"delta\":\" dongles. At\"}" },
+      { "offset_ms": 1860, "data": "{\"delta\":\" $34.50, it's\"}" },
+      { "offset_ms": 1935, "data": "{\"delta\":\" a no-brainer.\"}" },
+      { "offset_ms": 1950, "data": "[DONE]" }
+    ]
+  }
+}

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-keyboard.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-keyboard.json
@@ -1,0 +1,48 @@
+{
+  "id": "a1b2c3d4-0005-4000-8000-000000000005",
+  "route": "assist",
+  "recorded_at": "2026-04-16T10:01:00Z",
+  "request": {
+    "method": "GET",
+    "url": "/api/assist/keyboard",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["text/event-stream"],
+      "Cache-Control": ["no-cache"],
+      "Connection": ["keep-alive"]
+    },
+    "body": null,
+    "sse_events": [
+      { "offset_ms": 100, "data": "{\"delta\":\"The Wireless\"}" },
+      { "offset_ms": 185, "data": "{\"delta\":\" Keyboard is\"}" },
+      { "offset_ms": 260, "data": "{\"delta\":\" the top\"}" },
+      { "offset_ms": 345, "data": "{\"delta\":\" choice for\"}" },
+      { "offset_ms": 420, "data": "{\"delta\":\" developers. Low-profile\"}" },
+      { "offset_ms": 500, "data": "{\"delta\":\" mechanical switches\"}" },
+      { "offset_ms": 580, "data": "{\"delta\":\" give you\"}" },
+      { "offset_ms": 660, "data": "{\"delta\":\" fast, precise\"}" },
+      { "offset_ms": 735, "data": "{\"delta\":\" typing with\"}" },
+      { "offset_ms": 820, "data": "{\"delta\":\" satisfying tactile\"}" },
+      { "offset_ms": 900, "data": "{\"delta\":\" feedback, and\"}" },
+      { "offset_ms": 975, "data": "{\"delta\":\" the customizable\"}" },
+      { "offset_ms": 1060, "data": "{\"delta\":\" RGB backlight\"}" },
+      { "offset_ms": 1140, "data": "{\"delta\":\" keeps every\"}" },
+      { "offset_ms": 1215, "data": "{\"delta\":\" key visible\"}" },
+      { "offset_ms": 1300, "data": "{\"delta\":\" during late-night\"}" },
+      { "offset_ms": 1375, "data": "{\"delta\":\" coding sessions.\"}" },
+      { "offset_ms": 1460, "data": "{\"delta\":\" At $49.95,\"}" },
+      { "offset_ms": 1540, "data": "{\"delta\":\" it pairs\"}" },
+      { "offset_ms": 1620, "data": "{\"delta\":\" over Bluetooth\"}" },
+      { "offset_ms": 1695, "data": "{\"delta\":\" with up\"}" },
+      { "offset_ms": 1780, "data": "{\"delta\":\" to three\"}" },
+      { "offset_ms": 1860, "data": "{\"delta\":\" devices at\"}" },
+      { "offset_ms": 1935, "data": "{\"delta\":\" once.\"}" },
+      { "offset_ms": 1950, "data": "[DONE]" }
+    ]
+  }
+}

--- a/examples/ts-frontend-first/package-lock.json
+++ b/examples/ts-frontend-first/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^10.2.0",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.0",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
         "typescript": "~6.0.2",
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0.tgz",
+      "integrity": "sha512-LDicyhrRFrIaheDYryeM2W8gWyZXnAs4zIr2WVPiOSeTmIu2RjR4x/9N0xLaRWZ+9hssBDGo3AadcohuzAvSvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1452,7 +1452,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/examples/ts-frontend-first/package.json
+++ b/examples/ts-frontend-first/package.json
@@ -20,7 +20,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^10.2.0",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.0",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
     "typescript": "~6.0.2",

--- a/examples/ts-frontend-first/src/App.css
+++ b/examples/ts-frontend-first/src/App.css
@@ -382,18 +382,120 @@
 }
 .product-card button:hover { opacity: 0.85; }
 
-/* === Assistant section === */
-.assistant {
-  margin-top: 1.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid var(--border);
+/* === Assistant — floating trigger + modal === */
+.assistant-trigger {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 100;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.15rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 30px rgba(170, 59, 255, 0.35), 0 2px 6px rgba(170, 59, 255, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.assistant-trigger:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 34px rgba(170, 59, 255, 0.45), 0 2px 6px rgba(170, 59, 255, 0.25);
+}
+.assistant-trigger-icon {
+  font-size: 1rem;
+}
+
+.assistant-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(8, 6, 13, 0.55);
+  backdrop-filter: blur(3px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  animation: backdropFadeIn 0.2s ease;
+}
+@keyframes backdropFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.assistant-modal {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  width: min(520px, 100%);
+  max-height: min(80vh, 640px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  animation: modalRise 0.22s ease;
+}
+@keyframes modalRise {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.assistant-modal-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem 0.9rem;
+  border-bottom: 1px solid var(--border);
+}
+.assistant-modal-title {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  flex: 1;
+  min-width: 0;
+}
+.assistant-modal-title h3 {
+  margin: 0;
+  font-size: 0.98rem;
+  color: var(--text-h);
+}
+.assistant-modal-subtitle {
+  margin: 0.1rem 0 0;
+  font-size: 0.65rem;
+  color: var(--text);
+  line-height: 1.35;
+}
+.assistant-close {
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+  border-radius: 6px;
+  transition: background 0.15s;
+}
+.assistant-close:hover {
+  background: var(--code-bg);
+  color: var(--text-h);
+}
+
+.assistant-modal-body {
+  padding: 1rem 1.1rem;
+  overflow-y: auto;
+  flex: 1;
 }
 
 .assistant-buttons {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 0.85rem;
+  margin-bottom: 1rem;
 }
 
 .assistant-query-btn {
@@ -401,9 +503,9 @@
   color: var(--accent);
   border: 1px solid var(--accent-border);
   padding: 0.4rem 0.85rem;
-  border-radius: 6px;
+  border-radius: 999px;
   cursor: pointer;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 500;
   transition: all 0.15s ease;
 }
@@ -411,40 +513,95 @@
   background: var(--accent);
   color: #fff;
 }
+.assistant-query-btn.is-active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
 .assistant-query-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
 
-.assistant-output {
-  min-height: 4rem;
-  padding: 0.85rem 1rem;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 10px;
+/* Chat column */
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 0.25rem 0;
+}
+
+.chat-msg {
+  display: flex;
+  gap: 0.55rem;
+  max-width: 85%;
+  animation: chatFadeIn 0.2s ease;
+}
+@keyframes chatFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.chat-msg-user {
+  align-self: flex-end;
+  flex-direction: row-reverse;
+}
+
+.chat-msg-ai {
+  align-self: flex-start;
+}
+
+.chat-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+  box-shadow: 0 2px 6px rgba(170, 59, 255, 0.25);
+}
+
+.chat-bubble {
+  padding: 0.55rem 0.85rem;
+  border-radius: 14px;
   font-size: 0.82rem;
-  line-height: 1.55;
-  color: var(--text-h);
-}
-
-.assistant-empty {
-  margin: 0;
-  color: var(--text);
-  font-style: italic;
-  font-size: 0.78rem;
-}
-
-.assistant-text {
-  margin: 0;
+  line-height: 1.5;
+  word-break: break-word;
   white-space: pre-wrap;
 }
 
-.assistant-cursor {
+.chat-bubble-user {
+  background: var(--accent);
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-bubble-ai {
+  background: var(--code-bg);
+  color: var(--text-h);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+
+.chat-placeholder {
+  color: var(--text);
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.chat-cursor {
   display: inline-block;
   width: 2px;
   height: 1em;
   background: var(--accent);
-  margin-left: 1px;
+  margin-left: 2px;
   vertical-align: text-bottom;
   animation: cursorBlink 0.8s steps(2) infinite;
 }

--- a/examples/ts-frontend-first/src/App.css
+++ b/examples/ts-frontend-first/src/App.css
@@ -382,6 +382,78 @@
 }
 .product-card button:hover { opacity: 0.85; }
 
+/* === Assistant section === */
+.assistant {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.assistant-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+
+.assistant-query-btn {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border: 1px solid var(--accent-border);
+  padding: 0.4rem 0.85rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 500;
+  transition: all 0.15s ease;
+}
+.assistant-query-btn:hover:not(:disabled) {
+  background: var(--accent);
+  color: #fff;
+}
+.assistant-query-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.assistant-output {
+  min-height: 4rem;
+  padding: 0.85rem 1rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  color: var(--text-h);
+}
+
+.assistant-empty {
+  margin: 0;
+  color: var(--text);
+  font-style: italic;
+  font-size: 0.78rem;
+}
+
+.assistant-text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.assistant-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: var(--accent);
+  margin-left: 1px;
+  vertical-align: text-bottom;
+  animation: cursorBlink 0.8s steps(2) infinite;
+}
+
+@keyframes cursorBlink {
+  0% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
 @media (prefers-color-scheme: dark) {
   .source-live { color: #4ade80; }
   .source-l1 { color: #facc15; }

--- a/examples/ts-frontend-first/src/App.tsx
+++ b/examples/ts-frontend-first/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { getProducts, getProfile, createCart, type Product, type UserProfile, type DataSource } from "./api";
 import { useHealthStream } from "./useHealthStream";
 import { ProfileCard } from "./components/ProfileCard";
+import { Assistant } from "./components/Assistant";
 import { ArchitectureDiagram } from "./components/ArchitectureDiagram";
 import { Instructions } from "./components/Instructions";
 import "./App.css";
@@ -91,6 +92,7 @@ function App() {
                 </div>
               ))}
             </div>
+            <Assistant />
           </>
         )}
       </main>

--- a/examples/ts-frontend-first/src/components/Assistant.tsx
+++ b/examples/ts-frontend-first/src/components/Assistant.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { useAssistantStream } from "../useAssistantStream";
 
 interface Query {
@@ -12,34 +13,106 @@ const QUERIES: Query[] = [
 ];
 
 export function Assistant() {
+  const [open, setOpen] = useState(false);
   const { text, status, start } = useAssistantStream();
+  const [question, setQuestion] = useState<string | null>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom as text streams or new messages appear.
+  useEffect(() => {
+    if (bodyRef.current) {
+      bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+    }
+  }, [text, status, question, open]);
+
+  // Esc closes the modal.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const handleClick = (q: Query) => {
+    setQuestion(q.label);
+    start(q.path);
+  };
 
   return (
-    <section className="assistant">
-      <h2 className="section-title">Ask the assistant</h2>
-      <div className="assistant-buttons">
-        {QUERIES.map((q) => (
-          <button
-            key={q.path}
-            className="assistant-query-btn"
-            disabled={status === "streaming"}
-            onClick={() => start(q.path)}
+    <>
+      <button
+        className="assistant-trigger"
+        onClick={() => setOpen(true)}
+        aria-label="Ask the assistant"
+      >
+        <span className="assistant-trigger-icon" aria-hidden>✨</span>
+        Ask the assistant
+      </button>
+
+      {open && (
+        <div
+          className="assistant-backdrop"
+          onClick={() => setOpen(false)}
+          role="presentation"
+        >
+          <div
+            className="assistant-modal"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Assistant"
           >
-            {q.label}
-          </button>
-        ))}
-      </div>
-      <div className="assistant-output">
-        {status === "idle" && (
-          <p className="assistant-empty">Click a question above to see SSE streaming in action.</p>
-        )}
-        {(status === "streaming" || status === "done") && (
-          <p className="assistant-text">
-            {text}
-            {status === "streaming" && <span className="assistant-cursor" />}
-          </p>
-        )}
-      </div>
-    </section>
+            <header className="assistant-modal-header">
+              <div className="assistant-modal-title">
+                <span className="chat-avatar" aria-hidden>AI</span>
+                <div>
+                  <h3>Shopping assistant</h3>
+                  <p className="assistant-modal-subtitle">Powered by a recorded SSE fixture — same wire format as OpenAI streaming.</p>
+                </div>
+              </div>
+              <button
+                className="assistant-close"
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </header>
+
+            <div className="assistant-modal-body" ref={bodyRef}>
+              <div className="assistant-buttons">
+                {QUERIES.map((q) => (
+                  <button
+                    key={q.path}
+                    className={`assistant-query-btn ${question === q.label ? "is-active" : ""}`}
+                    disabled={status === "streaming"}
+                    onClick={() => handleClick(q)}
+                  >
+                    {q.label}
+                  </button>
+                ))}
+              </div>
+
+              {question && (
+                <div className="chat">
+                  <div className="chat-msg chat-msg-user">
+                    <div className="chat-bubble chat-bubble-user">{question}</div>
+                  </div>
+                  <div className="chat-msg chat-msg-ai">
+                    <div className="chat-avatar" aria-hidden>AI</div>
+                    <div className="chat-bubble chat-bubble-ai">
+                      {text || <span className="chat-placeholder">Thinking…</span>}
+                      {status === "streaming" && <span className="chat-cursor" />}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/examples/ts-frontend-first/src/components/Assistant.tsx
+++ b/examples/ts-frontend-first/src/components/Assistant.tsx
@@ -1,0 +1,45 @@
+import { useAssistantStream } from "../useAssistantStream";
+
+interface Query {
+  label: string;
+  path: string;
+}
+
+const QUERIES: Query[] = [
+  { label: "Best headphones for office use?", path: "/api/assist/headphones" },
+  { label: "Which keyboard for a developer?", path: "/api/assist/keyboard" },
+  { label: "Hub for 4K monitor + USB-C laptop?", path: "/api/assist/hub" },
+];
+
+export function Assistant() {
+  const { text, status, start } = useAssistantStream();
+
+  return (
+    <section className="assistant">
+      <h2 className="section-title">Ask the assistant</h2>
+      <div className="assistant-buttons">
+        {QUERIES.map((q) => (
+          <button
+            key={q.path}
+            className="assistant-query-btn"
+            disabled={status === "streaming"}
+            onClick={() => start(q.path)}
+          >
+            {q.label}
+          </button>
+        ))}
+      </div>
+      <div className="assistant-output">
+        {status === "idle" && (
+          <p className="assistant-empty">Click a question above to see SSE streaming in action.</p>
+        )}
+        {(status === "streaming" || status === "done") && (
+          <p className="assistant-text">
+            {text}
+            {status === "streaming" && <span className="assistant-cursor" />}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/examples/ts-frontend-first/src/useAssistantStream.ts
+++ b/examples/ts-frontend-first/src/useAssistantStream.ts
@@ -1,0 +1,66 @@
+import { useCallback, useRef, useState } from "react";
+
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
+
+export type AssistantStatus = "idle" | "streaming" | "done";
+
+interface AssistantState {
+  text: string;
+  status: AssistantStatus;
+}
+
+/**
+ * Hook that opens an EventSource on the given path and accumulates
+ * streamed text deltas. Expects SSE events with JSON payloads of the
+ * form `{"delta": "..."}` (OpenAI-style wire format). The stream ends
+ * when a `[DONE]` sentinel event is received.
+ */
+export function useAssistantStream(): AssistantState & { start: (path: string) => void } {
+  const [text, setText] = useState("");
+  const [status, setStatus] = useState<AssistantStatus>("idle");
+  const esRef = useRef<EventSource | null>(null);
+
+  const start = useCallback((path: string) => {
+    // Close any existing stream
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+
+    setText("");
+    setStatus("streaming");
+
+    const es = new EventSource(`${API_URL}${path}`);
+    esRef.current = es;
+
+    es.onmessage = (e: MessageEvent) => {
+      const raw: string = e.data;
+
+      // [DONE] sentinel — stream is complete
+      if (raw === "[DONE]") {
+        es.close();
+        esRef.current = null;
+        setStatus("done");
+        return;
+      }
+
+      // Parse JSON delta payload
+      try {
+        const parsed: { delta: string } = JSON.parse(raw);
+        if (typeof parsed.delta === "string") {
+          setText((prev) => prev + parsed.delta);
+        }
+      } catch {
+        // Ignore malformed events
+      }
+    };
+
+    es.onerror = () => {
+      es.close();
+      esRef.current = null;
+      setStatus("done");
+    };
+  }, []);
+
+  return { text, status, start };
+}


### PR DESCRIPTION
## Summary

Adds a working AI shopping assistant to `examples/ts-frontend-first/` that showcases httptape's v0.10.0 SSE record/replay + v0.10.1 `--sse-timing` flag. Click a pre-defined query button, watch text typewriter-stream in via SSE, same wire format you'd get recording a real OpenAI/Anthropic streaming call.

Closes #158.

## What shipped (4 commits on this branch)

### 1. `b29c0cb` — SSE chat assistant foundation

- 3 hand-authored SSE fixtures in `mocks/upstream-fixtures/` (`get-assist-headphones.json`, `get-assist-keyboard.json`, `get-assist-hub.json`)
- 25 events per response, OpenAI-style `{"delta":"..."}` wire format, `[DONE]` sentinel, ~80ms cadence totaling ~1.9s
- New `Assistant.tsx` component, `useAssistantStream.ts` hook (EventSource + delta parsing)
- Distinct URL paths per query (`/api/assist/headphones` etc.) because `DefaultMatcher` doesn't match query strings — architect finding in ADR-36

### 2. `3f0cde4` — eslint-plugin-react-hooks bump (unblocker)

Dependabot's eslint 9→10 bump (#142) landed before the react-hooks plugin had an eslint 10-compatible release. `npm ci` in the example was failing. Bumped `eslint-plugin-react-hooks` 7.0.1 → 7.1.0 and regenerated the lockfile.

### 3. `b8b84aa` — UI redesign: modal with chat bubbles

Based on local testing feedback:
- Assistant moved from inline section (below Products) to a floating ✨ pill button in the bottom-right
- Click opens a centered modal with backdrop (Esc / backdrop-click to close)
- Response layout: chat bubbles — user question on the right (accent), assistant on the left (neutral) with "AI" avatar
- Modal body is scrollable; auto-scrolls to bottom as text streams in
- "Thinking…" placeholder + blinking cursor during streaming

### 4. `4955c02` — v0.10.1 bump + `--sse-timing=realtime`

Fixes a real UX cliff: when upstream is down and proxy serves the SSE fixture from L1/L2 cache, the library default is `SSETimingInstant()` — user sees all text appear at once, losing the typewriter effect the demo is built around. With the new CLI flag (shipped in v0.10.1 via #162), the proxy preserves realtime cadence on fallback too.

Verified: warm L1 with upstream up → stop upstream → cached SSE replays 25 events over ~2s (matches recorded offsets within scheduling tolerance).

## Files touched

```
examples/ts-frontend-first/docker-compose.yml       # image tag + --sse-timing
examples/ts-frontend-first/README.md                # version refs + assistant section
examples/ts-frontend-first/package.json             # eslint-plugin-react-hooks pin
examples/ts-frontend-first/package-lock.json        # regenerated
examples/ts-frontend-first/src/App.tsx              # renders <Assistant />
examples/ts-frontend-first/src/App.css              # modal + chat bubble styles
examples/ts-frontend-first/src/components/Assistant.tsx
examples/ts-frontend-first/src/useAssistantStream.ts
examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-headphones.json
examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-keyboard.json
examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-hub.json
```

No library code changed. No `go.mod`/`go.sum` changes.

## Test plan

- [x] `docker compose up` from `examples/ts-frontend-first/` brings all 3 services healthy
- [x] Frontend at http://localhost:3000 loads; floating pill button visible
- [x] Click pill → modal opens with 3 query buttons
- [x] Click each query → 25 events stream in with typewriter cadence (~1.9s)
- [x] Close modal (× button, Esc, backdrop click) — all work
- [x] Stop upstream → click a previously-used query → realtime cadence preserved via `--sse-timing=realtime`
- [x] `npx tsc -b` clean (verified in Docker build)
- [x] `npm run build` clean
- [x] `go test ./... -race` on the library itself clean (no library code changes)

## Known limitations

- Fresh-query + upstream-down leaves the modal in a perpetual "Thinking…" state (EventSource gets transport error). Tracked in #164.
- Fixtures are hand-authored. The demo's README calls out that the wire format matches real LLM streaming exactly, and a real recording of `chat.completions.create(stream=True)` would produce byte-equivalent events.

## Follow-up already filed

- **#164** — what the proxy should do on cache miss + upstream down (general HTTP + SSE). Orthogonal to this PR.