### PR TITLE
refactor(matcher): Criterion interface (#179)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ httptape/
   sanitizer_test.go
   server.go            # Mock HTTP server (http.Handler, includes ServerOption)
   server_test.go
-  matcher.go           # Matcher interface, MatchCriterion, CompositeMatcher, ExactMatcher
+  matcher.go           # Matcher interface, Criterion, CompositeMatcher, ExactMatcher
   matcher_test.go
   store.go             # Storage port (interface)
   store_file.go        # Filesystem storage adapter (includes FileStoreOption)

--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ Composable matching with weighted scoring:
 ```go
 srv := httptape.NewServer(store,
     httptape.WithMatcher(httptape.NewCompositeMatcher(
-        httptape.MatchMethod(),      // score: 1
-        httptape.MatchPath(),        // score: 2
-        httptape.MatchHeaders("Accept", "application/json"), // score: 3
-        httptape.MatchQueryParams(), // score: 4
-        httptape.MatchBodyHash(),    // score: 8
+        httptape.MethodCriterion{},                                        // score: 1
+        httptape.PathCriterion{},                                          // score: 2
+        httptape.HeadersCriterion{Key: "Accept", Value: "application/json"}, // score: 3
+        httptape.QueryParamsCriterion{},                                   // score: 4
+        httptape.BodyHashCriterion{},                                      // score: 8
     )),
 )
 ```

--- a/doc.go
+++ b/doc.go
@@ -43,9 +43,9 @@
 //
 // The [Matcher] interface controls how incoming requests are matched to
 // recorded tapes. [DefaultMatcher] provides method + path matching via a
-// [CompositeMatcher]. Individual [MatchCriterion] functions (e.g.,
-// [MatchMethod], [MatchPath], [MatchQueryParams], [MatchBodyHash]) can be
-// composed for custom matching strategies.
+// [CompositeMatcher]. Individual [Criterion] implementations (e.g.,
+// [MethodCriterion], [PathCriterion], [QueryParamsCriterion], [BodyHashCriterion])
+// can be composed for custom matching strategies.
 //
 // # Health endpoints (proxy mode)
 //

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -249,29 +249,36 @@ type Matcher interface {
 type MatcherFunc func(req *http.Request, candidates []Tape) (Tape, bool)
 func (f MatcherFunc) Match(req *http.Request, candidates []Tape) (Tape, bool)
 
-type MatchCriterion func(req *http.Request, candidate Tape) int
+type Criterion interface {
+    Score(req *http.Request, candidate Tape) int
+    Name() string
+}
+
+type CriterionFunc func(req *http.Request, candidate Tape) int
+func (f CriterionFunc) Score(req *http.Request, candidate Tape) int
+func (f CriterionFunc) Name() string  // returns "custom"
 ```
 
 ### Matchers
 
 ```go
-func DefaultMatcher() *CompositeMatcher          // MatchMethod + MatchPath
+func DefaultMatcher() *CompositeMatcher          // MethodCriterion + PathCriterion
 func ExactMatcher() Matcher                       // first method+path match
-func NewCompositeMatcher(criteria ...MatchCriterion) *CompositeMatcher
+func NewCompositeMatcher(criteria ...Criterion) *CompositeMatcher
 ```
 
 ### Built-in criteria
 
-| Function | Signature | Score |
-|----------|-----------|-------|
-| MatchMethod | `MatchMethod() MatchCriterion` | 1 |
-| MatchPath | `MatchPath() MatchCriterion` | 2 |
-| MatchPathRegex | `MatchPathRegex(pattern string) (MatchCriterion, error)` | 1 |
-| MatchRoute | `MatchRoute(route string) MatchCriterion` | 1 |
-| MatchHeaders | `MatchHeaders(key, value string) MatchCriterion` | 3 |
-| MatchQueryParams | `MatchQueryParams() MatchCriterion` | 4 |
-| MatchBodyFuzzy | `MatchBodyFuzzy(paths ...string) MatchCriterion` | 6 |
-| MatchBodyHash | `MatchBodyHash() MatchCriterion` | 8 |
+| Criterion | Construction | Score |
+|-----------|-------------|-------|
+| MethodCriterion | `MethodCriterion{}` | 1 |
+| PathCriterion | `PathCriterion{}` | 2 |
+| PathRegexCriterion | `NewPathRegexCriterion(pattern string) (*PathRegexCriterion, error)` | 1 |
+| RouteCriterion | `RouteCriterion{Route: route}` | 1 |
+| HeadersCriterion | `HeadersCriterion{Key: key, Value: value}` | 3 |
+| QueryParamsCriterion | `QueryParamsCriterion{}` | 4 |
+| BodyFuzzyCriterion | `NewBodyFuzzyCriterion(paths ...string) *BodyFuzzyCriterion` | 6 |
+| BodyHashCriterion | `BodyHashCriterion{}` | 8 |
 
 **Details:** [Matching](matching.md)
 

--- a/docs/fixtures-authoring.md
+++ b/docs/fixtures-authoring.md
@@ -43,13 +43,13 @@ Every fixture file is a single JSON object with these fields:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `id` | string | Yes | Unique identifier. Used as the filename (`<id>.json`). Must not contain `/`, `\`, or `..`. |
-| `route` | string | No | Logical grouping label (e.g., `"users-api"`). Used by `Filter.Route` and `MatchRoute`. |
+| `route` | string | No | Logical grouping label (e.g., `"users-api"`). Used by `Filter.Route` and `RouteCriterion`. |
 | `recorded_at` | string (RFC 3339) | No | UTC timestamp. Informational only -- not used for matching. |
 | `request.method` | string | Yes | HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`). |
 | `request.url` | string | Yes | Full URL. The path component is used for matching (e.g., `http://mock/api/users`). |
 | `request.headers` | object | No | Request headers. Each key maps to an array of strings. |
 | `request.body` | string/null | No | Base64-encoded request body, or `null` for bodiless requests. |
-| `request.body_hash` | string | No | Hex-encoded SHA-256 hash of the original request body. Required for `MatchBodyHash`. |
+| `request.body_hash` | string | No | Hex-encoded SHA-256 hash of the original request body. Required for `BodyHashCriterion`. |
 | `request.body_encoding` | string | No | `"identity"` for UTF-8 text, `"base64"` for binary. Defaults to identity if omitted. |
 | `response.status_code` | int | Yes | HTTP status code (200, 201, 204, 404, 500, etc.). |
 | `response.headers` | object | No | Response headers. Each key maps to an array of strings. |
@@ -78,7 +78,7 @@ The `request.url` field stores a full URL, but the `DefaultMatcher` (used by the
 
 - `http://mock/api/users` and `https://production.example.com/api/users` match the same `GET /api/users` request
 - Use `http://mock` as the host for hand-written fixtures -- it is a convention, not a requirement
-- Query parameters are ignored by the default matcher. Use `MatchQueryParams` in a `CompositeMatcher` if you need them.
+- Query parameters are ignored by the default matcher. Use `QueryParamsCriterion{}` in a `CompositeMatcher` if you need them.
 
 ## Example fixtures
 

--- a/docs/matching.md
+++ b/docs/matching.md
@@ -21,7 +21,7 @@ matcher := httptape.DefaultMatcher()
 Matches by HTTP method and URL path. Equivalent to:
 
 ```go
-httptape.NewCompositeMatcher(httptape.MatchMethod(), httptape.MatchPath())
+httptape.NewCompositeMatcher(httptape.MethodCriterion{}, httptape.PathCriterion{})
 ```
 
 This is the default for `NewServer` if no matcher is specified.
@@ -40,16 +40,16 @@ The `CompositeMatcher` evaluates multiple criteria and returns the highest-scori
 
 ```go
 matcher := httptape.NewCompositeMatcher(
-    httptape.MatchMethod(),
-    httptape.MatchPath(),
-    httptape.MatchQueryParams(),
-    httptape.MatchBodyHash(),
+    httptape.MethodCriterion{},
+    httptape.PathCriterion{},
+    httptape.QueryParamsCriterion{},
+    httptape.BodyHashCriterion{},
 )
 ```
 
 ### How scoring works
 
-Each `MatchCriterion` returns a score for a candidate tape:
+Each `Criterion` returns a score for a candidate tape:
 
 - **Score 0** -- the candidate does not match on this dimension. It is **eliminated**.
 - **Positive score** -- the candidate matches, with higher values indicating stronger matches.
@@ -58,79 +58,79 @@ A candidate must pass **all** criteria (non-zero score from each) to survive. Th
 
 ## Built-in criteria
 
-### MatchMethod
+### MethodCriterion
 
 ```go
-httptape.MatchMethod()
+httptape.MethodCriterion{}
 ```
 
 Requires the HTTP method (GET, POST, etc.) to match exactly. **Score: 1**
 
-### MatchPath
+### PathCriterion
 
 ```go
-httptape.MatchPath()
+httptape.PathCriterion{}
 ```
 
 Requires the URL path to match exactly. The tape's stored URL is parsed to extract only the path component. **Score: 2**
 
-### MatchPathRegex
+### PathRegexCriterion
 
 ```go
-criterion, err := httptape.MatchPathRegex(`^/users/\d+/orders$`)
+criterion, err := httptape.NewPathRegexCriterion(`^/users/\d+/orders$`)
 if err != nil {
     log.Fatal(err)
 }
-matcher := httptape.NewCompositeMatcher(httptape.MatchMethod(), criterion)
+matcher := httptape.NewCompositeMatcher(httptape.MethodCriterion{}, criterion)
 ```
 
 Matches the URL path against a regular expression. Both the incoming request path and the tape's stored path must match the pattern. Returns an error if the pattern is invalid.
 
-Use `MatchPathRegex` as a **replacement** for `MatchPath`, not alongside it. If both are present, `MatchPath` will eliminate candidates that don't exact-match, regardless of the regex result.
+Use `PathRegexCriterion` as a **replacement** for `PathCriterion`, not alongside it. If both are present, `PathCriterion` will eliminate candidates that don't exact-match, regardless of the regex result.
 
 **Score: 1**
 
-### MatchRoute
+### RouteCriterion
 
 ```go
-httptape.MatchRoute("users-api")
+httptape.RouteCriterion{Route: "users-api"}
 ```
 
 Requires the tape's `Route` field to equal the given value. If the route is empty string, the criterion always matches (any tape). **Score: 1**
 
-### MatchHeaders
+### HeadersCriterion
 
 ```go
-httptape.MatchHeaders("Accept", "application/json")
-httptape.MatchHeaders("X-Feature-Flag", "new-checkout")
+httptape.HeadersCriterion{Key: "Accept", Value: "application/json"}
+httptape.HeadersCriterion{Key: "X-Feature-Flag", Value: "new-checkout"}
 ```
 
 Requires a specific header to be present in both the request and the tape with an exact value match. Header names are case-insensitive. If the header has multiple values, the criterion checks if the specified value appears among them (any-of semantics).
 
-To require multiple headers, add multiple `MatchHeaders` criteria -- they are AND-ed together naturally. **Score: 3**
+To require multiple headers, add multiple `HeadersCriterion` instances -- they are AND-ed together naturally. **Score: 3**
 
-### MatchQueryParams
+### QueryParamsCriterion
 
 ```go
-httptape.MatchQueryParams()
+httptape.QueryParamsCriterion{}
 ```
 
 Requires all query parameters from the incoming request to be present in the tape's URL with the same values. Extra parameters in the tape are allowed (subset match). If the request has no query parameters, this criterion always matches (vacuously true). **Score: 4**
 
-### MatchBodyHash
+### BodyHashCriterion
 
 ```go
-httptape.MatchBodyHash()
+httptape.BodyHashCriterion{}
 ```
 
 Computes the SHA-256 hash of the incoming request body and compares it with the tape's stored `BodyHash`. This is an exact body match.
 
 If both the tape and request have no body, it matches. If one has a body and the other doesn't, it doesn't match. **Score: 8**
 
-### MatchBodyFuzzy
+### BodyFuzzyCriterion
 
 ```go
-httptape.MatchBodyFuzzy("$.action", "$.user.id", "$.items[*].sku")
+httptape.NewBodyFuzzyCriterion("$.action", "$.user.id", "$.items[*].sku")
 ```
 
 Compares specific fields in the JSON request body between the incoming request and the tape. Only the fields at the specified paths are compared; all other fields are ignored. This is useful when request bodies contain volatile fields (timestamps, nonces) that vary per invocation.
@@ -143,7 +143,7 @@ Matching rules:
 - Paths that exist in both must have deeply equal values
 - At least one path must match for the criterion to return a positive score
 
-Using both `MatchBodyFuzzy` and `MatchBodyHash` in the same matcher is safe but redundant. Choose one or the other.
+Using both `BodyFuzzyCriterion` and `BodyHashCriterion` in the same matcher is safe but redundant. Choose one or the other.
 
 **Score: 6**
 
@@ -151,14 +151,14 @@ Using both `MatchBodyFuzzy` and `MatchBodyHash` in the same matcher is safe but 
 
 | Criterion | Score | Purpose |
 |-----------|-------|---------|
-| MatchMethod | 1 | HTTP method |
-| MatchPath | 2 | Exact URL path |
-| MatchPathRegex | 1 | Regex URL path |
-| MatchRoute | 1 | Route label |
-| MatchHeaders | 3 | Header key-value |
-| MatchQueryParams | 4 | Query parameters |
-| MatchBodyFuzzy | 6 | Partial body fields |
-| MatchBodyHash | 8 | Exact body hash |
+| MethodCriterion | 1 | HTTP method |
+| PathCriterion | 2 | Exact URL path |
+| PathRegexCriterion | 1 | Regex URL path |
+| RouteCriterion | 1 | Route label |
+| HeadersCriterion | 3 | Header key-value |
+| QueryParamsCriterion | 4 | Query parameters |
+| BodyFuzzyCriterion | 6 | Partial body fields |
+| BodyHashCriterion | 8 | Exact body hash |
 
 Higher-specificity criteria have higher scores, so a body-hash match dominates a path-only match. The weights are designed so that more specific criteria generally outweigh combinations of less specific ones.
 
@@ -183,9 +183,9 @@ matcher := httptape.MatcherFunc(func(req *http.Request, candidates []httptape.Ta
 
 ```go
 matcher := httptape.NewCompositeMatcher(
-    httptape.MatchMethod(),
-    httptape.MatchPath(),
-    httptape.MatchQueryParams(),
+    httptape.MethodCriterion{},
+    httptape.PathCriterion{},
+    httptape.QueryParamsCriterion{},
 )
 ```
 
@@ -193,20 +193,20 @@ matcher := httptape.NewCompositeMatcher(
 
 ```go
 matcher := httptape.NewCompositeMatcher(
-    httptape.MatchMethod(),
-    httptape.MatchPath(),
-    httptape.MatchHeaders("Accept", "application/vnd.api.v2+json"),
+    httptape.MethodCriterion{},
+    httptape.PathCriterion{},
+    httptape.HeadersCriterion{Key: "Accept", Value: "application/vnd.api.v2+json"},
 )
 ```
 
 ### Method + regex path + fuzzy body (complex POST APIs)
 
 ```go
-pathCriterion, _ := httptape.MatchPathRegex(`^/api/v\d+/orders`)
+pathCriterion, _ := httptape.NewPathRegexCriterion(`^/api/v\d+/orders`)
 matcher := httptape.NewCompositeMatcher(
-    httptape.MatchMethod(),
+    httptape.MethodCriterion{},
     pathCriterion,
-    httptape.MatchBodyFuzzy("$.action", "$.order.type"),
+    httptape.NewBodyFuzzyCriterion("$.action", "$.order.type"),
 )
 ```
 

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -43,7 +43,7 @@ httptape.WithRoute("users-api")
 Labels all tapes produced by this recorder with a route name. Routes are used for:
 - Logical grouping of fixtures
 - Filtering during [export](import-export.md)
-- Scoped matching with [MatchRoute](matching.md#matchroute)
+- Scoped matching with [RouteCriterion](matching.md#routecriterion)
 
 ### WithSanitizer
 

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -38,9 +38,9 @@ See [Matching](matching.md) for all available matchers.
 ```go
 srv := httptape.NewServer(store,
     httptape.WithMatcher(httptape.NewCompositeMatcher(
-        httptape.MatchMethod(),
-        httptape.MatchPath(),
-        httptape.MatchQueryParams(),
+        httptape.MethodCriterion{},
+        httptape.PathCriterion{},
+        httptape.QueryParamsCriterion{},
     )),
 )
 ```

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -86,8 +86,8 @@ replays cached SSE events using WithProxySSETiming (default: instant).
 ## Matching
 
 CompositeMatcher with scored criteria:
-- MatchMethod (1), MatchPath (2), MatchHeaders (3), MatchQueryParams (4),
-  MatchBodyFuzzy (6), MatchBodyHash (8), MatchPathRegex (1), MatchRoute (1)
+- MethodCriterion (1), PathCriterion (2), HeadersCriterion (3), QueryParamsCriterion (4),
+  BodyFuzzyCriterion (6), BodyHashCriterion (8), PathRegexCriterion (1), RouteCriterion (1)
 
 ## Storage
 
@@ -530,7 +530,7 @@ httptape.WithRoute("users-api")
 Labels all tapes produced by this recorder with a route name. Routes are used for:
 - Logical grouping of fixtures
 - Filtering during [export](import-export.md)
-- Scoped matching with [MatchRoute](matching.md#matchroute)
+- Scoped matching with [RouteCriterion](matching.md#routecriterion)
 
 ### WithSanitizer
 
@@ -702,9 +702,9 @@ See [Matching](matching.md) for all available matchers.
 ```go
 srv := httptape.NewServer(store,
     httptape.WithMatcher(httptape.NewCompositeMatcher(
-        httptape.MatchMethod(),
-        httptape.MatchPath(),
-        httptape.MatchQueryParams(),
+        httptape.MethodCriterion{},
+        httptape.PathCriterion{},
+        httptape.QueryParamsCriterion{},
     )),
 )
 ```
@@ -1371,7 +1371,7 @@ matcher := httptape.DefaultMatcher()
 Matches by HTTP method and URL path. Equivalent to:
 
 ```go
-httptape.NewCompositeMatcher(httptape.MatchMethod(), httptape.MatchPath())
+httptape.NewCompositeMatcher(httptape.MethodCriterion{}, httptape.PathCriterion{})
 ```
 
 This is the default for `NewServer` if no matcher is specified.
@@ -1390,16 +1390,16 @@ The `CompositeMatcher` evaluates multiple criteria and returns the highest-scori
 
 ```go
 matcher := httptape.NewCompositeMatcher(
-    httptape.MatchMethod(),
-    httptape.MatchPath(),
-    httptape.MatchQueryParams(),
-    httptape.MatchBodyHash(),
+    httptape.MethodCriterion{},
+    httptape.PathCriterion{},
+    httptape.QueryParamsCriterion{},
+    httptape.BodyHashCriterion{},
 )
 ```
 
 ### How scoring works
 
-Each `MatchCriterion` returns a score for a candidate tape:
+Each `Criterion` returns a score for a candidate tape:
 
 - **Score 0** -- the candidate does not match on this dimension. It is **eliminated**.
 - **Positive score** -- the candidate matches, with higher values indicating stronger matches.
@@ -1408,79 +1408,79 @@ A candidate must pass **all** criteria (non-zero score from each) to survive. Th
 
 ## Built-in criteria
 
-### MatchMethod
+### MethodCriterion
 
 ```go
-httptape.MatchMethod()
+httptape.MethodCriterion{}
 ```
 
 Requires the HTTP method (GET, POST, etc.) to match exactly. **Score: 1**
 
-### MatchPath
+### PathCriterion
 
 ```go
-httptape.MatchPath()
+httptape.PathCriterion{}
 ```
 
 Requires the URL path to match exactly. The tape's stored URL is parsed to extract only the path component. **Score: 2**
 
-### MatchPathRegex
+### PathRegexCriterion
 
 ```go
-criterion, err := httptape.MatchPathRegex(`^/users/\d+/orders$`)
+criterion, err := httptape.NewPathRegexCriterion(`^/users/\d+/orders$`)
 if err != nil {
     log.Fatal(err)
 }
-matcher := httptape.NewCompositeMatcher(httptape.MatchMethod(), criterion)
+matcher := httptape.NewCompositeMatcher(httptape.MethodCriterion{}, criterion)
 ```
 
 Matches the URL path against a regular expression. Both the incoming request path and the tape's stored path must match the pattern. Returns an error if the pattern is invalid.
 
-Use `MatchPathRegex` as a **replacement** for `MatchPath`, not alongside it. If both are present, `MatchPath` will eliminate candidates that don't exact-match, regardless of the regex result.
+Use `PathRegexCriterion` as a **replacement** for `PathCriterion`, not alongside it. If both are present, `PathCriterion` will eliminate candidates that don't exact-match, regardless of the regex result.
 
 **Score: 1**
 
-### MatchRoute
+### RouteCriterion
 
 ```go
-httptape.MatchRoute("users-api")
+httptape.RouteCriterion{Route: "users-api"}
 ```
 
 Requires the tape's `Route` field to equal the given value. If the route is empty string, the criterion always matches (any tape). **Score: 1**
 
-### MatchHeaders
+### HeadersCriterion
 
 ```go
-httptape.MatchHeaders("Accept", "application/json")
-httptape.MatchHeaders("X-Feature-Flag", "new-checkout")
+httptape.HeadersCriterion{Key: "Accept", Value: "application/json"}
+httptape.HeadersCriterion{Key: "X-Feature-Flag", Value: "new-checkout"}
 ```
 
 Requires a specific header to be present in both the request and the tape with an exact value match. Header names are case-insensitive. If the header has multiple values, the criterion checks if the specified value appears among them (any-of semantics).
 
-To require multiple headers, add multiple `MatchHeaders` criteria -- they are AND-ed together naturally. **Score: 3**
+To require multiple headers, add multiple `HeadersCriterion` criteria -- they are AND-ed together naturally. **Score: 3**
 
-### MatchQueryParams
+### QueryParamsCriterion
 
 ```go
-httptape.MatchQueryParams()
+httptape.QueryParamsCriterion{}
 ```
 
 Requires all query parameters from the incoming request to be present in the tape's URL with the same values. Extra parameters in the tape are allowed (subset match). If the request has no query parameters, this criterion always matches (vacuously true). **Score: 4**
 
-### MatchBodyHash
+### BodyHashCriterion
 
 ```go
-httptape.MatchBodyHash()
+httptape.BodyHashCriterion{}
 ```
 
 Computes the SHA-256 hash of the incoming request body and compares it with the tape's stored `BodyHash`. This is an exact body match.
 
 If both the tape and request have no body, it matches. If one has a body and the other doesn't, it doesn't match. **Score: 8**
 
-### MatchBodyFuzzy
+### BodyFuzzyCriterion
 
 ```go
-httptape.MatchBodyFuzzy("$.action", "$.user.id", "$.items[*].sku")
+httptape.NewBodyFuzzyCriterion("$.action", "$.user.id", "$.items[*].sku")
 ```
 
 Compares specific fields in the JSON request body between the incoming request and the tape. Only the fields at the specified paths are compared; all other fields are ignored. This is useful when request bodies contain volatile fields (timestamps, nonces) that vary per invocation.
@@ -1493,7 +1493,7 @@ Matching rules:
 - Paths that exist in both must have deeply equal values
 - At least one path must match for the criterion to return a positive score
 
-Using both `MatchBodyFuzzy` and `MatchBodyHash` in the same matcher is safe but redundant. Choose one or the other.
+Using both `BodyFuzzyCriterion` and `BodyHashCriterion` in the same matcher is safe but redundant. Choose one or the other.
 
 **Score: 6**
 
@@ -1501,14 +1501,14 @@ Using both `MatchBodyFuzzy` and `MatchBodyHash` in the same matcher is safe but 
 
 | Criterion | Score | Purpose |
 |-----------|-------|---------|
-| MatchMethod | 1 | HTTP method |
-| MatchPath | 2 | Exact URL path |
-| MatchPathRegex | 1 | Regex URL path |
-| MatchRoute | 1 | Route label |
-| MatchHeaders | 3 | Header key-value |
-| MatchQueryParams | 4 | Query parameters |
-| MatchBodyFuzzy | 6 | Partial body fields |
-| MatchBodyHash | 8 | Exact body hash |
+| MethodCriterion | 1 | HTTP method |
+| PathCriterion | 2 | Exact URL path |
+| PathRegexCriterion | 1 | Regex URL path |
+| RouteCriterion | 1 | Route label |
+| HeadersCriterion | 3 | Header key-value |
+| QueryParamsCriterion | 4 | Query parameters |
+| BodyFuzzyCriterion | 6 | Partial body fields |
+| BodyHashCriterion | 8 | Exact body hash |
 
 Higher-specificity criteria have higher scores, so a body-hash match dominates a path-only match. The weights are designed so that more specific criteria generally outweigh combinations of less specific ones.
 
@@ -1533,9 +1533,9 @@ matcher := httptape.MatcherFunc(func(req *http.Request, candidates []httptape.Ta
 
 ```go
 matcher := httptape.NewCompositeMatcher(
-    httptape.MatchMethod(),
-    httptape.MatchPath(),
-    httptape.MatchQueryParams(),
+    httptape.MethodCriterion{},
+    httptape.PathCriterion{},
+    httptape.QueryParamsCriterion{},
 )
 ```
 
@@ -1543,20 +1543,20 @@ matcher := httptape.NewCompositeMatcher(
 
 ```go
 matcher := httptape.NewCompositeMatcher(
-    httptape.MatchMethod(),
-    httptape.MatchPath(),
-    httptape.MatchHeaders("Accept", "application/vnd.api.v2+json"),
+    httptape.MethodCriterion{},
+    httptape.PathCriterion{},
+    httptape.HeadersCriterion{Key: "Accept", Value: "application/vnd.api.v2+json"},
 )
 ```
 
 ### Method + regex path + fuzzy body (complex POST APIs)
 
 ```go
-pathCriterion, _ := httptape.MatchPathRegex(`^/api/v\d+/orders`)
+pathCriterion, _ := httptape.NewPathRegexCriterion(`^/api/v\d+/orders`)
 matcher := httptape.NewCompositeMatcher(
-    httptape.MatchMethod(),
+    httptape.MethodCriterion{},
     pathCriterion,
-    httptape.MatchBodyFuzzy("$.action", "$.order.type"),
+    httptape.NewBodyFuzzyCriterion("$.action", "$.order.type"),
 )
 ```
 
@@ -1777,13 +1777,13 @@ Every fixture file is a single JSON object with these fields:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `id` | string | Yes | Unique identifier. Used as the filename (`<id>.json`). Must not contain `/`, `\`, or `..`. |
-| `route` | string | No | Logical grouping label (e.g., `"users-api"`). Used by `Filter.Route` and `MatchRoute`. |
+| `route` | string | No | Logical grouping label (e.g., `"users-api"`). Used by `Filter.Route` and `RouteCriterion`. |
 | `recorded_at` | string (RFC 3339) | No | UTC timestamp. Informational only -- not used for matching. |
 | `request.method` | string | Yes | HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`). |
 | `request.url` | string | Yes | Full URL. The path component is used for matching (e.g., `http://mock/api/users`). |
 | `request.headers` | object | No | Request headers. Each key maps to an array of strings. |
 | `request.body` | string/null | No | Base64-encoded request body, or `null` for bodiless requests. |
-| `request.body_hash` | string | No | Hex-encoded SHA-256 hash of the original request body. Required for `MatchBodyHash`. |
+| `request.body_hash` | string | No | Hex-encoded SHA-256 hash of the original request body. Required for `BodyHashCriterion`. |
 | `request.body_encoding` | string | No | `"identity"` for UTF-8 text, `"base64"` for binary. Defaults to identity if omitted. |
 | `response.status_code` | int | Yes | HTTP status code (200, 201, 204, 404, 500, etc.). |
 | `response.headers` | object | No | Response headers. Each key maps to an array of strings. |
@@ -1812,7 +1812,7 @@ The `request.url` field stores a full URL, but the `DefaultMatcher` (used by the
 
 - `http://mock/api/users` and `https://production.example.com/api/users` match the same `GET /api/users` request
 - Use `http://mock` as the host for hand-written fixtures -- it is a convention, not a requirement
-- Query parameters are ignored by the default matcher. Use `MatchQueryParams` in a `CompositeMatcher` if you need them.
+- Query parameters are ignored by the default matcher. Use `QueryParamsCriterion{}` in a `CompositeMatcher` if you need them.
 
 ## Example fixtures
 
@@ -4038,29 +4038,36 @@ type Matcher interface {
 type MatcherFunc func(req *http.Request, candidates []Tape) (Tape, bool)
 func (f MatcherFunc) Match(req *http.Request, candidates []Tape) (Tape, bool)
 
-type MatchCriterion func(req *http.Request, candidate Tape) int
+type Criterion interface {
+    Score(req *http.Request, candidate Tape) int
+    Name() string
+}
+
+type CriterionFunc func(req *http.Request, candidate Tape) int
+func (f CriterionFunc) Score(req *http.Request, candidate Tape) int
+func (f CriterionFunc) Name() string  // returns "custom"
 ```
 
 ### Matchers
 
 ```go
-func DefaultMatcher() *CompositeMatcher          // MatchMethod + MatchPath
+func DefaultMatcher() *CompositeMatcher          // MethodCriterion + PathCriterion
 func ExactMatcher() Matcher                       // first method+path match
-func NewCompositeMatcher(criteria ...MatchCriterion) *CompositeMatcher
+func NewCompositeMatcher(criteria ...Criterion) *CompositeMatcher
 ```
 
 ### Built-in criteria
 
-| Function | Signature | Score |
-|----------|-----------|-------|
-| MatchMethod | `MatchMethod() MatchCriterion` | 1 |
-| MatchPath | `MatchPath() MatchCriterion` | 2 |
-| MatchPathRegex | `MatchPathRegex(pattern string) (MatchCriterion, error)` | 1 |
-| MatchRoute | `MatchRoute(route string) MatchCriterion` | 1 |
-| MatchHeaders | `MatchHeaders(key, value string) MatchCriterion` | 3 |
-| MatchQueryParams | `MatchQueryParams() MatchCriterion` | 4 |
-| MatchBodyFuzzy | `MatchBodyFuzzy(paths ...string) MatchCriterion` | 6 |
-| MatchBodyHash | `MatchBodyHash() MatchCriterion` | 8 |
+| Type | Construction | Score |
+|------|-------------|-------|
+| MethodCriterion | `MethodCriterion{}` | 1 |
+| PathCriterion | `PathCriterion{}` | 2 |
+| PathRegexCriterion | `NewPathRegexCriterion(pattern string) (*PathRegexCriterion, error)` | 1 |
+| RouteCriterion | `RouteCriterion{Route: route}` | 1 |
+| HeadersCriterion | `HeadersCriterion{Key: key, Value: value}` | 3 |
+| QueryParamsCriterion | `QueryParamsCriterion{}` | 4 |
+| BodyFuzzyCriterion | `NewBodyFuzzyCriterion(paths ...string) *BodyFuzzyCriterion` | 6 |
+| BodyHashCriterion | `BodyHashCriterion{}` | 8 |
 
 **Details:** [Matching](matching.md)
 

--- a/llms.txt
+++ b/llms.txt
@@ -86,8 +86,8 @@ replays cached SSE events using WithProxySSETiming (default: instant).
 ## Matching
 
 CompositeMatcher with scored criteria:
-- MatchMethod (1), MatchPath (2), MatchHeaders (3), MatchQueryParams (4),
-  MatchBodyFuzzy (6), MatchBodyHash (8), MatchPathRegex (1), MatchRoute (1)
+- MethodCriterion (1), PathCriterion (2), HeadersCriterion (3), QueryParamsCriterion (4),
+  BodyFuzzyCriterion (6), BodyHashCriterion (8), PathRegexCriterion (1), RouteCriterion (1)
 
 ## Storage
 

--- a/matcher.go
+++ b/matcher.go
@@ -55,147 +55,260 @@ func ExactMatcher() Matcher {
 	})
 }
 
-// MatchCriterion evaluates how well a candidate Tape matches an incoming
-// request for a single dimension (method, path, body, etc.).
-//
-// It returns a score:
-//   - 0 means the candidate does not match on this dimension (eliminates it).
-//   - A positive value means the candidate matches, with higher values
-//     indicating a stronger/more specific match.
-//
-// Implementations must not modify the candidate tape. They may read and
-// restore the request body (as MatchBodyHash does) but must leave the
-// request otherwise unchanged.
-type MatchCriterion func(req *http.Request, candidate Tape) int
+// Criterion evaluates how well a candidate Tape matches an incoming request
+// for a single dimension (method, path, body, etc.).
+type Criterion interface {
+	// Score returns a match score:
+	//   - 0 means the candidate does not match on this dimension (eliminates it).
+	//   - A positive value means the candidate matches, with higher values
+	//     indicating a stronger/more specific match.
+	//
+	// Implementations must not modify the candidate tape. They may read and
+	// restore the request body but must leave the request otherwise unchanged.
+	Score(req *http.Request, candidate Tape) int
 
-// MatchMethod returns a MatchCriterion that requires the HTTP method to match.
-// Returns score 1 on match, 0 on mismatch.
-func MatchMethod() MatchCriterion {
-	return func(req *http.Request, candidate Tape) int {
-		if req.Method == candidate.Request.Method {
-			return 1
-		}
-		return 0
-	}
+	// Name returns a stable identifier for this criterion type.
+	// Used for debugging, logging, and config-driven dispatch.
+	// Built-in criteria use lowercase underscore-separated names
+	// (e.g., "method", "path", "body_hash").
+	Name() string
 }
 
-// MatchPath returns a MatchCriterion that requires the URL path to match.
+// CriterionFunc is an adapter to allow the use of ordinary functions as
+// Criterion implementations. Its Name() method returns "custom".
+type CriterionFunc func(req *http.Request, candidate Tape) int
+
+// Score calls f(req, candidate).
+func (f CriterionFunc) Score(req *http.Request, candidate Tape) int {
+	return f(req, candidate)
+}
+
+// Name returns "custom" for ad-hoc functional criteria.
+func (f CriterionFunc) Name() string {
+	return "custom"
+}
+
+// MethodCriterion matches on HTTP method.
+// Returns score 1 on match, 0 on mismatch.
+type MethodCriterion struct{}
+
+// Score returns 1 if the request method matches the candidate tape's method,
+// 0 otherwise.
+func (MethodCriterion) Score(req *http.Request, candidate Tape) int {
+	if req.Method == candidate.Request.Method {
+		return 1
+	}
+	return 0
+}
+
+// Name returns "method".
+func (MethodCriterion) Name() string { return "method" }
+
+// PathCriterion matches on URL path (exact).
 // It compares the incoming request's URL.Path against the path component of
 // the tape's stored URL. Returns score 2 on match, 0 on mismatch.
 //
 // The tape's URL is stored as a full URL string (e.g., "https://api.example.com/users?page=1").
-// MatchPath parses it with url.Parse and compares only the Path component.
+// PathCriterion parses it with url.Parse and compares only the Path component.
 // If the tape's URL cannot be parsed, the criterion returns 0.
-func MatchPath() MatchCriterion {
-	return func(req *http.Request, candidate Tape) int {
-		parsed, err := url.Parse(candidate.Request.URL)
-		if err != nil {
-			return 0
-		}
-		if req.URL.Path == parsed.Path {
-			return 2
-		}
+type PathCriterion struct{}
+
+// Score returns 2 if the request path matches the candidate tape's URL path,
+// 0 otherwise.
+func (PathCriterion) Score(req *http.Request, candidate Tape) int {
+	parsed, err := url.Parse(candidate.Request.URL)
+	if err != nil {
 		return 0
 	}
+	if req.URL.Path == parsed.Path {
+		return 2
+	}
+	return 0
 }
 
-// MatchPathRegex returns a MatchCriterion that matches the incoming request's
-// URL path against a compiled regular expression, and also verifies that the
-// candidate tape's stored URL path matches the same expression. This ensures
-// that only tapes belonging to the same "path family" as the request are
-// considered matches.
-//
-// The pattern is compiled once at construction time using regexp.Compile.
-// If the pattern is invalid, MatchPathRegex returns a non-nil error and a
-// nil MatchCriterion. Callers must check the error before using the criterion.
+// Name returns "path".
+func (PathCriterion) Name() string { return "path" }
+
+// PathRegexCriterion matches the incoming request's URL path against a compiled
+// regular expression, and also verifies that the candidate tape's stored URL
+// path matches the same expression. This ensures that only tapes belonging to
+// the same "path family" as the request are considered matches.
 //
 // Returns score 1 on match, 0 on mismatch.
 //
-// Usage: use MatchPathRegex as a replacement for MatchPath when regex matching
-// is desired, not alongside it. If MatchPath is also present in the same
-// CompositeMatcher, candidates that do not exact-match will be eliminated by
-// MatchPath (score 0) regardless of the regex result.
+// Usage: use PathRegexCriterion as a replacement for PathCriterion when regex
+// matching is desired, not alongside it. If PathCriterion is also present in
+// the same CompositeMatcher, candidates that do not exact-match will be
+// eliminated by PathCriterion (score 0) regardless of the regex result.
 //
 // Example:
 //
-//	criterion, err := MatchPathRegex(`^/users/\d+/orders$`)
+//	criterion, err := NewPathRegexCriterion(`^/users/\d+/orders$`)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	matcher := NewCompositeMatcher(MatchMethod(), criterion)
-func MatchPathRegex(pattern string) (MatchCriterion, error) {
+//	matcher := NewCompositeMatcher(MethodCriterion{}, criterion)
+type PathRegexCriterion struct {
+	// Pattern is the original regex pattern string.
+	Pattern string
+	re      *regexp.Regexp
+}
+
+// NewPathRegexCriterion compiles the pattern and returns a PathRegexCriterion.
+// Returns an error if the pattern is not a valid regular expression.
+func NewPathRegexCriterion(pattern string) (*PathRegexCriterion, error) {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("httptape: invalid path regex %q: %w", pattern, err)
 	}
-	return func(req *http.Request, candidate Tape) int {
-		if !re.MatchString(req.URL.Path) {
-			return 0
-		}
-		parsed, err := url.Parse(candidate.Request.URL)
-		if err != nil {
-			return 0
-		}
-		if !re.MatchString(parsed.Path) {
-			return 0
-		}
-		return 1
-	}, nil
+	return &PathRegexCriterion{Pattern: pattern, re: re}, nil
 }
 
-// MatchRoute returns a MatchCriterion that requires the tape's Route field
-// to equal a specific value. Returns score 1 on match, 0 on mismatch.
-// If route is empty, the criterion always returns 1 (matches any tape).
-func MatchRoute(route string) MatchCriterion {
-	return func(_ *http.Request, candidate Tape) int {
-		if route == "" {
-			return 1
-		}
-		if candidate.Route == route {
-			return 1
-		}
+// Score returns 1 if both the request path and the candidate tape's URL path
+// match the compiled regex, 0 otherwise.
+func (c *PathRegexCriterion) Score(req *http.Request, candidate Tape) int {
+	if !c.re.MatchString(req.URL.Path) {
 		return 0
 	}
+	parsed, err := url.Parse(candidate.Request.URL)
+	if err != nil {
+		return 0
+	}
+	if !c.re.MatchString(parsed.Path) {
+		return 0
+	}
+	return 1
 }
 
-// MatchQueryParams returns a MatchCriterion that requires all query parameters
-// from the incoming request to be present in the tape's stored URL with the
-// same values. Extra parameters in the tape are allowed (subset match).
+// Name returns "path_regex".
+func (c *PathRegexCriterion) Name() string { return "path_regex" }
+
+// RouteCriterion matches on the tape's Route field.
+// Returns score 1 on match, 0 on mismatch.
+// If Route is empty, the criterion always returns 1 (matches any tape).
+type RouteCriterion struct {
+	Route string
+}
+
+// Score returns 1 if the candidate tape's Route matches, 0 otherwise.
+// If Route is empty, the criterion always returns 1.
+func (c RouteCriterion) Score(_ *http.Request, candidate Tape) int {
+	if c.Route == "" {
+		return 1
+	}
+	if candidate.Route == c.Route {
+		return 1
+	}
+	return 0
+}
+
+// Name returns "route".
+func (c RouteCriterion) Name() string { return "route" }
+
+// QueryParamsCriterion matches on query parameters (subset match).
+// It requires all query parameters from the incoming request to be present
+// in the tape's stored URL with the same values. Extra parameters in the
+// tape are allowed.
 // Returns score 4 on match, 0 on mismatch.
 //
 // If the incoming request has no query parameters, this criterion always
-// returns 4 (vacuously true — all zero params match).
+// returns 4 (vacuously true -- all zero params match).
 //
 // The tape's URL is parsed with url.Parse to extract query parameters.
 // If parsing fails, the criterion returns 0.
-func MatchQueryParams() MatchCriterion {
-	return func(req *http.Request, candidate Tape) int {
-		reqParams := req.URL.Query()
-		if len(reqParams) == 0 {
-			return 4
-		}
+type QueryParamsCriterion struct{}
 
-		parsed, err := url.Parse(candidate.Request.URL)
-		if err != nil {
-			return 0
-		}
-		tapeParams := parsed.Query()
-
-		for key, reqValues := range reqParams {
-			tapeValues, ok := tapeParams[key]
-			if !ok {
-				return 0
-			}
-			if !stringSlicesEqual(reqValues, tapeValues) {
-				return 0
-			}
-		}
+// Score returns 4 if the request query parameters are a subset of the
+// candidate tape's query parameters, 0 otherwise.
+func (QueryParamsCriterion) Score(req *http.Request, candidate Tape) int {
+	reqParams := req.URL.Query()
+	if len(reqParams) == 0 {
 		return 4
 	}
+
+	parsed, err := url.Parse(candidate.Request.URL)
+	if err != nil {
+		return 0
+	}
+	tapeParams := parsed.Query()
+
+	for key, reqValues := range reqParams {
+		tapeValues, ok := tapeParams[key]
+		if !ok {
+			return 0
+		}
+		if !stringSlicesEqual(reqValues, tapeValues) {
+			return 0
+		}
+	}
+	return 4
 }
 
-// MatchBodyHash returns a MatchCriterion that requires the SHA-256 hash of
-// the incoming request's body to match the tape's BodyHash field.
+// Name returns "query_params".
+func (QueryParamsCriterion) Name() string { return "query_params" }
+
+// HeadersCriterion matches a specific header key-value pair.
+// It requires the specified header to be present in both the incoming request
+// and the candidate tape's recorded request, with an exact value match.
+//
+// The header name is canonicalized using http.CanonicalHeaderKey at score time,
+// making it case-insensitive per HTTP specification (RFC 7230 section 3.2).
+// The header value comparison is exact and case-sensitive.
+//
+// If the header has multiple values in either the request or the tape, the
+// criterion checks whether the specified value appears among them (any-of
+// semantics).
+//
+// To require multiple headers, add multiple HeadersCriterion instances to the
+// CompositeMatcher. They are AND-ed together naturally: if any criterion
+// returns 0, the candidate is eliminated.
+//
+// Returns score 3 on match, 0 on mismatch.
+//
+// Example:
+//
+//	matcher := NewCompositeMatcher(
+//	    MethodCriterion{},
+//	    PathCriterion{},
+//	    HeadersCriterion{Key: "Accept", Value: "application/vnd.api.v2+json"},
+//	    HeadersCriterion{Key: "X-Feature-Flag", Value: "new-checkout"},
+//	)
+type HeadersCriterion struct {
+	Key   string
+	Value string
+}
+
+// Score returns 3 if both the request and the candidate tape contain the
+// specified header key-value pair, 0 otherwise.
+func (c HeadersCriterion) Score(req *http.Request, candidate Tape) int {
+	canonicalKey := http.CanonicalHeaderKey(c.Key)
+	if !headerContains(req.Header, canonicalKey, c.Value) {
+		return 0
+	}
+	if !headerContains(candidate.Request.Headers, canonicalKey, c.Value) {
+		return 0
+	}
+	return 3
+}
+
+// Name returns "headers".
+func (c HeadersCriterion) Name() string { return "headers" }
+
+// headerContains reports whether the header map contains the specified
+// canonical key with the specified value among its values.
+func headerContains(h http.Header, canonicalKey, value string) bool {
+	values := h[canonicalKey]
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+// BodyHashCriterion matches on SHA-256 body hash.
+// It requires the SHA-256 hash of the incoming request's body to match the
+// tape's BodyHash field.
 // Returns score 8 on match, 0 on mismatch.
 //
 // If the tape's BodyHash is empty (e.g., a GET request with no body), and
@@ -213,34 +326,166 @@ func MatchQueryParams() MatchCriterion {
 // a bottleneck.
 //
 // TODO: pre-compute request body hash once before candidate iteration.
-func MatchBodyHash() MatchCriterion {
-	return func(req *http.Request, candidate Tape) int {
-		// Compute hash of incoming request body.
-		// NOTE: This recomputes the hash per candidate. The body bytes are
-		// cached in memory after the first read (via bytes.NewReader), but
-		// the SHA-256 hash is recomputed each time. See TODO above.
-		var reqHash string
-		if req.Body != nil {
-			bodyBytes, err := io.ReadAll(req.Body)
-			if err != nil {
-				return 0
-			}
-			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			reqHash = BodyHashFromBytes(bodyBytes)
-		}
+type BodyHashCriterion struct{}
 
-		// Compare with tape's stored hash.
-		if candidate.Request.BodyHash == "" && reqHash == "" {
-			return 8 // both empty — match
+// Score returns 8 if the request body hash matches the candidate tape's
+// BodyHash, 0 otherwise.
+func (BodyHashCriterion) Score(req *http.Request, candidate Tape) int {
+	// Compute hash of incoming request body.
+	// NOTE: This recomputes the hash per candidate. The body bytes are
+	// cached in memory after the first read (via bytes.NewReader), but
+	// the SHA-256 hash is recomputed each time. See TODO above.
+	var reqHash string
+	if req.Body != nil {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return 0
 		}
-		if candidate.Request.BodyHash == reqHash {
-			return 8
-		}
-		return 0
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		reqHash = BodyHashFromBytes(bodyBytes)
 	}
+
+	// Compare with tape's stored hash.
+	if candidate.Request.BodyHash == "" && reqHash == "" {
+		return 8 // both empty -- match
+	}
+	if candidate.Request.BodyHash == reqHash {
+		return 8
+	}
+	return 0
 }
 
-// CompositeMatcher evaluates a list of MatchCriterion functions against
+// Name returns "body_hash".
+func (BodyHashCriterion) Name() string { return "body_hash" }
+
+// BodyFuzzyCriterion compares specific fields in the JSON request body between
+// the incoming request and the candidate tape. Only the fields at the specified
+// paths are compared; all other fields are ignored. This is useful when request
+// bodies contain volatile fields (timestamps, nonces, request IDs) that vary
+// per invocation.
+//
+// Paths use the same JSONPath-like syntax as RedactBodyPaths and FakeFields:
+//   - $.field             -- top-level field
+//   - $.nested.field      -- nested field access
+//   - $.array[*].field    -- field within each element of an array
+//
+// Matching semantics:
+//   - If both the incoming request body and the tape body are absent
+//     (nil, empty, or not valid JSON), the criterion returns 1 (vacuous
+//     match -- the body dimension is irrelevant for this request/tape
+//     pair). If exactly one side is absent, the criterion returns 0.
+//   - When both bodies are present (not absent per the rule above),
+//     they are unmarshaled as JSON. Path extraction and comparison
+//     proceeds on the unmarshaled values.
+//   - For each specified path, the value is extracted from both the request
+//     and the tape body. If a path does not exist in both bodies, it is
+//     skipped (does not cause a mismatch).
+//   - If a path exists in both bodies, the extracted values must be
+//     deeply equal (compared via reflect.DeepEqual on the unmarshaled
+//     any values). If any compared field differs, the criterion returns 0.
+//   - If no paths are provided, or no paths match fields present in both
+//     bodies, the criterion returns 0 (no match -- nothing to compare means
+//     no evidence of a match).
+//   - If at least one path matched and all matched fields are equal, the
+//     criterion returns its score.
+//
+// The request body is read fully, then restored (replaced with a new reader
+// over the same bytes) so subsequent criteria can read it again.
+//
+// Invalid or unsupported paths are silently ignored (same as RedactBodyPaths).
+//
+// Returns score 6 on match, 1 on vacuous match (both bodies absent),
+// 0 on mismatch.
+//
+// Note: using both BodyFuzzyCriterion and BodyHashCriterion in the same
+// CompositeMatcher is safe but semantically redundant. If BodyHashCriterion
+// passes (exact match), BodyFuzzyCriterion will also pass. If BodyHashCriterion
+// fails, the candidate is already eliminated. Choose one or the other.
+//
+// Example:
+//
+//	matcher := NewCompositeMatcher(
+//	    MethodCriterion{},
+//	    PathCriterion{},
+//	    NewBodyFuzzyCriterion("$.action", "$.user.id", "$.items[*].sku"),
+//	)
+type BodyFuzzyCriterion struct {
+	// Paths contains the JSONPath-like expressions to compare.
+	Paths  []string
+	parsed []parsedPath
+}
+
+// NewBodyFuzzyCriterion creates a BodyFuzzyCriterion with the given paths.
+// Invalid paths are silently skipped (same behavior as the previous MatchBodyFuzzy).
+func NewBodyFuzzyCriterion(paths ...string) *BodyFuzzyCriterion {
+	var parsed []parsedPath
+	for _, p := range paths {
+		if pp, ok := parsePath(p); ok {
+			parsed = append(parsed, pp)
+		}
+	}
+	return &BodyFuzzyCriterion{Paths: paths, parsed: parsed}
+}
+
+// Score returns 6 if all compared fields match, 1 on vacuous match (both
+// bodies absent), 0 on mismatch.
+func (c *BodyFuzzyCriterion) Score(req *http.Request, candidate Tape) int {
+	if len(c.parsed) == 0 {
+		return 0
+	}
+
+	// Read and restore the incoming request body.
+	var reqBody []byte
+	if req.Body != nil {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return 0
+		}
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		reqBody = bodyBytes
+	}
+
+	// Determine whether each side is "absent" (nil, empty, or not valid JSON).
+	var reqData, tapeData any
+	reqAbsent := len(reqBody) == 0 || json.Unmarshal(reqBody, &reqData) != nil
+	tapeAbsent := len(candidate.Request.Body) == 0 || json.Unmarshal(candidate.Request.Body, &tapeData) != nil
+
+	// Vacuous-true: both bodies absent -- return minimum positive score.
+	if reqAbsent && tapeAbsent {
+		return 1
+	}
+	// Asymmetric: one absent, one present -- mismatch.
+	if reqAbsent || tapeAbsent {
+		return 0
+	}
+
+	// Compare specified fields.
+	matched := 0
+	for _, p := range c.parsed {
+		reqVal, reqOk := extractAtPath(reqData, p.segments)
+		tapeVal, tapeOk := extractAtPath(tapeData, p.segments)
+
+		if !reqOk || !tapeOk {
+			// Path doesn't exist in one or both -- skip, not a mismatch.
+			continue
+		}
+
+		if !reflect.DeepEqual(reqVal, tapeVal) {
+			return 0 // field exists in both but values differ -- eliminate.
+		}
+		matched++
+	}
+
+	if matched == 0 {
+		return 0 // no fields compared -- no evidence of match.
+	}
+	return 6
+}
+
+// Name returns "body_fuzzy".
+func (c *BodyFuzzyCriterion) Name() string { return "body_fuzzy" }
+
+// CompositeMatcher evaluates a list of Criterion implementations against
 // candidate tapes and returns the highest-scoring match. If all criteria
 // return a positive score for a candidate, the candidate's total score is
 // the sum of all criterion scores. If any criterion returns 0 for a
@@ -248,36 +493,36 @@ func MatchBodyHash() MatchCriterion {
 //
 // Score weight table for built-in criteria:
 //
-//	MatchMethod:      1
-//	MatchPath:        2
-//	MatchRoute:       1
-//	MatchPathRegex:   1
-//	MatchHeaders:     3
-//	MatchQueryParams: 4
-//	MatchBodyFuzzy:   6
-//	MatchBodyHash:    8
+//	MethodCriterion:      1
+//	PathCriterion:        2
+//	RouteCriterion:       1
+//	PathRegexCriterion:   1
+//	HeadersCriterion:     3
+//	QueryParamsCriterion: 4
+//	BodyFuzzyCriterion:   6
+//	BodyHashCriterion:    8
 //
 // The original design (ADR-4) used powers-of-two-ish weights so each
 // higher-specificity criterion dominates all lower ones combined. Later
-// additions (MatchHeaders=3, MatchBodyFuzzy=6) create a gap where
-// MatchQueryParams(4) + MatchHeaders(3) = 7 > MatchBodyFuzzy(6). This is
-// acceptable for practical use — body-fuzzy matches are typically used
-// without query-param matching — but the strict dominance property no
+// additions (HeadersCriterion=3, BodyFuzzyCriterion=6) create a gap where
+// QueryParamsCriterion(4) + HeadersCriterion(3) = 7 > BodyFuzzyCriterion(6).
+// This is acceptable for practical use -- body-fuzzy matches are typically
+// used without query-param matching -- but the strict dominance property no
 // longer holds perfectly.
 //
 // If no candidates survive all criteria, CompositeMatcher returns (Tape{}, false).
 // If multiple candidates have the same highest score, the first one in the
 // candidates slice wins (stable ordering).
 //
-// CompositeMatcher is safe for concurrent use — immutable after construction.
+// CompositeMatcher is safe for concurrent use -- immutable after construction.
 type CompositeMatcher struct {
-	criteria []MatchCriterion
+	criteria []Criterion
 }
 
 // NewCompositeMatcher creates a CompositeMatcher with the given criteria.
 // At least one criterion must be provided. If no criteria are given,
 // the matcher matches nothing (returns false for all requests).
-func NewCompositeMatcher(criteria ...MatchCriterion) *CompositeMatcher {
+func NewCompositeMatcher(criteria ...Criterion) *CompositeMatcher {
 	return &CompositeMatcher{criteria: criteria}
 }
 
@@ -290,7 +535,7 @@ func (m *CompositeMatcher) Match(req *http.Request, candidates []Tape) (Tape, bo
 		total := 0
 		eliminated := false
 		for _, criterion := range m.criteria {
-			score := criterion(req, tape)
+			score := criterion.Score(req, tape)
 			if score == 0 {
 				eliminated = true
 				break
@@ -316,175 +561,9 @@ func (m *CompositeMatcher) Match(req *http.Request, candidates []Tape) (Tape, bo
 // This covers the most common use case (exact method + path matching) and is
 // the recommended default for the Server.
 //
-// It is equivalent to NewCompositeMatcher(MatchMethod(), MatchPath()).
+// It is equivalent to NewCompositeMatcher(MethodCriterion{}, PathCriterion{}).
 func DefaultMatcher() *CompositeMatcher {
-	return NewCompositeMatcher(MatchMethod(), MatchPath())
-}
-
-// MatchHeaders returns a MatchCriterion that requires the specified header to
-// be present in both the incoming request and the candidate tape's recorded
-// request, with an exact value match.
-//
-// The header name is canonicalized using http.CanonicalHeaderKey, making it
-// case-insensitive per HTTP specification (RFC 7230 section 3.2). The header
-// value comparison is exact and case-sensitive.
-//
-// If the header has multiple values in either the request or the tape, the
-// criterion checks whether the specified value appears among them (any-of
-// semantics). This handles the common case where a header may be set multiple
-// times (e.g., multiple Accept values).
-//
-// To require multiple headers, add multiple MatchHeaders criteria to the
-// CompositeMatcher. They are AND-ed together naturally: if any criterion
-// returns 0, the candidate is eliminated.
-//
-// Returns score 3 on match, 0 on mismatch.
-//
-// Example:
-//
-//	matcher := NewCompositeMatcher(
-//	    MatchMethod(),
-//	    MatchPath(),
-//	    MatchHeaders("Accept", "application/vnd.api.v2+json"),
-//	    MatchHeaders("X-Feature-Flag", "new-checkout"),
-//	)
-func MatchHeaders(key, value string) MatchCriterion {
-	canonicalKey := http.CanonicalHeaderKey(key)
-	return func(req *http.Request, candidate Tape) int {
-		if !headerContains(req.Header, canonicalKey, value) {
-			return 0
-		}
-		if !headerContains(candidate.Request.Headers, canonicalKey, value) {
-			return 0
-		}
-		return 3
-	}
-}
-
-// headerContains reports whether the header map contains the specified
-// canonical key with the specified value among its values.
-func headerContains(h http.Header, canonicalKey, value string) bool {
-	values := h[canonicalKey]
-	for _, v := range values {
-		if v == value {
-			return true
-		}
-	}
-	return false
-}
-
-// MatchBodyFuzzy returns a MatchCriterion that compares specific fields in
-// the JSON request body between the incoming request and the candidate tape.
-// Only the fields at the specified paths are compared; all other fields are
-// ignored. This is useful when request bodies contain volatile fields
-// (timestamps, nonces, request IDs) that vary per invocation.
-//
-// Paths use the same JSONPath-like syntax as RedactBodyPaths and FakeFields:
-//   - $.field             -- top-level field
-//   - $.nested.field      -- nested field access
-//   - $.array[*].field    -- field within each element of an array
-//
-// Matching semantics:
-//   - If both the incoming request body and the tape body are absent
-//     (nil, empty, or not valid JSON), the criterion returns 1 (vacuous
-//     match — the body dimension is irrelevant for this request/tape
-//     pair). If exactly one side is absent, the criterion returns 0.
-//   - When both bodies are present (not absent per the rule above),
-//     they are unmarshaled as JSON. Path extraction and comparison
-//     proceeds on the unmarshaled values.
-//   - For each specified path, the value is extracted from both the request
-//     and the tape body. If a path does not exist in both bodies, it is
-//     skipped (does not cause a mismatch).
-//   - If a path exists in both bodies, the extracted values must be
-//     deeply equal (compared via reflect.DeepEqual on the unmarshaled
-//     any values). If any compared field differs, the criterion returns 0.
-//   - If no paths are provided, or no paths match fields present in both
-//     bodies, the criterion returns 0 (no match — nothing to compare means
-//     no evidence of a match).
-//   - If at least one path matched and all matched fields are equal, the
-//     criterion returns its score.
-//
-// The request body is read fully, then restored (replaced with a new reader
-// over the same bytes) so subsequent criteria can read it again.
-//
-// Invalid or unsupported paths are silently ignored (same as RedactBodyPaths).
-//
-// Returns score 6 on match, 1 on vacuous match (both bodies absent),
-// 0 on mismatch.
-//
-// Note: using both MatchBodyFuzzy and MatchBodyHash in the same
-// CompositeMatcher is safe but semantically redundant. If MatchBodyHash
-// passes (exact match), MatchBodyFuzzy will also pass. If MatchBodyHash
-// fails, the candidate is already eliminated. Choose one or the other.
-//
-// Example:
-//
-//	matcher := NewCompositeMatcher(
-//	    MatchMethod(),
-//	    MatchPath(),
-//	    MatchBodyFuzzy("$.action", "$.user.id", "$.items[*].sku"),
-//	)
-func MatchBodyFuzzy(paths ...string) MatchCriterion {
-	// Parse all paths at construction time (reuses parsePath from sanitizer.go).
-	var parsed []parsedPath
-	for _, p := range paths {
-		if pp, ok := parsePath(p); ok {
-			parsed = append(parsed, pp)
-		}
-	}
-
-	return func(req *http.Request, candidate Tape) int {
-		if len(parsed) == 0 {
-			return 0
-		}
-
-		// Read and restore the incoming request body.
-		var reqBody []byte
-		if req.Body != nil {
-			bodyBytes, err := io.ReadAll(req.Body)
-			if err != nil {
-				return 0
-			}
-			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			reqBody = bodyBytes
-		}
-
-		// Determine whether each side is "absent" (nil, empty, or not valid JSON).
-		var reqData, tapeData any
-		reqAbsent := len(reqBody) == 0 || json.Unmarshal(reqBody, &reqData) != nil
-		tapeAbsent := len(candidate.Request.Body) == 0 || json.Unmarshal(candidate.Request.Body, &tapeData) != nil
-
-		// Vacuous-true: both bodies absent — return minimum positive score.
-		if reqAbsent && tapeAbsent {
-			return 1
-		}
-		// Asymmetric: one absent, one present — mismatch.
-		if reqAbsent || tapeAbsent {
-			return 0
-		}
-
-		// Compare specified fields.
-		matched := 0
-		for _, p := range parsed {
-			reqVal, reqOk := extractAtPath(reqData, p.segments)
-			tapeVal, tapeOk := extractAtPath(tapeData, p.segments)
-
-			if !reqOk || !tapeOk {
-				// Path doesn't exist in one or both — skip, not a mismatch.
-				continue
-			}
-
-			if !reflect.DeepEqual(reqVal, tapeVal) {
-				return 0 // field exists in both but values differ — eliminate.
-			}
-			matched++
-		}
-
-		if matched == 0 {
-			return 0 // no fields compared — no evidence of match.
-		}
-		return 6
-	}
+	return NewCompositeMatcher(MethodCriterion{}, PathCriterion{})
 }
 
 // extractAtPath traverses the JSON structure following the given segments

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -14,7 +14,7 @@ import (
 // --- Individual criterion tests ---
 
 func TestMatchMethod(t *testing.T) {
-	criterion := MatchMethod()
+	criterion := MethodCriterion{}
 
 	tests := []struct {
 		name       string
@@ -33,16 +33,16 @@ func TestMatchMethod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(tt.reqMethod, "/test", nil)
 			tape := Tape{Request: RecordedReq{Method: tt.tapeMethod}}
-			got := criterion(req, tape)
+			got := criterion.Score(req, tape)
 			if got != tt.wantScore {
-				t.Errorf("MatchMethod() = %d, want %d", got, tt.wantScore)
+				t.Errorf("MethodCriterion.Score() = %d, want %d", got, tt.wantScore)
 			}
 		})
 	}
 }
 
 func TestMatchPath(t *testing.T) {
-	criterion := MatchPath()
+	criterion := PathCriterion{}
 
 	tests := []struct {
 		name      string
@@ -63,21 +63,21 @@ func TestMatchPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", tt.reqPath, nil)
 			tape := Tape{Request: RecordedReq{URL: tt.tapeURL}}
-			got := criterion(req, tape)
+			got := criterion.Score(req, tape)
 			if got != tt.wantScore {
-				t.Errorf("MatchPath() = %d, want %d", got, tt.wantScore)
+				t.Errorf("PathCriterion.Score() = %d, want %d", got, tt.wantScore)
 			}
 		})
 	}
 }
 
 func TestMatchPath_UnparsableURL(t *testing.T) {
-	criterion := MatchPath()
+	criterion := PathCriterion{}
 	req := httptest.NewRequest("GET", "/users", nil)
 	tape := Tape{Request: RecordedReq{URL: "://not-a-url"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchPath() with unparsable URL = %d, want 0", got)
+		t.Errorf("PathCriterion.Score() with unparsable URL = %d, want 0", got)
 	}
 }
 
@@ -95,19 +95,19 @@ func TestMatchRoute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			criterion := MatchRoute(tt.route)
+			criterion := RouteCriterion{Route: tt.route}
 			req := httptest.NewRequest("GET", "/test", nil)
 			tape := Tape{Route: tt.tapeRoute}
-			got := criterion(req, tape)
+			got := criterion.Score(req, tape)
 			if got != tt.wantScore {
-				t.Errorf("MatchRoute(%q) = %d, want %d", tt.route, got, tt.wantScore)
+				t.Errorf("RouteCriterion{Route: %q}.Score() = %d, want %d", tt.route, got, tt.wantScore)
 			}
 		})
 	}
 }
 
 func TestMatchRoute_EmptyFilter(t *testing.T) {
-	criterion := MatchRoute("")
+	criterion := RouteCriterion{Route: ""}
 	req := httptest.NewRequest("GET", "/test", nil)
 
 	tests := []struct {
@@ -122,16 +122,16 @@ func TestMatchRoute_EmptyFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tape := Tape{Route: tt.tapeRoute}
-			got := criterion(req, tape)
+			got := criterion.Score(req, tape)
 			if got != 1 {
-				t.Errorf("MatchRoute(\"\") with tape route %q = %d, want 1", tt.tapeRoute, got)
+				t.Errorf("RouteCriterion{Route: \"\"}.Score() with tape route %q = %d, want 1", tt.tapeRoute, got)
 			}
 		})
 	}
 }
 
 func TestMatchQueryParams(t *testing.T) {
-	criterion := MatchQueryParams()
+	criterion := QueryParamsCriterion{}
 
 	tests := []struct {
 		name      string
@@ -163,102 +163,102 @@ func TestMatchQueryParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", tt.reqURL, nil)
 			tape := Tape{Request: RecordedReq{URL: tt.tapeURL}}
-			got := criterion(req, tape)
+			got := criterion.Score(req, tape)
 			if got != tt.wantScore {
-				t.Errorf("MatchQueryParams() = %d, want %d", got, tt.wantScore)
+				t.Errorf("QueryParamsCriterion.Score() = %d, want %d", got, tt.wantScore)
 			}
 		})
 	}
 }
 
 func TestMatchQueryParams_NoRequestParams(t *testing.T) {
-	criterion := MatchQueryParams()
+	criterion := QueryParamsCriterion{}
 	req := httptest.NewRequest("GET", "/users", nil)
 	tape := Tape{Request: RecordedReq{URL: "https://api.example.com/users?page=1"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 4 {
-		t.Errorf("MatchQueryParams() with no request params = %d, want 4", got)
+		t.Errorf("QueryParamsCriterion.Score() with no request params = %d, want 4", got)
 	}
 }
 
 func TestMatchQueryParams_Missing(t *testing.T) {
-	criterion := MatchQueryParams()
+	criterion := QueryParamsCriterion{}
 	req := httptest.NewRequest("GET", "/users?page=1&sort=asc", nil)
 	tape := Tape{Request: RecordedReq{URL: "https://api.example.com/users?page=1"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchQueryParams() with missing tape param = %d, want 0", got)
+		t.Errorf("QueryParamsCriterion.Score() with missing tape param = %d, want 0", got)
 	}
 }
 
 func TestMatchQueryParams_UnparsableURL(t *testing.T) {
-	criterion := MatchQueryParams()
+	criterion := QueryParamsCriterion{}
 	req := httptest.NewRequest("GET", "/users?page=1", nil)
 	tape := Tape{Request: RecordedReq{URL: "://not-a-url"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchQueryParams() with unparsable URL = %d, want 0", got)
+		t.Errorf("QueryParamsCriterion.Score() with unparsable URL = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyHash_Match(t *testing.T) {
-	criterion := MatchBodyHash()
+	criterion := BodyHashCriterion{}
 	body := []byte("hello world")
 	hash := BodyHashFromBytes(body)
 
 	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
 	tape := Tape{Request: RecordedReq{BodyHash: hash}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 8 {
-		t.Errorf("MatchBodyHash() = %d, want 8", got)
+		t.Errorf("BodyHashCriterion.Score() = %d, want 8", got)
 	}
 }
 
 func TestMatchBodyHash_Mismatch(t *testing.T) {
-	criterion := MatchBodyHash()
+	criterion := BodyHashCriterion{}
 	reqBody := []byte("hello world")
 	tapeHash := BodyHashFromBytes([]byte("different body"))
 
 	req := httptest.NewRequest("POST", "/test", bytes.NewReader(reqBody))
 	tape := Tape{Request: RecordedReq{BodyHash: tapeHash}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyHash() = %d, want 0", got)
+		t.Errorf("BodyHashCriterion.Score() = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyHash_BothEmpty(t *testing.T) {
-	criterion := MatchBodyHash()
+	criterion := BodyHashCriterion{}
 	req := httptest.NewRequest("GET", "/test", nil)
 	tape := Tape{Request: RecordedReq{BodyHash: ""}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 8 {
-		t.Errorf("MatchBodyHash() both empty = %d, want 8", got)
+		t.Errorf("BodyHashCriterion.Score() both empty = %d, want 8", got)
 	}
 }
 
 func TestMatchBodyHash_RequestEmpty_TapeNot(t *testing.T) {
-	criterion := MatchBodyHash()
+	criterion := BodyHashCriterion{}
 	req := httptest.NewRequest("GET", "/test", nil)
 	tape := Tape{Request: RecordedReq{BodyHash: "abc123"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyHash() request empty, tape not = %d, want 0", got)
+		t.Errorf("BodyHashCriterion.Score() request empty, tape not = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyHash_RequestNotEmpty_TapeEmpty(t *testing.T) {
-	criterion := MatchBodyHash()
+	criterion := BodyHashCriterion{}
 	req := httptest.NewRequest("POST", "/test", strings.NewReader("some body"))
 	tape := Tape{Request: RecordedReq{BodyHash: ""}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyHash() request not empty, tape empty = %d, want 0", got)
+		t.Errorf("BodyHashCriterion.Score() request not empty, tape empty = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyHash_BodyRestored(t *testing.T) {
-	criterion := MatchBodyHash()
+	criterion := BodyHashCriterion{}
 	body := []byte("hello world")
 	hash := BodyHashFromBytes(body)
 
@@ -266,9 +266,9 @@ func TestMatchBodyHash_BodyRestored(t *testing.T) {
 	tape := Tape{Request: RecordedReq{BodyHash: hash}}
 
 	// First call should match.
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 8 {
-		t.Fatalf("MatchBodyHash() first call = %d, want 8", got)
+		t.Fatalf("BodyHashCriterion.Score() first call = %d, want 8", got)
 	}
 
 	// Body should still be readable after criterion runs.
@@ -281,10 +281,10 @@ func TestMatchBodyHash_BodyRestored(t *testing.T) {
 	}
 }
 
-// --- MatchHeaders tests ---
+// --- HeadersCriterion tests ---
 
 func TestMatchHeaders_SingleHeader(t *testing.T) {
-	criterion := MatchHeaders("Content-Type", "application/json")
+	criterion := HeadersCriterion{Key: "Content-Type", Value: "application/json"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -294,9 +294,9 @@ func TestMatchHeaders_SingleHeader(t *testing.T) {
 		Headers: http.Header{"Content-Type": {"application/json"}},
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 3 {
-		t.Errorf("MatchHeaders() = %d, want 3", got)
+		t.Errorf("HeadersCriterion.Score() = %d, want 3", got)
 	}
 }
 
@@ -313,7 +313,7 @@ func TestMatchHeaders_CaseInsensitiveName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			criterion := MatchHeaders(tt.key, "application/json")
+			criterion := HeadersCriterion{Key: tt.key, Value: "application/json"}
 
 			req := httptest.NewRequest("GET", "/test", nil)
 			req.Header.Set("Content-Type", "application/json")
@@ -321,16 +321,16 @@ func TestMatchHeaders_CaseInsensitiveName(t *testing.T) {
 				Headers: http.Header{"Content-Type": {"application/json"}},
 			}}
 
-			got := criterion(req, tape)
+			got := criterion.Score(req, tape)
 			if got != 3 {
-				t.Errorf("MatchHeaders(%q, ...) = %d, want 3", tt.key, got)
+				t.Errorf("HeadersCriterion{Key: %q}.Score() = %d, want 3", tt.key, got)
 			}
 		})
 	}
 }
 
 func TestMatchHeaders_CaseSensitiveValue(t *testing.T) {
-	criterion := MatchHeaders("Accept", "Application/JSON")
+	criterion := HeadersCriterion{Key: "Accept", Value: "Application/JSON"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Accept", "application/json")
@@ -338,14 +338,14 @@ func TestMatchHeaders_CaseSensitiveValue(t *testing.T) {
 		Headers: http.Header{"Accept": {"application/json"}},
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchHeaders() with case mismatch value = %d, want 0", got)
+		t.Errorf("HeadersCriterion.Score() with case mismatch value = %d, want 0", got)
 	}
 }
 
 func TestMatchHeaders_HeaderNotInRequest(t *testing.T) {
-	criterion := MatchHeaders("X-Custom", "value")
+	criterion := HeadersCriterion{Key: "X-Custom", Value: "value"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	// No X-Custom header set on request.
@@ -353,14 +353,14 @@ func TestMatchHeaders_HeaderNotInRequest(t *testing.T) {
 		Headers: http.Header{"X-Custom": {"value"}},
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchHeaders() header not in request = %d, want 0", got)
+		t.Errorf("HeadersCriterion.Score() header not in request = %d, want 0", got)
 	}
 }
 
 func TestMatchHeaders_HeaderNotInTape(t *testing.T) {
-	criterion := MatchHeaders("X-Custom", "value")
+	criterion := HeadersCriterion{Key: "X-Custom", Value: "value"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Custom", "value")
@@ -368,14 +368,14 @@ func TestMatchHeaders_HeaderNotInTape(t *testing.T) {
 		Headers: http.Header{},
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchHeaders() header not in tape = %d, want 0", got)
+		t.Errorf("HeadersCriterion.Score() header not in tape = %d, want 0", got)
 	}
 }
 
 func TestMatchHeaders_WrongValueInRequest(t *testing.T) {
-	criterion := MatchHeaders("Accept", "application/xml")
+	criterion := HeadersCriterion{Key: "Accept", Value: "application/xml"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Accept", "application/json")
@@ -383,14 +383,14 @@ func TestMatchHeaders_WrongValueInRequest(t *testing.T) {
 		Headers: http.Header{"Accept": {"application/xml"}},
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchHeaders() wrong value in request = %d, want 0", got)
+		t.Errorf("HeadersCriterion.Score() wrong value in request = %d, want 0", got)
 	}
 }
 
 func TestMatchHeaders_WrongValueInTape(t *testing.T) {
-	criterion := MatchHeaders("Accept", "application/xml")
+	criterion := HeadersCriterion{Key: "Accept", Value: "application/xml"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Accept", "application/xml")
@@ -398,14 +398,14 @@ func TestMatchHeaders_WrongValueInTape(t *testing.T) {
 		Headers: http.Header{"Accept": {"application/json"}},
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchHeaders() wrong value in tape = %d, want 0", got)
+		t.Errorf("HeadersCriterion.Score() wrong value in tape = %d, want 0", got)
 	}
 }
 
 func TestMatchHeaders_MultiValuedHeader_AnyOf(t *testing.T) {
-	criterion := MatchHeaders("Accept", "application/json")
+	criterion := HeadersCriterion{Key: "Accept", Value: "application/json"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Add("Accept", "text/html")
@@ -414,14 +414,14 @@ func TestMatchHeaders_MultiValuedHeader_AnyOf(t *testing.T) {
 		Headers: http.Header{"Accept": {"text/html", "application/json"}},
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 3 {
-		t.Errorf("MatchHeaders() multi-valued any-of = %d, want 3", got)
+		t.Errorf("HeadersCriterion.Score() multi-valued any-of = %d, want 3", got)
 	}
 }
 
 func TestMatchHeaders_MultiValuedHeader_NotPresent(t *testing.T) {
-	criterion := MatchHeaders("Accept", "application/xml")
+	criterion := HeadersCriterion{Key: "Accept", Value: "application/xml"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Add("Accept", "text/html")
@@ -430,31 +430,31 @@ func TestMatchHeaders_MultiValuedHeader_NotPresent(t *testing.T) {
 		Headers: http.Header{"Accept": {"text/html", "application/json"}},
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchHeaders() multi-valued not present = %d, want 0", got)
+		t.Errorf("HeadersCriterion.Score() multi-valued not present = %d, want 0", got)
 	}
 }
 
 func TestMatchHeaders_NilTapeHeaders(t *testing.T) {
-	criterion := MatchHeaders("X-Custom", "value")
+	criterion := HeadersCriterion{Key: "X-Custom", Value: "value"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Custom", "value")
 	tape := Tape{Request: RecordedReq{}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchHeaders() nil tape headers = %d, want 0", got)
+		t.Errorf("HeadersCriterion.Score() nil tape headers = %d, want 0", got)
 	}
 }
 
 func TestMatchHeaders_MultipleCriteria_AND(t *testing.T) {
 	m := NewCompositeMatcher(
-		MatchMethod(),
-		MatchPath(),
-		MatchHeaders("Accept", "application/json"),
-		MatchHeaders("X-Api-Version", "v2"),
+		MethodCriterion{},
+		PathCriterion{},
+		HeadersCriterion{Key: "Accept", Value: "application/json"},
+		HeadersCriterion{Key: "X-Api-Version", Value: "v2"},
 	)
 
 	candidates := []Tape{
@@ -499,8 +499,8 @@ func TestMatchHeaders_MultipleCriteria_AND(t *testing.T) {
 
 func TestMatchHeaders_ScoreStacking(t *testing.T) {
 	// Two header criteria should contribute 6 total (3 + 3).
-	c1 := MatchHeaders("Accept", "application/json")
-	c2 := MatchHeaders("X-Api-Version", "v2")
+	c1 := HeadersCriterion{Key: "Accept", Value: "application/json"}
+	c2 := HeadersCriterion{Key: "X-Api-Version", Value: "v2"}
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Accept", "application/json")
@@ -512,8 +512,8 @@ func TestMatchHeaders_ScoreStacking(t *testing.T) {
 		},
 	}}
 
-	s1 := c1(req, tape)
-	s2 := c2(req, tape)
+	s1 := c1.Score(req, tape)
+	s2 := c2.Score(req, tape)
 	if s1+s2 != 6 {
 		t.Errorf("stacked header scores = %d, want 6", s1+s2)
 	}
@@ -602,7 +602,7 @@ func TestCompositeMatcher_Priority(t *testing.T) {
 	body := []byte("request body")
 	hash := BodyHashFromBytes(body)
 
-	m := NewCompositeMatcher(MatchMethod(), MatchPath(), MatchBodyHash())
+	m := NewCompositeMatcher(MethodCriterion{}, PathCriterion{}, BodyHashCriterion{})
 
 	candidates := []Tape{
 		{
@@ -646,13 +646,13 @@ func TestCompositeMatcher_StableOrdering(t *testing.T) {
 
 func TestCompositeMatcher_ShortCircuit(t *testing.T) {
 	called := false
-	trackingCriterion := MatchCriterion(func(_ *http.Request, _ Tape) int {
+	trackingCriterion := CriterionFunc(func(_ *http.Request, _ Tape) int {
 		called = true
 		return 1
 	})
 
 	// Put a criterion that always returns 0 first, then a tracking one.
-	alwaysFail := MatchCriterion(func(_ *http.Request, _ Tape) int { return 0 })
+	alwaysFail := CriterionFunc(func(_ *http.Request, _ Tape) int { return 0 })
 	m := NewCompositeMatcher(alwaysFail, trackingCriterion)
 
 	req := httptest.NewRequest("GET", "/users", nil)
@@ -669,11 +669,11 @@ func TestCompositeMatcher_FullComposition(t *testing.T) {
 	hash := BodyHashFromBytes(body)
 
 	m := NewCompositeMatcher(
-		MatchMethod(),
-		MatchPath(),
-		MatchRoute("users-api"),
-		MatchQueryParams(),
-		MatchBodyHash(),
+		MethodCriterion{},
+		PathCriterion{},
+		RouteCriterion{Route: "users-api"},
+		QueryParamsCriterion{},
+		BodyHashCriterion{},
 	)
 
 	candidates := []Tape{
@@ -806,66 +806,66 @@ func TestStringSlicesEqual(t *testing.T) {
 	}
 }
 
-// --- MatchPathRegex tests ---
+// --- PathRegexCriterion tests ---
 
 func TestMatchPathRegex_Match(t *testing.T) {
-	criterion, err := MatchPathRegex(`^/users/\d+/orders$`)
+	criterion, err := NewPathRegexCriterion(`^/users/\d+/orders$`)
 	if err != nil {
-		t.Fatalf("MatchPathRegex() error = %v", err)
+		t.Fatalf("NewPathRegexCriterion() error = %v", err)
 	}
 
 	req := httptest.NewRequest("GET", "/users/456/orders", nil)
 	tape := Tape{Request: RecordedReq{URL: "https://api.example.com/users/123/orders"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 1 {
-		t.Errorf("MatchPathRegex() = %d, want 1", got)
+		t.Errorf("PathRegexCriterion.Score() = %d, want 1", got)
 	}
 }
 
 func TestMatchPathRegex_RequestNoMatch(t *testing.T) {
-	criterion, err := MatchPathRegex(`^/users/\d+/orders$`)
+	criterion, err := NewPathRegexCriterion(`^/users/\d+/orders$`)
 	if err != nil {
-		t.Fatalf("MatchPathRegex() error = %v", err)
+		t.Fatalf("NewPathRegexCriterion() error = %v", err)
 	}
 
 	req := httptest.NewRequest("GET", "/products/1", nil)
 	tape := Tape{Request: RecordedReq{URL: "https://api.example.com/users/123/orders"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchPathRegex() = %d, want 0", got)
+		t.Errorf("PathRegexCriterion.Score() = %d, want 0", got)
 	}
 }
 
 func TestMatchPathRegex_TapeNoMatch(t *testing.T) {
-	criterion, err := MatchPathRegex(`^/users/\d+/orders$`)
+	criterion, err := NewPathRegexCriterion(`^/users/\d+/orders$`)
 	if err != nil {
-		t.Fatalf("MatchPathRegex() error = %v", err)
+		t.Fatalf("NewPathRegexCriterion() error = %v", err)
 	}
 
 	req := httptest.NewRequest("GET", "/users/456/orders", nil)
 	tape := Tape{Request: RecordedReq{URL: "https://api.example.com/products/42"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchPathRegex() = %d, want 0", got)
+		t.Errorf("PathRegexCriterion.Score() = %d, want 0", got)
 	}
 }
 
 func TestMatchPathRegex_UnparsableTapeURL(t *testing.T) {
-	criterion, err := MatchPathRegex(`^/users/\d+$`)
+	criterion, err := NewPathRegexCriterion(`^/users/\d+$`)
 	if err != nil {
-		t.Fatalf("MatchPathRegex() error = %v", err)
+		t.Fatalf("NewPathRegexCriterion() error = %v", err)
 	}
 
 	req := httptest.NewRequest("GET", "/users/123", nil)
 	tape := Tape{Request: RecordedReq{URL: "://not-a-url"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchPathRegex() with unparsable URL = %d, want 0", got)
+		t.Errorf("PathRegexCriterion.Score() with unparsable URL = %d, want 0", got)
 	}
 }
 
 func TestMatchPathRegex_InvalidPattern(t *testing.T) {
-	criterion, err := MatchPathRegex("[invalid")
+	criterion, err := NewPathRegexCriterion("[invalid")
 	if err == nil {
 		t.Fatal("expected error for invalid regex pattern")
 	}
@@ -875,16 +875,16 @@ func TestMatchPathRegex_InvalidPattern(t *testing.T) {
 }
 
 func TestMatchPathRegex_BroadPattern(t *testing.T) {
-	criterion, err := MatchPathRegex(`.*`)
+	criterion, err := NewPathRegexCriterion(`.*`)
 	if err != nil {
-		t.Fatalf("MatchPathRegex() error = %v", err)
+		t.Fatalf("NewPathRegexCriterion() error = %v", err)
 	}
 
 	req := httptest.NewRequest("GET", "/anything/at/all", nil)
 	tape := Tape{Request: RecordedReq{URL: "https://api.example.com/something/else"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 1 {
-		t.Errorf("MatchPathRegex(\".*\") = %d, want 1", got)
+		t.Errorf("PathRegexCriterion.Score(\".*\") = %d, want 1", got)
 	}
 }
 
@@ -921,41 +921,41 @@ func TestMatchPathRegex_AnchoredPattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			criterion, err := MatchPathRegex(tt.pattern)
+			criterion, err := NewPathRegexCriterion(tt.pattern)
 			if err != nil {
-				t.Fatalf("MatchPathRegex(%q) error = %v", tt.pattern, err)
+				t.Fatalf("NewPathRegexCriterion(%q) error = %v", tt.pattern, err)
 			}
 			req := httptest.NewRequest("GET", tt.reqPath, nil)
 			tape := Tape{Request: RecordedReq{URL: tt.tapeURL}}
-			got := criterion(req, tape)
+			got := criterion.Score(req, tape)
 			if got != tt.wantScore {
-				t.Errorf("MatchPathRegex(%q) = %d, want %d", tt.pattern, got, tt.wantScore)
+				t.Errorf("PathRegexCriterion.Score(%q) = %d, want %d", tt.pattern, got, tt.wantScore)
 			}
 		})
 	}
 }
 
 func TestMatchPathRegex_EmptyPattern(t *testing.T) {
-	criterion, err := MatchPathRegex("")
+	criterion, err := NewPathRegexCriterion("")
 	if err != nil {
-		t.Fatalf("MatchPathRegex(\"\") error = %v", err)
+		t.Fatalf("NewPathRegexCriterion(\"\") error = %v", err)
 	}
 
 	req := httptest.NewRequest("GET", "/anything", nil)
 	tape := Tape{Request: RecordedReq{URL: "https://api.example.com/whatever"}}
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 1 {
-		t.Errorf("MatchPathRegex(\"\") = %d, want 1", got)
+		t.Errorf("PathRegexCriterion.Score(\"\") = %d, want 1", got)
 	}
 }
 
 func TestCompositeMatcher_RegexPath(t *testing.T) {
-	criterion, err := MatchPathRegex(`^/users/\d+/orders$`)
+	criterion, err := NewPathRegexCriterion(`^/users/\d+/orders$`)
 	if err != nil {
-		t.Fatalf("MatchPathRegex() error = %v", err)
+		t.Fatalf("NewPathRegexCriterion() error = %v", err)
 	}
 
-	m := NewCompositeMatcher(MatchMethod(), criterion)
+	m := NewCompositeMatcher(MethodCriterion{}, criterion)
 
 	candidates := []Tape{
 		{ID: "user-orders", Request: RecordedReq{Method: "GET", URL: "https://api.example.com/users/123/orders"}},
@@ -974,15 +974,15 @@ func TestCompositeMatcher_RegexPath(t *testing.T) {
 }
 
 func TestCompositeMatcher_ExactBeatsRegex(t *testing.T) {
-	// Exact matcher: MatchMethod (1) + MatchPath (2) = 3
-	exactMatcher := NewCompositeMatcher(MatchMethod(), MatchPath())
+	// Exact matcher: MethodCriterion (1) + PathCriterion (2) = 3
+	exactMatcher := NewCompositeMatcher(MethodCriterion{}, PathCriterion{})
 
-	// Regex matcher: MatchMethod (1) + MatchPathRegex (1) = 2
-	regexCriterion, err := MatchPathRegex(`^/users/\d+$`)
+	// Regex matcher: MethodCriterion (1) + PathRegexCriterion (1) = 2
+	regexCriterion, err := NewPathRegexCriterion(`^/users/\d+$`)
 	if err != nil {
-		t.Fatalf("MatchPathRegex() error = %v", err)
+		t.Fatalf("NewPathRegexCriterion() error = %v", err)
 	}
-	regexMatcher := NewCompositeMatcher(MatchMethod(), regexCriterion)
+	regexMatcher := NewCompositeMatcher(MethodCriterion{}, regexCriterion)
 
 	candidates := []Tape{
 		{ID: "user-123", Request: RecordedReq{Method: "GET", URL: "https://api.example.com/users/123"}},
@@ -1006,18 +1006,18 @@ func TestCompositeMatcher_ExactBeatsRegex(t *testing.T) {
 	}
 
 	// Verify scores directly by running criteria.
-	exactPathScore := MatchPath()(req, candidates[0])
-	regexPathScore := regexCriterion(req, candidates[0])
+	exactPathScore := PathCriterion{}.Score(req, candidates[0])
+	regexPathScore := regexCriterion.Score(req, candidates[0])
 	if exactPathScore <= regexPathScore {
-		t.Errorf("MatchPath score (%d) should be greater than MatchPathRegex score (%d)",
+		t.Errorf("PathCriterion score (%d) should be greater than PathRegexCriterion score (%d)",
 			exactPathScore, regexPathScore)
 	}
 }
 
-// --- MatchBodyFuzzy tests ---
+// --- BodyFuzzyCriterion tests ---
 
 func TestMatchBodyFuzzy_SingleField(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action")
+	criterion := NewBodyFuzzyCriterion("$.action")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create","timestamp":"2026-01-01T00:00:00Z"}`))
@@ -1025,14 +1025,14 @@ func TestMatchBodyFuzzy_SingleField(t *testing.T) {
 		Body: []byte(`{"action":"create","timestamp":"2025-06-15T12:00:00Z"}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_MultipleFields(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action", "$.user")
+	criterion := NewBodyFuzzyCriterion("$.action", "$.user")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create","user":"alice","nonce":"abc123"}`))
@@ -1040,14 +1040,14 @@ func TestMatchBodyFuzzy_MultipleFields(t *testing.T) {
 		Body: []byte(`{"action":"create","user":"alice","nonce":"xyz789"}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_NestedField(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.user.id")
+	criterion := NewBodyFuzzyCriterion("$.user.id")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"user":{"id":42,"session":"s1"}}`))
@@ -1055,14 +1055,14 @@ func TestMatchBodyFuzzy_NestedField(t *testing.T) {
 		Body: []byte(`{"user":{"id":42,"session":"s2"}}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() nested = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() nested = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_ArrayWildcard(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.items[*].sku")
+	criterion := NewBodyFuzzyCriterion("$.items[*].sku")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"items":[{"sku":"A1","qty":5},{"sku":"B2","qty":3}]}`))
@@ -1070,14 +1070,14 @@ func TestMatchBodyFuzzy_ArrayWildcard(t *testing.T) {
 		Body: []byte(`{"items":[{"sku":"A1","qty":10},{"sku":"B2","qty":7}]}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() array wildcard = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() array wildcard = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_FieldValueDiffers(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action")
+	criterion := NewBodyFuzzyCriterion("$.action")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create"}`))
@@ -1085,14 +1085,14 @@ func TestMatchBodyFuzzy_FieldValueDiffers(t *testing.T) {
 		Body: []byte(`{"action":"delete"}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() mismatch = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() mismatch = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_NonJSONRequestBody(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action")
+	criterion := NewBodyFuzzyCriterion("$.action")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader("not json"))
@@ -1100,14 +1100,14 @@ func TestMatchBodyFuzzy_NonJSONRequestBody(t *testing.T) {
 		Body: []byte(`{"action":"create"}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() non-JSON request = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() non-JSON request = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_NonJSONTapeBody(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action")
+	criterion := NewBodyFuzzyCriterion("$.action")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create"}`))
@@ -1115,14 +1115,14 @@ func TestMatchBodyFuzzy_NonJSONTapeBody(t *testing.T) {
 		Body: []byte("not json"),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() non-JSON tape = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() non-JSON tape = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_EmptyPaths(t *testing.T) {
-	criterion := MatchBodyFuzzy()
+	criterion := NewBodyFuzzyCriterion()
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create"}`))
@@ -1130,14 +1130,14 @@ func TestMatchBodyFuzzy_EmptyPaths(t *testing.T) {
 		Body: []byte(`{"action":"create"}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() empty paths = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() empty paths = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_PathInRequestNotInTape(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action", "$.extra")
+	criterion := NewBodyFuzzyCriterion("$.action", "$.extra")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create","extra":"value"}`))
@@ -1146,14 +1146,14 @@ func TestMatchBodyFuzzy_PathInRequestNotInTape(t *testing.T) {
 	}}
 
 	// "extra" is skipped (not in tape), "action" matches => score 6
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() path in req not tape = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() path in req not tape = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_PathInTapeNotInRequest(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action", "$.extra")
+	criterion := NewBodyFuzzyCriterion("$.action", "$.extra")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create"}`))
@@ -1162,26 +1162,26 @@ func TestMatchBodyFuzzy_PathInTapeNotInRequest(t *testing.T) {
 	}}
 
 	// "extra" is skipped (not in request), "action" matches => score 6
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() path in tape not req = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() path in tape not req = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_BothBodiesEmpty(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action")
+	criterion := NewBodyFuzzyCriterion("$.action")
 
 	req := httptest.NewRequest("POST", "/test", nil)
 	tape := Tape{Request: RecordedReq{Body: nil}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 1 {
-		t.Errorf("MatchBodyFuzzy() both empty = %d, want 1", got)
+		t.Errorf("BodyFuzzyCriterion.Score() both empty = %d, want 1", got)
 	}
 }
 
 func TestMatchBodyFuzzy_VacuousTrue(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action")
+	criterion := NewBodyFuzzyCriterion("$.action")
 
 	tests := []struct {
 		name     string
@@ -1278,9 +1278,9 @@ func TestMatchBodyFuzzy_VacuousTrue(t *testing.T) {
 			req := httptest.NewRequest("POST", "/test", body)
 			tape := Tape{Request: RecordedReq{Body: tt.tapeBody}}
 
-			got := criterion(req, tape)
+			got := criterion.Score(req, tape)
 			if got != tt.want {
-				t.Errorf("MatchBodyFuzzy() = %d, want %d", got, tt.want)
+				t.Errorf("BodyFuzzyCriterion.Score() = %d, want %d", got, tt.want)
 			}
 		})
 	}
@@ -1288,13 +1288,13 @@ func TestMatchBodyFuzzy_VacuousTrue(t *testing.T) {
 
 func TestMatchBodyFuzzy_VacuousTrueComposability(t *testing.T) {
 	// Integration test: validates the real user story from issue #178.
-	// A CompositeMatcher with MatchMethod, MatchPath, and MatchBodyFuzzy
+	// A CompositeMatcher with MethodCriterion, PathCriterion, and BodyFuzzyCriterion
 	// must correctly match a body-less GET request against a body-less
-	// GET tape, without MatchBodyFuzzy eliminating the candidate via score 0.
+	// GET tape, without BodyFuzzyCriterion eliminating the candidate via score 0.
 	matcher := NewCompositeMatcher(
-		MatchMethod(),
-		MatchPath(),
-		MatchBodyFuzzy("$.action"),
+		MethodCriterion{},
+		PathCriterion{},
+		NewBodyFuzzyCriterion("$.action"),
 	)
 
 	// Candidate tapes: one body-less GET and one bodied POST.
@@ -1330,7 +1330,7 @@ func TestMatchBodyFuzzy_VacuousTrueComposability(t *testing.T) {
 
 func TestMatchBodyFuzzy_InvalidPaths(t *testing.T) {
 	// All paths invalid => parsed list is empty => returns 0
-	criterion := MatchBodyFuzzy("not-a-path", "also-bad")
+	criterion := NewBodyFuzzyCriterion("not-a-path", "also-bad")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create"}`))
@@ -1338,15 +1338,15 @@ func TestMatchBodyFuzzy_InvalidPaths(t *testing.T) {
 		Body: []byte(`{"action":"create"}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() invalid paths = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() invalid paths = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_AllPathsMissing(t *testing.T) {
 	// Valid paths but none exist in either body => matched=0 => returns 0
-	criterion := MatchBodyFuzzy("$.nonexistent")
+	criterion := NewBodyFuzzyCriterion("$.nonexistent")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"action":"create"}`))
@@ -1354,14 +1354,14 @@ func TestMatchBodyFuzzy_AllPathsMissing(t *testing.T) {
 		Body: []byte(`{"action":"create"}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() all paths missing = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() all paths missing = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_BodyRestored(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.action")
+	criterion := NewBodyFuzzyCriterion("$.action")
 
 	body := `{"action":"create"}`
 	req := httptest.NewRequest("POST", "/test", strings.NewReader(body))
@@ -1369,7 +1369,7 @@ func TestMatchBodyFuzzy_BodyRestored(t *testing.T) {
 		Body: []byte(`{"action":"create"}`),
 	}}
 
-	criterion(req, tape)
+	criterion.Score(req, tape)
 
 	// Body should be restored for subsequent reads.
 	restored, err := io.ReadAll(req.Body)
@@ -1382,7 +1382,7 @@ func TestMatchBodyFuzzy_BodyRestored(t *testing.T) {
 }
 
 func TestMatchBodyFuzzy_DeepNestedObject(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.a.b.c")
+	criterion := NewBodyFuzzyCriterion("$.a.b.c")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"a":{"b":{"c":"deep"}}}`))
@@ -1390,14 +1390,14 @@ func TestMatchBodyFuzzy_DeepNestedObject(t *testing.T) {
 		Body: []byte(`{"a":{"b":{"c":"deep"}}}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() deep nested = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() deep nested = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_NumericValue(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.count")
+	criterion := NewBodyFuzzyCriterion("$.count")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"count":42}`))
@@ -1405,14 +1405,14 @@ func TestMatchBodyFuzzy_NumericValue(t *testing.T) {
 		Body: []byte(`{"count":42}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() numeric = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() numeric = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_BooleanValue(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.active")
+	criterion := NewBodyFuzzyCriterion("$.active")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"active":true}`))
@@ -1420,14 +1420,14 @@ func TestMatchBodyFuzzy_BooleanValue(t *testing.T) {
 		Body: []byte(`{"active":true}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() boolean = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() boolean = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_NullValue(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.data")
+	criterion := NewBodyFuzzyCriterion("$.data")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"data":null}`))
@@ -1435,15 +1435,15 @@ func TestMatchBodyFuzzy_NullValue(t *testing.T) {
 		Body: []byte(`{"data":null}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() null = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() null = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_ObjectValue(t *testing.T) {
 	// Comparing an entire nested object
-	criterion := MatchBodyFuzzy("$.config")
+	criterion := NewBodyFuzzyCriterion("$.config")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"config":{"retries":3,"timeout":30},"id":"abc"}`))
@@ -1451,14 +1451,14 @@ func TestMatchBodyFuzzy_ObjectValue(t *testing.T) {
 		Body: []byte(`{"config":{"retries":3,"timeout":30},"id":"xyz"}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 6 {
-		t.Errorf("MatchBodyFuzzy() object value = %d, want 6", got)
+		t.Errorf("BodyFuzzyCriterion.Score() object value = %d, want 6", got)
 	}
 }
 
 func TestMatchBodyFuzzy_ArrayWildcard_DifferentValues(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.items[*].sku")
+	criterion := NewBodyFuzzyCriterion("$.items[*].sku")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"items":[{"sku":"A1"},{"sku":"B2"}]}`))
@@ -1466,14 +1466,14 @@ func TestMatchBodyFuzzy_ArrayWildcard_DifferentValues(t *testing.T) {
 		Body: []byte(`{"items":[{"sku":"A1"},{"sku":"C3"}]}`),
 	}}
 
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() array wildcard mismatch = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() array wildcard mismatch = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_ArrayWildcard_DifferentLengths(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.items[*].sku")
+	criterion := NewBodyFuzzyCriterion("$.items[*].sku")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"items":[{"sku":"A1"},{"sku":"B2"}]}`))
@@ -1482,17 +1482,17 @@ func TestMatchBodyFuzzy_ArrayWildcard_DifferentLengths(t *testing.T) {
 	}}
 
 	// Different array lengths produce different collected slices
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() array different lengths = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() array different lengths = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_Composability(t *testing.T) {
 	m := NewCompositeMatcher(
-		MatchMethod(),
-		MatchPath(),
-		MatchBodyFuzzy("$.action"),
+		MethodCriterion{},
+		PathCriterion{},
+		NewBodyFuzzyCriterion("$.action"),
 	)
 
 	candidates := []Tape{
@@ -1526,7 +1526,7 @@ func TestMatchBodyFuzzy_Composability(t *testing.T) {
 }
 
 func TestMatchBodyFuzzy_WildcardNotArray(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.items[*].sku")
+	criterion := NewBodyFuzzyCriterion("$.items[*].sku")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"items":"not-an-array"}`))
@@ -1535,14 +1535,14 @@ func TestMatchBodyFuzzy_WildcardNotArray(t *testing.T) {
 	}}
 
 	// items is not an array, so path extraction fails => skipped => matched=0 => 0
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() wildcard not array = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() wildcard not array = %d, want 0", got)
 	}
 }
 
 func TestMatchBodyFuzzy_WildcardMissingFieldInElement(t *testing.T) {
-	criterion := MatchBodyFuzzy("$.items[*].sku")
+	criterion := NewBodyFuzzyCriterion("$.items[*].sku")
 
 	req := httptest.NewRequest("POST", "/test",
 		strings.NewReader(`{"items":[{"sku":"A1"},{"name":"B2"}]}`))
@@ -1551,9 +1551,9 @@ func TestMatchBodyFuzzy_WildcardMissingFieldInElement(t *testing.T) {
 	}}
 
 	// Second element in request doesn't have "sku" => extractAtPath returns false (all-or-nothing)
-	got := criterion(req, tape)
+	got := criterion.Score(req, tape)
 	if got != 0 {
-		t.Errorf("MatchBodyFuzzy() wildcard missing field = %d, want 0", got)
+		t.Errorf("BodyFuzzyCriterion.Score() wildcard missing field = %d, want 0", got)
 	}
 }
 
@@ -1650,9 +1650,9 @@ func TestExactMatcher_FullURLMatch(t *testing.T) {
 	matcher := ExactMatcher()
 
 	tests := []struct {
-		name      string
-		reqMethod string
-		reqPath   string
+		name       string
+		reqMethod  string
+		reqPath    string
 		tapeMethod string
 		tapeURL    string
 		wantMatch  bool
@@ -1792,6 +1792,47 @@ func TestServer_UsesDefaultMatcher(t *testing.T) {
 	}
 }
 
+// --- Criterion Name() tests ---
+
+func TestCriterionFunc_Name(t *testing.T) {
+	f := CriterionFunc(func(_ *http.Request, _ Tape) int { return 1 })
+	if got := f.Name(); got != "custom" {
+		t.Errorf("CriterionFunc.Name() = %q, want %q", got, "custom")
+	}
+}
+
+func TestCriterion_Names(t *testing.T) {
+	regexCriterion, err := NewPathRegexCriterion(`^/test$`)
+	if err != nil {
+		t.Fatalf("NewPathRegexCriterion() error = %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		c        Criterion
+		wantName string
+	}{
+		{"MethodCriterion", MethodCriterion{}, "method"},
+		{"PathCriterion", PathCriterion{}, "path"},
+		{"PathRegexCriterion", regexCriterion, "path_regex"},
+		{"RouteCriterion", RouteCriterion{Route: "test"}, "route"},
+		{"QueryParamsCriterion", QueryParamsCriterion{}, "query_params"},
+		{"HeadersCriterion", HeadersCriterion{Key: "X-Test", Value: "v"}, "headers"},
+		{"BodyHashCriterion", BodyHashCriterion{}, "body_hash"},
+		{"BodyFuzzyCriterion", NewBodyFuzzyCriterion("$.action"), "body_fuzzy"},
+		{"CriterionFunc", CriterionFunc(func(_ *http.Request, _ Tape) int { return 0 }), "custom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.c.Name()
+			if got != tt.wantName {
+				t.Errorf("%s.Name() = %q, want %q", tt.name, got, tt.wantName)
+			}
+		})
+	}
+}
+
 // --- Benchmarks ---
 
 // generateCandidates creates n candidate tapes. The matching tape for
@@ -1872,10 +1913,10 @@ func BenchmarkCompositeMatcher_Match(b *testing.B) {
 				matchIdx := n / 2
 				candidates := generateCandidates(n, matchIdx)
 				matcher := NewCompositeMatcher(
-					MatchMethod(),
-					MatchPath(),
-					MatchQueryParams(),
-					MatchBodyHash(),
+					MethodCriterion{},
+					PathCriterion{},
+					QueryParamsCriterion{},
+					BodyHashCriterion{},
 				)
 
 				body := []byte(`{"action":"find"}`)
@@ -1883,7 +1924,7 @@ func BenchmarkCompositeMatcher_Match(b *testing.B) {
 
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					// Reset request body for each iteration since MatchBodyHash reads it.
+					// Reset request body for each iteration since BodyHashCriterion reads it.
 					req.Body = io.NopCloser(bytes.NewReader(body))
 					tape, ok := matcher.Match(req, candidates)
 					if !ok {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -426,7 +426,7 @@ func TestProxy_RequestBodyPreservedForMatching(t *testing.T) {
 
 	proxy := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
-		WithProxyMatcher(NewCompositeMatcher(MatchMethod(), MatchPath(), MatchBodyHash())),
+		WithProxyMatcher(NewCompositeMatcher(MethodCriterion{}, PathCriterion{}, BodyHashCriterion{})),
 	)
 
 	req, _ := http.NewRequest("POST", "http://example.com/api/items", bytes.NewReader(postBody))


### PR DESCRIPTION
Closes #179

## Summary

Promotes the `MatchCriterion` function type to a `Criterion` interface with `Score()` and `Name()` methods, per ADR-38 in `decisions.md`. This is a pure structural refactor with no behavioral changes.

### ADR-38 resolved decisions reflected in this PR:

1. **Back-compat (Option B -- clean break)**: All `Match*()` constructor functions and the `MatchCriterion` function type are removed. Pre-1.0, no external consumers.
2. **`Name()` method on `Criterion` interface**: Each built-in criterion returns a stable lowercase underscore-separated identifier (`"method"`, `"path"`, `"path_regex"`, `"route"`, `"query_params"`, `"headers"`, `"body_hash"`, `"body_fuzzy"`). `CriterionFunc` returns `"custom"`.
3. **Field exposure**: Public fields for config-visible state. Constructors only for criteria needing validation (`NewPathRegexCriterion`) or pre-processing (`NewBodyFuzzyCriterion`). Zero-value structs for stateless criteria.
4. **`NewPathRegexCriterion` returns `(*PathRegexCriterion, error)`**: No panic on invalid regex -- value error, not a nil-dep guard.

### Files changed:

- `matcher.go` -- Primary target: `Criterion` interface, `CriterionFunc`, 8 struct implementations, updated `CompositeMatcher` and `DefaultMatcher`
- `matcher_test.go` -- Mechanical rename of all construction sites; added `TestCriterionFunc_Name` and `TestCriterion_Names`
- `proxy_test.go` -- Updated one `NewCompositeMatcher` call
- `doc.go` -- Updated type references from `MatchCriterion` to `Criterion`
- `docs/api-reference.md` -- Updated criterion table to reflect struct types
- `docs/matching.md` -- Updated examples and type references
- `CLAUDE.md` -- Updated package structure comment

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests updated + new Name() tests)
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] All 13 `TestMatchBodyFuzzy_VacuousTrue` sub-cases from PR #182 continue to pass
- [x] `TestMatchBodyFuzzy_VacuousTrueComposability` integration test passes
- [x] `TestCriterion_Names` verifies all 9 criterion Name() strings
- [x] No behavioral changes to any criterion scoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)