### PR TITLE
fix(matcher): MatchBodyFuzzy vacuous-true for body-less requests (#178)

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -389,8 +389,9 @@ func headerContains(h http.Header, canonicalKey, value string) bool {
 //     (nil, empty, or not valid JSON), the criterion returns 1 (vacuous
 //     match — the body dimension is irrelevant for this request/tape
 //     pair). If exactly one side is absent, the criterion returns 0.
-//   - Both bodies are unmarshaled as JSON. If either body is not valid JSON,
-//     the criterion returns 0 (no match).
+//   - When both bodies are present (not absent per the rule above),
+//     they are unmarshaled as JSON. Path extraction and comparison
+//     proceeds on the unmarshaled values.
 //   - For each specified path, the value is extracted from both the request
 //     and the tape body. If a path does not exist in both bodies, it is
 //     skipped (does not cause a mismatch).

--- a/matcher.go
+++ b/matcher.go
@@ -385,6 +385,10 @@ func headerContains(h http.Header, canonicalKey, value string) bool {
 //   - $.array[*].field    -- field within each element of an array
 //
 // Matching semantics:
+//   - If both the incoming request body and the tape body are absent
+//     (nil, empty, or not valid JSON), the criterion returns 1 (vacuous
+//     match — the body dimension is irrelevant for this request/tape
+//     pair). If exactly one side is absent, the criterion returns 0.
 //   - Both bodies are unmarshaled as JSON. If either body is not valid JSON,
 //     the criterion returns 0 (no match).
 //   - For each specified path, the value is extracted from both the request
@@ -404,7 +408,8 @@ func headerContains(h http.Header, canonicalKey, value string) bool {
 //
 // Invalid or unsupported paths are silently ignored (same as RedactBodyPaths).
 //
-// Returns score 6 on match, 0 on mismatch.
+// Returns score 6 on match, 1 on vacuous match (both bodies absent),
+// 0 on mismatch.
 //
 // Note: using both MatchBodyFuzzy and MatchBodyHash in the same
 // CompositeMatcher is safe but semantically redundant. If MatchBodyHash
@@ -443,12 +448,17 @@ func MatchBodyFuzzy(paths ...string) MatchCriterion {
 			reqBody = bodyBytes
 		}
 
-		// Unmarshal both bodies.
+		// Determine whether each side is "absent" (nil, empty, or not valid JSON).
 		var reqData, tapeData any
-		if err := json.Unmarshal(reqBody, &reqData); err != nil {
-			return 0
+		reqAbsent := len(reqBody) == 0 || json.Unmarshal(reqBody, &reqData) != nil
+		tapeAbsent := len(candidate.Request.Body) == 0 || json.Unmarshal(candidate.Request.Body, &tapeData) != nil
+
+		// Vacuous-true: both bodies absent — return minimum positive score.
+		if reqAbsent && tapeAbsent {
+			return 1
 		}
-		if err := json.Unmarshal(candidate.Request.Body, &tapeData); err != nil {
+		// Asymmetric: one absent, one present — mismatch.
+		if reqAbsent || tapeAbsent {
 			return 0
 		}
 

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1286,6 +1286,48 @@ func TestMatchBodyFuzzy_VacuousTrue(t *testing.T) {
 	}
 }
 
+func TestMatchBodyFuzzy_VacuousTrueComposability(t *testing.T) {
+	// Integration test: validates the real user story from issue #178.
+	// A CompositeMatcher with MatchMethod, MatchPath, and MatchBodyFuzzy
+	// must correctly match a body-less GET request against a body-less
+	// GET tape, without MatchBodyFuzzy eliminating the candidate via score 0.
+	matcher := NewCompositeMatcher(
+		MatchMethod(),
+		MatchPath(),
+		MatchBodyFuzzy("$.action"),
+	)
+
+	// Candidate tapes: one body-less GET and one bodied POST.
+	getTape := Tape{
+		ID: "get-tape",
+		Request: RecordedReq{
+			Method: "GET",
+			URL:    "http://example.com/test",
+			Body:   nil, // no body
+		},
+	}
+	postTape := Tape{
+		ID: "post-tape",
+		Request: RecordedReq{
+			Method: "POST",
+			URL:    "http://example.com/test",
+			Body:   []byte(`{"action":"create"}`),
+		},
+	}
+	candidates := []Tape{getTape, postTape}
+
+	// Incoming request: GET /test with no body.
+	req := httptest.NewRequest("GET", "/test", nil)
+
+	matched, ok := matcher.Match(req, candidates)
+	if !ok {
+		t.Fatal("CompositeMatcher.Match() returned ok=false, want a match")
+	}
+	if matched.ID != "get-tape" {
+		t.Errorf("CompositeMatcher.Match() matched tape ID = %q, want %q", matched.ID, "get-tape")
+	}
+}
+
 func TestMatchBodyFuzzy_InvalidPaths(t *testing.T) {
 	// All paths invalid => parsed list is empty => returns 0
 	criterion := MatchBodyFuzzy("not-a-path", "also-bad")

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1175,8 +1175,114 @@ func TestMatchBodyFuzzy_BothBodiesEmpty(t *testing.T) {
 	tape := Tape{Request: RecordedReq{Body: nil}}
 
 	got := criterion(req, tape)
-	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() both empty = %d, want 0", got)
+	if got != 1 {
+		t.Errorf("MatchBodyFuzzy() both empty = %d, want 1", got)
+	}
+}
+
+func TestMatchBodyFuzzy_VacuousTrue(t *testing.T) {
+	criterion := MatchBodyFuzzy("$.action")
+
+	tests := []struct {
+		name     string
+		reqBody  []byte // nil means no body on the request
+		tapeBody []byte // nil means no body on the tape
+		want     int
+	}{
+		{
+			name:     "both nil",
+			reqBody:  nil,
+			tapeBody: nil,
+			want:     1,
+		},
+		{
+			name:     "both empty bytes",
+			reqBody:  []byte{},
+			tapeBody: []byte{},
+			want:     1,
+		},
+		{
+			name:     "req nil tape empty",
+			reqBody:  nil,
+			tapeBody: []byte{},
+			want:     1,
+		},
+		{
+			name:     "req empty tape nil",
+			reqBody:  []byte{},
+			tapeBody: nil,
+			want:     1,
+		},
+		{
+			name:     "both invalid JSON",
+			reqBody:  []byte("not json"),
+			tapeBody: []byte("also not json"),
+			want:     1,
+		},
+		{
+			name:     "req nil tape has body",
+			reqBody:  nil,
+			tapeBody: []byte(`{"action":"create"}`),
+			want:     0,
+		},
+		{
+			name:     "req has body tape nil",
+			reqBody:  []byte(`{"action":"create"}`),
+			tapeBody: nil,
+			want:     0,
+		},
+		{
+			name:     "req invalid tape has body",
+			reqBody:  []byte("not json"),
+			tapeBody: []byte(`{"action":"create"}`),
+			want:     0,
+		},
+		{
+			name:     "req has body tape invalid",
+			reqBody:  []byte(`{"action":"create"}`),
+			tapeBody: []byte("not json"),
+			want:     0,
+		},
+		{
+			name:     "both empty JSON objects",
+			reqBody:  []byte(`{}`),
+			tapeBody: []byte(`{}`),
+			want:     0,
+		},
+		{
+			name:     "both JSON null",
+			reqBody:  []byte(`null`),
+			tapeBody: []byte(`null`),
+			want:     0,
+		},
+		{
+			name:     "both bodied fields match",
+			reqBody:  []byte(`{"action":"create"}`),
+			tapeBody: []byte(`{"action":"create"}`),
+			want:     6,
+		},
+		{
+			name:     "both bodied fields differ",
+			reqBody:  []byte(`{"action":"create"}`),
+			tapeBody: []byte(`{"action":"delete"}`),
+			want:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body io.Reader
+			if tt.reqBody != nil {
+				body = bytes.NewReader(tt.reqBody)
+			}
+			req := httptest.NewRequest("POST", "/test", body)
+			tape := Tape{Request: RecordedReq{Body: tt.tapeBody}}
+
+			got := criterion(req, tape)
+			if got != tt.want {
+				t.Errorf("MatchBodyFuzzy() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #178

## Summary

- `MatchBodyFuzzy` now returns score 1 (vacuous match) when both the incoming request body and the tape body are absent (nil, empty, or not valid JSON), instead of returning 0 which incorrectly eliminated body-less requests (GET, DELETE, HEAD) from matching.
- When exactly one side is absent, the criterion returns 0 (asymmetric mismatch).
- When both sides have valid JSON, the existing field-extraction and `reflect.DeepEqual` logic is unchanged (returns 6 on match, 0 on mismatch).
- Implements ADR-37 from `decisions.md`.

## Test plan

- [x] Updated `TestMatchBodyFuzzy_BothBodiesEmpty` expected score from 0 to 1
- [x] Added `TestMatchBodyFuzzy_VacuousTrue` table-driven test with 13 sub-cases:
  - both nil -> 1
  - both empty bytes -> 1
  - req nil / tape empty -> 1
  - req empty / tape nil -> 1
  - both invalid JSON -> 1
  - req nil / tape has body -> 0
  - req has body / tape nil -> 0
  - req invalid / tape has body -> 0
  - req has body / tape invalid -> 0
  - both empty JSON objects `{}` -> 0 (valid JSON, no paths match)
  - both JSON `null` -> 0 (valid JSON, paths fail extraction)
  - both bodied fields match -> 6 (unchanged)
  - both bodied fields differ -> 0 (unchanged)
- [x] All existing `TestMatchBodyFuzzy_*` tests pass unchanged
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)