### PR TITLE
feat: declarative matcher composition via config file (#180)

### DIFF
--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -154,7 +154,7 @@ func runServe(args []string) error {
 	fixtures := fs.String("fixtures", "", "Path to fixture directory (required)")
 	port := fs.Int("port", 8081, "Listen port")
 	fallbackStatus := fs.Int("fallback-status", 404, "HTTP status when no tape matches")
-	_ = fs.String("config", "", "Path to sanitization config JSON (accepted but not used by serve)")
+	configPath := fs.String("config", "", "Path to httptape config JSON (matcher and sanitization rules)")
 	cors := fs.Bool("cors", false, "Enable CORS headers (Access-Control-Allow-Origin: *)")
 	delay := fs.Duration("delay", 0, "Fixed delay before every response (e.g., 200ms, 1s)")
 	errorRate := fs.Float64("error-rate", 0, "Fraction of requests that return 500 (0.0-1.0)")
@@ -178,6 +178,17 @@ func runServe(args []string) error {
 
 	var serverOpts []httptape.ServerOption
 	serverOpts = append(serverOpts, httptape.WithFallbackStatus(*fallbackStatus))
+	if *configPath != "" {
+		cfg, err := httptape.LoadConfigFile(*configPath)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		matcher, err := cfg.BuildMatcher()
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		serverOpts = append(serverOpts, httptape.WithMatcher(matcher))
+	}
 	if *sseTiming != "" {
 		mode, err := parseSSETiming(*sseTiming)
 		if err != nil {

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -468,6 +469,170 @@ func TestSSETimingFlagIntegration(t *testing.T) {
 				t.Errorf("run(%v) = %d, want %d", tt.args, got, tt.wantCode)
 			}
 		})
+	}
+}
+
+func TestServeWithConfigMatcher(t *testing.T) {
+	tmpDir := t.TempDir()
+	fixturesDir := filepath.Join(tmpDir, "fixtures")
+
+	// Create a fixtures directory with two tapes at the same POST path
+	// but different response bodies. We'll use body_fuzzy matching to
+	// distinguish them by $.action field.
+	store, err := httptape.NewFileStore(httptape.WithDirectory(fixturesDir))
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	ctx := context.Background()
+
+	tape1 := httptape.NewTape("test", httptape.RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/api/do",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    []byte(`{"action":"create","name":"widget"}`),
+	}, httptape.RecordedResp{
+		StatusCode: 201,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"result":"created"}`),
+	})
+	if err := store.Save(ctx, tape1); err != nil {
+		t.Fatalf("save tape1: %v", err)
+	}
+
+	tape2 := httptape.NewTape("test", httptape.RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/api/do",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    []byte(`{"action":"delete","name":"widget"}`),
+	}, httptape.RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"result":"deleted"}`),
+	})
+	if err := store.Save(ctx, tape2); err != nil {
+		t.Fatalf("save tape2: %v", err)
+	}
+
+	// Write a config file with body_fuzzy matching on $.action.
+	configPath := filepath.Join(tmpDir, "config.json")
+	configContent := `{
+		"version": "1",
+		"matcher": {
+			"criteria": [
+				{"type": "method"},
+				{"type": "path"},
+				{"type": "body_fuzzy", "paths": ["$.action"]}
+			]
+		},
+		"rules": []
+	}`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Find a free port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	// Start the server in a goroutine.
+	done := make(chan int, 1)
+	go func() {
+		done <- run([]string{
+			"serve",
+			"--fixtures", fixturesDir,
+			"--port", itoa(port),
+			"--config", configPath,
+		})
+	}()
+
+	base := "http://127.0.0.1:" + itoa(port)
+
+	// Wait for the server to start.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		resp, err := http.Get(base + "/healthz")
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server never came up: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Send POST with action=create, expect "created" response.
+	resp, err := http.Post(base+"/api/do", "application/json",
+		strings.NewReader(`{"action":"create","name":"something"}`))
+	if err != nil {
+		t.Fatalf("POST create: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 201 {
+		t.Errorf("create status = %d, want 201", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "created") {
+		t.Errorf("create body = %q, want to contain %q", string(body), "created")
+	}
+
+	// Send POST with action=delete, expect "deleted" response.
+	resp, err = http.Post(base+"/api/do", "application/json",
+		strings.NewReader(`{"action":"delete","name":"something"}`))
+	if err != nil {
+		t.Fatalf("POST delete: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("delete status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "deleted") {
+		t.Errorf("delete body = %q, want to contain %q", string(body), "deleted")
+	}
+
+	// Shutdown.
+	p, _ := os.FindProcess(os.Getpid())
+	_ = p.Signal(os.Interrupt)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CLI did not exit after SIGINT")
+	}
+}
+
+func TestServeWithInvalidConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	fixturesDir := filepath.Join(tmpDir, "fixtures")
+	if err := os.MkdirAll(fixturesDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "bad-config.json")
+	if err := os.WriteFile(configPath, []byte(`{"version":"1","rules":[],"matcher":{"criteria":[{"type":"bogus"}]}}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	got := run([]string{
+		"serve",
+		"--fixtures", fixturesDir,
+		"--config", configPath,
+	})
+	if got != exitRuntime {
+		t.Errorf("got exit %d, want %d (runtime error)", got, exitRuntime)
+	}
+}
+
+func TestServeNoConfig(t *testing.T) {
+	// serve with no --config flag should work fine (default behavior).
+	got := run([]string{"serve", "-h"})
+	if got != exitOK {
+		t.Errorf("got exit %d, want %d", got, exitOK)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -29,14 +29,36 @@ var validActions = map[string]struct{}{
 	ActionFake:          {},
 }
 
-// Config represents a declarative sanitization configuration.
+// Config represents a declarative configuration for httptape.
 // It can be loaded from JSON or constructed programmatically.
 //
 // The Version field must be "1". The Rules field contains an ordered list
 // of sanitization rules that map to the existing Pipeline / SanitizeFunc API.
+// The optional Matcher field declares which criteria the replay server's
+// CompositeMatcher uses to select recorded tapes.
 type Config struct {
-	Version string `json:"version"`
-	Rules   []Rule `json:"rules"`
+	Version string         `json:"version"`
+	Matcher *MatcherConfig `json:"matcher,omitempty"`
+	Rules   []Rule         `json:"rules"`
+}
+
+// MatcherConfig declares the composition of matching criteria for the replay
+// server. It maps to a CompositeMatcher constructed via Config.BuildMatcher.
+type MatcherConfig struct {
+	Criteria []CriterionConfig `json:"criteria"`
+}
+
+// CriterionConfig represents a single matching criterion in the declarative
+// config. The Type field is the discriminator (matches Criterion.Name()).
+// Type-specific fields are validated based on the Type value.
+//
+// Currently supported types:
+//   - "method":     matches on HTTP method (no type-specific fields)
+//   - "path":       matches on URL path (no type-specific fields)
+//   - "body_fuzzy": matches on specific JSON body fields (requires Paths)
+type CriterionConfig struct {
+	Type  string   `json:"type"`
+	Paths []string `json:"paths,omitempty"`
 }
 
 // Rule represents a single sanitization rule within a Config.
@@ -96,10 +118,12 @@ func LoadConfigFile(path string) (*Config, error) {
 //
 // Validation checks include:
 //   - Version must be "1"
-//   - Rules must be non-empty
+//   - Rules must be non-empty (unless a matcher is configured)
 //   - Each rule must have a known action
 //   - Action-specific required fields must be present
 //   - All paths must be valid JSONPath-like syntax
+//   - If a matcher is configured, each criterion type must be recognized
+//     and type-specific field requirements must be met
 func (c *Config) Validate() error {
 	var errs []string
 
@@ -107,7 +131,7 @@ func (c *Config) Validate() error {
 		errs = append(errs, fmt.Sprintf("unsupported version %q (expected %q)", c.Version, configVersion))
 	}
 
-	if len(c.Rules) == 0 {
+	if len(c.Rules) == 0 && c.Matcher == nil {
 		errs = append(errs, "rules must be a non-empty array")
 	}
 
@@ -177,10 +201,117 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Validate matcher config if present.
+	if c.Matcher != nil {
+		if len(c.Matcher.Criteria) == 0 {
+			errs = append(errs, "matcher.criteria must be a non-empty array")
+		}
+		for i, cc := range c.Matcher.Criteria {
+			prefix := fmt.Sprintf("matcher.criteria[%d]", i)
+
+			builder, ok := criterionBuilders[cc.Type]
+			if !ok {
+				errs = append(errs, fmt.Sprintf("%s: unknown type %q", prefix, cc.Type))
+				continue
+			}
+
+			// Use the builder's validate function for type-specific checks.
+			if vErr := builder.validate(cc); vErr != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", prefix, vErr))
+			}
+		}
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("config validation: %s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+// criterionBuilder holds a factory function and a validation function for
+// a single criterion type. The validate function performs shape checks
+// (type-specific field requirements). The build function constructs the
+// Criterion value.
+type criterionBuilder struct {
+	validate func(CriterionConfig) error
+	build    func(CriterionConfig) (Criterion, error)
+}
+
+// criterionBuilders maps criterion type names to their builder definitions.
+// Each entry corresponds to a supported Criterion.Name() value.
+var criterionBuilders = map[string]criterionBuilder{
+	"method":     {validate: validateMethodCriterion, build: buildMethodCriterion},
+	"path":       {validate: validatePathCriterion, build: buildPathCriterion},
+	"body_fuzzy": {validate: validateBodyFuzzyCriterion, build: buildBodyFuzzyCriterion},
+}
+
+func validateMethodCriterion(cc CriterionConfig) error {
+	if len(cc.Paths) > 0 {
+		return fmt.Errorf("%q does not use \"paths\"", cc.Type)
+	}
+	return nil
+}
+
+func buildMethodCriterion(_ CriterionConfig) (Criterion, error) {
+	return MethodCriterion{}, nil
+}
+
+func validatePathCriterion(cc CriterionConfig) error {
+	if len(cc.Paths) > 0 {
+		return fmt.Errorf("%q does not use \"paths\"", cc.Type)
+	}
+	return nil
+}
+
+func buildPathCriterion(_ CriterionConfig) (Criterion, error) {
+	return PathCriterion{}, nil
+}
+
+func validateBodyFuzzyCriterion(cc CriterionConfig) error {
+	if len(cc.Paths) == 0 {
+		return fmt.Errorf("%q requires non-empty \"paths\"", cc.Type)
+	}
+	for _, p := range cc.Paths {
+		if _, ok := parsePath(p); !ok {
+			return fmt.Errorf("%q invalid path syntax: %q", cc.Type, p)
+		}
+	}
+	return nil
+}
+
+func buildBodyFuzzyCriterion(cc CriterionConfig) (Criterion, error) {
+	return NewBodyFuzzyCriterion(cc.Paths...), nil
+}
+
+// BuildMatcher constructs a Matcher from the config's matcher declaration.
+// If no matcher is configured (Matcher field is nil or has no criteria),
+// it returns DefaultMatcher().
+//
+// BuildMatcher validates criterion types and their fields. It returns an
+// error if any criterion type is unknown or required fields are missing.
+//
+// BuildMatcher assumes the config has been validated via Validate(). However,
+// it performs its own materialization-time checks (e.g., for criteria that
+// require runtime validation beyond shape checks).
+func (c *Config) BuildMatcher() (Matcher, error) {
+	if c.Matcher == nil || len(c.Matcher.Criteria) == 0 {
+		return DefaultMatcher(), nil
+	}
+
+	criteria := make([]Criterion, 0, len(c.Matcher.Criteria))
+	for i, cc := range c.Matcher.Criteria {
+		builder, ok := criterionBuilders[cc.Type]
+		if !ok {
+			return nil, fmt.Errorf("matcher: criteria[%d]: unknown type %q", i, cc.Type)
+		}
+		criterion, err := builder.build(cc)
+		if err != nil {
+			return nil, fmt.Errorf("matcher: criteria[%d]: %w", i, err)
+		}
+		criteria = append(criteria, criterion)
+	}
+
+	return NewCompositeMatcher(criteria...), nil
 }
 
 // BuildPipeline converts the Config into a Pipeline by mapping each Rule

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/VibeWarden/httptape/config.schema.json",
-  "title": "httptape sanitization config",
-  "description": "Declarative configuration for httptape's sanitization pipeline. Maps to the Go API: RedactHeaders, RedactBodyPaths, FakeFields.",
+  "title": "httptape config",
+  "description": "Declarative configuration for httptape's sanitization pipeline and matcher composition. Maps to the Go API: RedactHeaders, RedactBodyPaths, FakeFields, CompositeMatcher.",
   "type": "object",
   "required": ["version", "rules"],
   "additionalProperties": false,
@@ -12,10 +12,66 @@
       "const": "1",
       "description": "Config schema version. Must be \"1\"."
     },
+    "matcher": {
+      "type": "object",
+      "description": "Optional matcher configuration for the replay server. Declares which criteria the CompositeMatcher uses to select recorded tapes.",
+      "required": ["criteria"],
+      "additionalProperties": false,
+      "properties": {
+        "criteria": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Ordered list of matching criteria. Each entry declares a criterion type and its type-specific fields.",
+          "items": {
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["method", "path", "body_fuzzy"],
+                "description": "Criterion type name. Must match a supported Criterion.Name() value."
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^\\$\\..+",
+                  "minLength": 3
+                },
+                "minItems": 1,
+                "description": "JSONPath-like paths for body_fuzzy criterion. Required when type is body_fuzzy."
+              }
+            },
+            "additionalProperties": false,
+            "allOf": [
+              {
+                "if": {
+                  "properties": { "type": { "const": "body_fuzzy" } },
+                  "required": ["type"]
+                },
+                "then": {
+                  "required": ["type", "paths"]
+                }
+              },
+              {
+                "if": {
+                  "properties": { "type": { "enum": ["method", "path"] } },
+                  "required": ["type"]
+                },
+                "then": {
+                  "properties": {
+                    "paths": false
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
     "rules": {
       "type": "array",
-      "minItems": 1,
-      "description": "Ordered list of sanitization rules. Applied sequentially to each recorded tape.",
+      "description": "Ordered list of sanitization rules. Applied sequentially to each recorded tape. May be empty when a matcher is configured.",
       "items": {
         "type": "object",
         "required": ["action"],

--- a/config_test.go
+++ b/config_test.go
@@ -581,6 +581,344 @@ func TestParseFakerSpec_DateDefaultFormat(t *testing.T) {
 	}
 }
 
+// ---------- Matcher config tests ----------
+
+func TestLoadConfig_MatcherValid(t *testing.T) {
+	input := `{
+		"version": "1",
+		"matcher": {
+			"criteria": [
+				{"type": "method"},
+				{"type": "path"},
+				{"type": "body_fuzzy", "paths": ["$.messages[*].role"]}
+			]
+		},
+		"rules": [
+			{"action": "redact_headers"}
+		]
+	}`
+
+	cfg, err := LoadConfig(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Matcher == nil {
+		t.Fatal("Matcher is nil, want non-nil")
+	}
+	if len(cfg.Matcher.Criteria) != 3 {
+		t.Fatalf("len(criteria) = %d, want 3", len(cfg.Matcher.Criteria))
+	}
+	if cfg.Matcher.Criteria[0].Type != "method" {
+		t.Errorf("criteria[0].type = %q, want %q", cfg.Matcher.Criteria[0].Type, "method")
+	}
+	if cfg.Matcher.Criteria[1].Type != "path" {
+		t.Errorf("criteria[1].type = %q, want %q", cfg.Matcher.Criteria[1].Type, "path")
+	}
+	if cfg.Matcher.Criteria[2].Type != "body_fuzzy" {
+		t.Errorf("criteria[2].type = %q, want %q", cfg.Matcher.Criteria[2].Type, "body_fuzzy")
+	}
+	if len(cfg.Matcher.Criteria[2].Paths) != 1 || cfg.Matcher.Criteria[2].Paths[0] != "$.messages[*].role" {
+		t.Errorf("criteria[2].paths = %v, want [$.messages[*].role]", cfg.Matcher.Criteria[2].Paths)
+	}
+}
+
+func TestLoadConfig_MatcherValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "unknown criterion type",
+			input:   `{"version":"1","matcher":{"criteria":[{"type":"bogus"}]},"rules":[{"action":"redact_headers"}]}`,
+			wantErr: `unknown type "bogus"`,
+		},
+		{
+			name:    "body_fuzzy missing paths",
+			input:   `{"version":"1","matcher":{"criteria":[{"type":"body_fuzzy"}]},"rules":[{"action":"redact_headers"}]}`,
+			wantErr: `"body_fuzzy" requires non-empty "paths"`,
+		},
+		{
+			name:    "method with paths",
+			input:   `{"version":"1","matcher":{"criteria":[{"type":"method","paths":["$.x"]}]},"rules":[{"action":"redact_headers"}]}`,
+			wantErr: `"method" does not use "paths"`,
+		},
+		{
+			name:    "path with paths",
+			input:   `{"version":"1","matcher":{"criteria":[{"type":"path","paths":["$.x"]}]},"rules":[{"action":"redact_headers"}]}`,
+			wantErr: `"path" does not use "paths"`,
+		},
+		{
+			name:    "body_fuzzy invalid path syntax",
+			input:   `{"version":"1","matcher":{"criteria":[{"type":"body_fuzzy","paths":["invalid"]}]},"rules":[{"action":"redact_headers"}]}`,
+			wantErr: `invalid path syntax: "invalid"`,
+		},
+		{
+			name:    "empty criteria array",
+			input:   `{"version":"1","matcher":{"criteria":[]},"rules":[{"action":"redact_headers"}]}`,
+			wantErr: "matcher.criteria must be a non-empty array",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadConfig(strings.NewReader(tt.input))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_EmptyRulesWithMatcher(t *testing.T) {
+	input := `{
+		"version": "1",
+		"matcher": {
+			"criteria": [
+				{"type": "method"},
+				{"type": "path"}
+			]
+		},
+		"rules": []
+	}`
+
+	cfg, err := LoadConfig(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Matcher == nil {
+		t.Fatal("Matcher is nil")
+	}
+	if len(cfg.Rules) != 0 {
+		t.Errorf("len(rules) = %d, want 0", len(cfg.Rules))
+	}
+}
+
+func TestLoadConfig_EmptyRulesNoMatcher(t *testing.T) {
+	input := `{"version": "1", "rules": []}`
+	_, err := LoadConfig(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("expected error for empty rules without matcher, got nil")
+	}
+	if !strings.Contains(err.Error(), "rules must be a non-empty array") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "rules must be a non-empty array")
+	}
+}
+
+func TestConfig_BuildMatcher_NoMatcher(t *testing.T) {
+	cfg := &Config{
+		Version: "1",
+		Rules:   []Rule{{Action: ActionRedactHeaders}},
+	}
+
+	matcher, err := cfg.BuildMatcher()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should return DefaultMatcher equivalent (CompositeMatcher with method + path).
+	cm, ok := matcher.(*CompositeMatcher)
+	if !ok {
+		t.Fatalf("expected *CompositeMatcher, got %T", matcher)
+	}
+	if len(cm.criteria) != 2 {
+		t.Fatalf("criteria count = %d, want 2", len(cm.criteria))
+	}
+	if cm.criteria[0].Name() != "method" {
+		t.Errorf("criteria[0].Name() = %q, want %q", cm.criteria[0].Name(), "method")
+	}
+	if cm.criteria[1].Name() != "path" {
+		t.Errorf("criteria[1].Name() = %q, want %q", cm.criteria[1].Name(), "path")
+	}
+}
+
+func TestConfig_BuildMatcher_Composed(t *testing.T) {
+	cfg := &Config{
+		Version: "1",
+		Matcher: &MatcherConfig{
+			Criteria: []CriterionConfig{
+				{Type: "method"},
+				{Type: "path"},
+				{Type: "body_fuzzy", Paths: []string{"$.messages[*].role", "$.model"}},
+			},
+		},
+		Rules: []Rule{},
+	}
+
+	matcher, err := cfg.BuildMatcher()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm, ok := matcher.(*CompositeMatcher)
+	if !ok {
+		t.Fatalf("expected *CompositeMatcher, got %T", matcher)
+	}
+	if len(cm.criteria) != 3 {
+		t.Fatalf("criteria count = %d, want 3", len(cm.criteria))
+	}
+
+	wantNames := []string{"method", "path", "body_fuzzy"}
+	for i, want := range wantNames {
+		if cm.criteria[i].Name() != want {
+			t.Errorf("criteria[%d].Name() = %q, want %q", i, cm.criteria[i].Name(), want)
+		}
+	}
+
+	// Verify body_fuzzy criterion has the correct paths.
+	bfc, ok := cm.criteria[2].(*BodyFuzzyCriterion)
+	if !ok {
+		t.Fatalf("expected *BodyFuzzyCriterion, got %T", cm.criteria[2])
+	}
+	if len(bfc.Paths) != 2 {
+		t.Fatalf("body_fuzzy paths count = %d, want 2", len(bfc.Paths))
+	}
+	if bfc.Paths[0] != "$.messages[*].role" {
+		t.Errorf("body_fuzzy paths[0] = %q, want %q", bfc.Paths[0], "$.messages[*].role")
+	}
+	if bfc.Paths[1] != "$.model" {
+		t.Errorf("body_fuzzy paths[1] = %q, want %q", bfc.Paths[1], "$.model")
+	}
+}
+
+func TestConfig_BuildMatcher_UnknownType(t *testing.T) {
+	cfg := &Config{
+		Version: "1",
+		Matcher: &MatcherConfig{
+			Criteria: []CriterionConfig{
+				{Type: "unknown_criterion"},
+			},
+		},
+		Rules: []Rule{},
+	}
+
+	_, err := cfg.BuildMatcher()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unknown type "unknown_criterion"`) {
+		t.Errorf("error = %q, want to contain %q", err.Error(), `unknown type "unknown_criterion"`)
+	}
+}
+
+func TestConfig_BuildMatcher_EmptyCriteria(t *testing.T) {
+	cfg := &Config{
+		Version: "1",
+		Matcher: &MatcherConfig{
+			Criteria: []CriterionConfig{},
+		},
+		Rules: []Rule{{Action: ActionRedactHeaders}},
+	}
+
+	// Empty criteria returns DefaultMatcher.
+	matcher, err := cfg.BuildMatcher()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm, ok := matcher.(*CompositeMatcher)
+	if !ok {
+		t.Fatalf("expected *CompositeMatcher, got %T", matcher)
+	}
+	if len(cm.criteria) != 2 {
+		t.Fatalf("criteria count = %d, want 2 (default)", len(cm.criteria))
+	}
+}
+
+func TestLoadConfig_BackwardCompat_SanitizationOnly(t *testing.T) {
+	// Existing sanitization-only configs (no matcher) continue to work.
+	input := `{
+		"version": "1",
+		"rules": [
+			{"action": "redact_headers", "headers": ["Authorization"]},
+			{"action": "redact_body", "paths": ["$.password"]},
+			{"action": "fake", "seed": "seed", "paths": ["$.email"]}
+		]
+	}`
+
+	cfg, err := LoadConfig(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Matcher != nil {
+		t.Error("Matcher should be nil for sanitization-only config")
+	}
+
+	// BuildMatcher returns default.
+	matcher, err := cfg.BuildMatcher()
+	if err != nil {
+		t.Fatalf("BuildMatcher error: %v", err)
+	}
+	cm, ok := matcher.(*CompositeMatcher)
+	if !ok {
+		t.Fatalf("expected *CompositeMatcher, got %T", matcher)
+	}
+	if len(cm.criteria) != 2 {
+		t.Errorf("criteria count = %d, want 2 (default)", len(cm.criteria))
+	}
+
+	// BuildPipeline still works.
+	pipeline := cfg.BuildPipeline()
+	if pipeline == nil {
+		t.Fatal("BuildPipeline returned nil")
+	}
+	if len(pipeline.funcs) != 3 {
+		t.Errorf("pipeline.funcs len = %d, want 3", len(pipeline.funcs))
+	}
+}
+
+func TestLoadConfig_MatcherWithRules(t *testing.T) {
+	// Config with both matcher and sanitization rules works correctly.
+	input := `{
+		"version": "1",
+		"matcher": {
+			"criteria": [
+				{"type": "method"},
+				{"type": "path"},
+				{"type": "body_fuzzy", "paths": ["$.action"]}
+			]
+		},
+		"rules": [
+			{"action": "redact_headers"}
+		]
+	}`
+
+	cfg, err := LoadConfig(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Matcher == nil {
+		t.Fatal("Matcher is nil")
+	}
+	if len(cfg.Rules) != 1 {
+		t.Errorf("len(rules) = %d, want 1", len(cfg.Rules))
+	}
+
+	// Both BuildMatcher and BuildPipeline work.
+	matcher, err := cfg.BuildMatcher()
+	if err != nil {
+		t.Fatalf("BuildMatcher error: %v", err)
+	}
+	cm, ok := matcher.(*CompositeMatcher)
+	if !ok {
+		t.Fatalf("expected *CompositeMatcher, got %T", matcher)
+	}
+	if len(cm.criteria) != 3 {
+		t.Errorf("criteria count = %d, want 3", len(cm.criteria))
+	}
+
+	pipeline := cfg.BuildPipeline()
+	if len(pipeline.funcs) != 1 {
+		t.Errorf("pipeline.funcs len = %d, want 1", len(pipeline.funcs))
+	}
+}
+
 // writeTestFile is a helper that writes content to the given path.
 func writeTestFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o644)

--- a/decisions.md
+++ b/decisions.md
@@ -9695,6 +9695,492 @@ All other criteria remain infallible at construction time:
 
 ---
 
+
+### ADR-39: Declarative matcher composition via JSON config
+
+**Date**: 2026-04-18
+**Issue**: #180
+**Status**: Accepted
+
+#### Context
+
+Container consumers (Java/Kotlin/TS demos that pull the published Docker image) cannot
+configure the httptape server's matcher beyond the hardcoded `DefaultMatcher()` (method +
+path only). The upcoming Kotlin + Ktor + Koog agent demo requires body-aware matching to
+distinguish multiple LLM calls to `POST /v1/chat/completions` that share the same method,
+path, and headers, differing only in the `messages` JSON body array.
+
+Per-criterion CLI flags (`--match-body-fuzzy`) were rejected by the PM because they do not
+compose and lead to flag explosion as more criteria are added. The `Config` struct in
+`config.go` already provides a versioned, JSON-Schema-validated declarative configuration
+surface for sanitization rules. The `--config` flag already exists on `httptape serve`
+(line 157 of `main.go`) but is currently unused by the serve command. Extending `Config`
+with an optional `matcher` field reuses all existing infrastructure: parsing, validation,
+schema, and loading.
+
+This ADR builds on ADR-38 (issue #179), which promoted `MatchCriterion` from a function
+type to a `Criterion` interface with `Score()` and `Name()` methods. The `Name()` method
+on each criterion struct provides the registry key for config-driven dispatch.
+
+#### Decision
+
+##### Config struct extension
+
+Add an optional top-level `Matcher` field to `Config`:
+
+```go
+// Config represents a declarative configuration for httptape.
+// It can be loaded from JSON or constructed programmatically.
+type Config struct {
+    Version string         `json:"version"`
+    Matcher *MatcherConfig `json:"matcher,omitempty"`
+    Rules   []Rule         `json:"rules"`
+}
+```
+
+The field is a pointer to `MatcherConfig` (not a value) so that `omitempty` works correctly
+and `nil` vs zero-value is distinguishable. When `Matcher` is nil (field absent from JSON),
+`BuildMatcher()` returns `DefaultMatcher()` -- no behavior change.
+
+`Rules` remains required per the existing schema (`"required": ["version", "rules"]`).
+However, `Validate()` must be updated to allow empty `Rules` when `Matcher` is present,
+since a config file used purely for matcher composition (no sanitization) should be valid.
+This is a relaxation: config files that only declare `matcher` and have `"rules": []` become
+valid, while the existing behavior (rules-only configs) is unchanged.
+
+**Correction on Rules requirement**: On further consideration, the simplest backward-
+compatible approach is to keep `rules` required in the JSON schema (callers must pass
+`"rules": []` at minimum) but relax the Go-side validation to allow an empty rules array
+when a matcher is configured. This avoids changing the JSON schema's `required` array and
+minimizes blast radius. Config files that only need matcher composition write `"rules": []`
+explicitly -- a minor inconvenience that keeps the schema stable.
+
+##### MatcherConfig type
+
+```go
+// MatcherConfig declares the composition of matching criteria for the replay server.
+// It maps to a CompositeMatcher constructed via BuildMatcher.
+type MatcherConfig struct {
+    Criteria []CriterionConfig `json:"criteria"`
+}
+```
+
+##### CriterionConfig type
+
+A single struct with a `Type` discriminator and all possible type-specific fields.
+Only the fields relevant to the given type are populated; irrelevant fields are
+validated as absent.
+
+```go
+// CriterionConfig represents a single matching criterion in the declarative config.
+// The Type field is the discriminator (matches Criterion.Name()).
+// Type-specific fields are validated based on the Type value.
+type CriterionConfig struct {
+    Type  string   `json:"type"`
+    Paths []string `json:"paths,omitempty"`
+}
+```
+
+**Rationale for single-struct approach**: The three deserialization options were:
+
+1. **Single struct with all possible fields, only relevant ones populated per type**
+   (chosen). Cheap, simple, Go-idiomatic for a small number of type-specific fields.
+   Validation enforces that irrelevant fields are not set. Adding a new criterion type
+   that needs a new field means adding one field to `CriterionConfig` and one validation
+   case -- a two-line change plus validation logic.
+
+2. **Type-specific struct per criterion type with custom UnmarshalJSON**. More idiomatic
+   in languages with sum types, but in Go this requires either a wrapper struct with
+   `json.RawMessage` and a manual dispatch, or a custom `UnmarshalJSON` on the slice.
+   The code volume is significantly higher for the same result, and it creates N types
+   instead of 1.
+
+3. **`map[string]any` for type-specific fields**. Flexible but completely untyped at
+   the Go level. Every field access requires type assertions. Validation becomes manual
+   and error-prone. This is what `Rule.Fields` uses for faker specs (because faker
+   specs have high type diversity with 12+ types), but criterion configs have only 1
+   type-specific field today (`paths`), making the cost/benefit of `map[string]any`
+   unfavorable.
+
+The single-struct approach is consistent with how `Rule` works in the existing config:
+one struct with all possible fields, validated per `action` type. As the criterion
+type count grows (future: `pattern` for `path_regex`, `key`/`value` for `headers`,
+`route` for `route`), the struct gains one field each. If the field count ever becomes
+unwieldy (unlikely -- criteria have at most 1-2 config fields each), a refactor to
+option 2 can be done without changing the JSON schema.
+
+##### Initial criterion types supported (scope of #180)
+
+| `type` value | `Name()` match | Type-specific fields | Constructor call |
+|---|---|---|---|
+| `"method"` | `MethodCriterion.Name()` = `"method"` | none | `MethodCriterion{}` |
+| `"path"` | `PathCriterion.Name()` = `"path"` | none | `PathCriterion{}` |
+| `"body_fuzzy"` | `BodyFuzzyCriterion.Name()` = `"body_fuzzy"` | `paths` (required, non-empty) | `NewBodyFuzzyCriterion(paths...)` |
+
+Out of scope for this issue: `path_regex`, `route`, `headers`, `query_params`,
+`body_hash`. These can be added as follow-up issues by extending the dispatch
+table and adding validation for their type-specific fields.
+
+##### Factory function: BuildMatcher
+
+```go
+// BuildMatcher constructs a Matcher from the config's matcher declaration.
+// If no matcher is configured (Matcher field is nil or has no criteria),
+// it returns DefaultMatcher().
+//
+// BuildMatcher validates criterion types and their fields. It returns an error
+// if any criterion type is unknown or required fields are missing/invalid.
+//
+// BuildMatcher assumes the config has been validated via Validate(). However,
+// it performs its own materialization-time checks (e.g., for criteria that
+// require runtime validation beyond shape checks).
+func (c *Config) BuildMatcher() (Matcher, error)
+```
+
+The function constructs a `*CompositeMatcher` from the parsed criteria. It uses a
+dispatch table keyed on the `Type` string:
+
+```go
+// criterionBuilders maps criterion type names to factory functions.
+// Each factory validates type-specific fields and returns the constructed Criterion.
+var criterionBuilders = map[string]func(CriterionConfig) (Criterion, error){
+    "method":     buildMethodCriterion,
+    "path":       buildPathCriterion,
+    "body_fuzzy": buildBodyFuzzyCriterion,
+}
+```
+
+Each builder function validates that only relevant fields are set and required fields
+are present, then constructs the appropriate `Criterion` struct.
+
+Error cases handled by `BuildMatcher`:
+- Unknown criterion type: `fmt.Errorf("matcher: criteria[%d]: unknown type %q", i, cc.Type)`
+- Missing required field: `fmt.Errorf("matcher: criteria[%d]: %q requires non-empty \"paths\"", i, cc.Type)`
+- Irrelevant field set: `fmt.Errorf("matcher: criteria[%d]: %q does not use \"paths\"", i, cc.Type)`
+- Empty criteria array: returns `DefaultMatcher(), nil` (no error, falls back to default)
+
+##### Config.Validate extension
+
+`Validate()` gains matcher validation alongside the existing rule validation:
+
+1. If `c.Matcher` is nil, skip matcher validation (backward compatible).
+2. If `c.Matcher` is non-nil, validate `c.Matcher.Criteria`:
+   - If `Criteria` is empty, produce an error: `"matcher.criteria must be a non-empty array"`.
+   - For each criterion config entry, validate:
+     - `Type` is a recognized value (from `criterionBuilders` keys or a parallel `validCriterionTypes` set).
+     - Type-specific field requirements (e.g., `body_fuzzy` requires non-empty `paths`).
+     - Irrelevant fields are not set (e.g., `method` with `paths` produces an error).
+     - All paths in `paths` are valid JSONPath-like syntax (reuse `parsePath`).
+3. If `c.Matcher` is non-nil, relax the "rules must be non-empty" check: a config
+   with a matcher but empty rules is valid (config used purely for matcher composition).
+   The existing check `if len(c.Rules) == 0` is refined to
+   `if len(c.Rules) == 0 && c.Matcher == nil`.
+
+Validation errors from matcher config are accumulated into the same `errs` slice as
+rule validation errors, following the existing pattern of collecting all errors before
+returning.
+
+The split between `Validate()` and `BuildMatcher()` is intentional:
+- `Validate()` performs shape checks (type recognized, required fields present,
+  irrelevant fields absent, path syntax valid).
+- `BuildMatcher()` performs materialization checks (currently none beyond what
+  `Validate()` covers, but future criteria like `path_regex` would compile the regex
+  here and return a compile error).
+
+##### JSON Schema extension (config.schema.json)
+
+The schema gains a `matcher` property at the top level. The `additionalProperties: false`
+constraint on the root object means we must add `matcher` to the properties map.
+
+```json
+{
+  "matcher": {
+    "type": "object",
+    "description": "Optional matcher configuration for the replay server. Declares which criteria the CompositeMatcher uses to select recorded tapes.",
+    "required": ["criteria"],
+    "additionalProperties": false,
+    "properties": {
+      "criteria": {
+        "type": "array",
+        "minItems": 1,
+        "description": "Ordered list of matching criteria. Each entry declares a criterion type and its type-specific fields.",
+        "items": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["method", "path", "body_fuzzy"],
+              "description": "Criterion type name. Must match a supported Criterion.Name() value."
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^\\$\\..+",
+                "minLength": 3
+              },
+              "minItems": 1,
+              "description": "JSONPath-like paths for body_fuzzy criterion. Required when type is body_fuzzy."
+            }
+          },
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": { "type": { "const": "body_fuzzy" } },
+                "required": ["type"]
+              },
+              "then": {
+                "required": ["type", "paths"]
+              }
+            },
+            {
+              "if": {
+                "properties": { "type": { "enum": ["method", "path"] } },
+                "required": ["type"]
+              },
+              "then": {
+                "properties": {
+                  "paths": false
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+The `if/then` constructs enforce:
+- `body_fuzzy` requires `paths`.
+- `method` and `path` reject `paths`.
+
+This approach uses `allOf` with `if/then` rather than `oneOf` because the criterion items
+share most of their shape (only `paths` varies), making `oneOf` with three separate sub-schemas
+unnecessarily repetitive. The `if/then` approach is cleaner and extends naturally as new
+criterion types are added.
+
+Additionally, the `rules` field's `minItems: 1` constraint must be removed from the
+JSON schema, since rules can now be empty when a matcher is configured. This aligns
+with the Go-side relaxation of the empty-rules validation.
+
+##### CLI integration in cmd/httptape/main.go
+
+`runServe` changes:
+
+1. **Replace the dead `--config` flag** (currently `_ = fs.String("config", ...)`)
+   with a live variable: `configPath := fs.String("config", "", "Path to httptape config JSON (matcher and sanitization rules)")`.
+
+2. **After flag parsing**, if `*configPath != ""`:
+   a. Load the config: `cfg, err := httptape.LoadConfigFile(*configPath)`.
+   b. Build the matcher: `matcher, err := cfg.BuildMatcher()`.
+   c. Append to server options: `serverOpts = append(serverOpts, httptape.WithMatcher(matcher))`.
+   d. If `cfg.Rules` is non-empty, build the sanitization pipeline too (future-proofing
+      for when serve mode supports sanitization, though currently serve mode does not
+      sanitize). For now, the rules are simply ignored by serve mode -- the config is
+      loaded and validated, but only the matcher portion is consumed.
+
+3. **Remove the TODO comment** ("accepted but not used by serve").
+
+4. **Update `--help` text**: The flag description changes from `"Path to sanitization
+   config JSON (accepted but not used by serve)"` to `"Path to httptape config JSON
+   (matcher and sanitization rules)"`.
+
+5. **Error handling**: Config loading errors and `BuildMatcher` errors are returned
+   as `fmt.Errorf("load config: %w", err)` (consistent with the `runRecord` pattern).
+
+##### Backward compatibility
+
+- **Existing config files** (sanitization-only, no `matcher` field) continue to work
+  unchanged. The `matcher` field is optional (`omitempty` on the Go struct, not in
+  `required` in the JSON schema). `BuildMatcher()` on a config with no matcher returns
+  `DefaultMatcher()`.
+
+- **Existing `serve` invocations** without `--config` are completely unchanged.
+  `DefaultMatcher()` is still the default.
+
+- **`LoadConfig` with `DisallowUnknownFields`**: The existing decoder uses
+  `dec.DisallowUnknownFields()`. Adding the `Matcher` field to `Config` means JSON
+  files containing `"matcher": {...}` will now decode successfully instead of failing
+  with "unknown field". This is the desired behavior. Files without `"matcher"` continue
+  to decode with `Matcher` as `nil`.
+
+- **Record and proxy modes**: these modes already consume `--config` for sanitization
+  only. Adding `Matcher` to `Config` does not break them. `BuildMatcher()` returns
+  `DefaultMatcher()` when matcher config is absent. Record/proxy modes do not call
+  `BuildMatcher()` -- they only call `BuildPipeline()`. No changes to `runRecord` or
+  `runProxy` in this issue.
+
+#### Types
+
+| Type | File | Description |
+|---|---|---|
+| `MatcherConfig` | `config.go` | Declares matcher criteria composition. Contains `Criteria []CriterionConfig`. |
+| `CriterionConfig` | `config.go` | Single criterion declaration with `Type` discriminator and type-specific fields (`Paths`). |
+
+Modified type:
+
+| Type | File | Change |
+|---|---|---|
+| `Config` | `config.go` | New optional field `Matcher *MatcherConfig` |
+
+#### Functions and methods
+
+| Function / Method | Signature | File | Notes |
+|---|---|---|---|
+| `Config.BuildMatcher` | `func (c *Config) BuildMatcher() (Matcher, error)` | `config.go` | New. Constructs `*CompositeMatcher` from config. Returns `DefaultMatcher()` when no matcher configured. |
+| `Config.Validate` | `func (c *Config) Validate() error` | `config.go` | Modified. Adds matcher config validation. Relaxes empty-rules check when matcher is present. |
+
+No new exported package-level functions. The `criterionBuilders` dispatch table and
+individual builder functions (`buildMethodCriterion`, `buildPathCriterion`,
+`buildBodyFuzzyCriterion`) are unexported.
+
+#### File layout
+
+| File | Changes |
+|---|---|
+| `config.go` | Add `MatcherConfig` and `CriterionConfig` types. Add `Matcher *MatcherConfig` field to `Config`. Add `BuildMatcher()` method. Extend `Validate()` with matcher validation. Add `criterionBuilders` dispatch table and builder functions. |
+| `config_test.go` | Add tests for: config with no matcher (backward compat), config with valid matcher, config with unknown criterion type, config with `body_fuzzy` missing `paths`, config with `method` having spurious `paths`, config with empty criteria array, `BuildMatcher` returning `DefaultMatcher` for nil matcher, `BuildMatcher` constructing correct `CompositeMatcher`. |
+| `config.schema.json` | Add `matcher` property with `criteria` array schema. Remove `minItems: 1` from `rules`. Add `if/then` constraints for per-type field validation. |
+| `cmd/httptape/main.go` | Wire `--config` in `runServe`: load config, call `BuildMatcher()`, pass `WithMatcher(matcher)` to `NewServer`. Update flag description. Remove TODO comment. |
+| `cmd/httptape/main_test.go` | Add test: serve with `--config` providing matcher config (write temp config file, verify exit code). Add test: serve with `--config` pointing to invalid config (verify exit code = `exitRuntime`). |
+
+No new files. No changes to `matcher.go`, `server.go`, or any other existing files.
+
+#### Sequence
+
+Request/response flow when `--config` is provided to `httptape serve`:
+
+1. CLI parses `--config <path>` and `--fixtures <dir>`.
+2. `httptape.LoadConfigFile(path)` reads and parses the JSON. `DisallowUnknownFields` ensures no typos. `Validate()` checks version, rules (relaxed for empty when matcher present), and matcher criteria (type recognized, fields valid).
+3. `cfg.BuildMatcher()` iterates `cfg.Matcher.Criteria`, dispatches each to its builder function via `criterionBuilders`, collects `[]Criterion`, returns `NewCompositeMatcher(criteria...)`. If `cfg.Matcher` is nil, returns `DefaultMatcher()`.
+4. `serverOpts = append(serverOpts, httptape.WithMatcher(matcher))`.
+5. `httptape.NewServer(store, serverOpts...)` creates the server with the custom matcher.
+6. Server starts listening. Incoming requests are matched via the `CompositeMatcher` constructed from config.
+
+Request matching at runtime (unchanged from existing `CompositeMatcher` behavior):
+
+1. `Server.ServeHTTP` calls `s.matcher.Match(req, candidates)`.
+2. `CompositeMatcher.Match` iterates candidates, scores each against all criteria.
+3. If any criterion returns 0 for a candidate, that candidate is eliminated.
+4. Highest-scoring surviving candidate is returned.
+
+#### Error cases
+
+| Error | Where | Handling |
+|---|---|---|
+| Config file not found / unreadable | `LoadConfigFile` | Returns `fmt.Errorf("config: open file: %w", err)`. CLI exits with `exitRuntime`. |
+| Malformed JSON | `LoadConfig` | Returns `fmt.Errorf("config: invalid JSON: %w", err)`. |
+| Unknown field in JSON | `LoadConfig` (via `DisallowUnknownFields`) | Returns `fmt.Errorf("config: invalid JSON: %w", err)`. |
+| Unknown criterion type | `Validate` | Error: `"matcher.criteria[N]: unknown type \"foo\""`. |
+| Missing required field (`body_fuzzy` without `paths`) | `Validate` | Error: `"matcher.criteria[N]: \"body_fuzzy\" requires non-empty \"paths\""`. |
+| Irrelevant field set (`method` with `paths`) | `Validate` | Error: `"matcher.criteria[N]: \"method\" does not use \"paths\""`. |
+| Invalid path syntax in `paths` | `Validate` | Error: `"matcher.criteria[N]: \"body_fuzzy\" invalid path syntax: \"bad\""`. |
+| Empty criteria array | `Validate` | Error: `"matcher.criteria must be a non-empty array"`. |
+| BuildMatcher on nil matcher | `BuildMatcher` | Returns `DefaultMatcher(), nil` (not an error). |
+
+All errors from `Validate` are accumulated into a single error message (existing pattern).
+`BuildMatcher` returns the first error encountered (since it performs materialization, not
+shape validation). In practice, if `Validate` passes, `BuildMatcher` should not fail for
+the three criterion types in scope (no materialization-time validation needed). Future
+types like `path_regex` would have `BuildMatcher` return regex compilation errors.
+
+#### Test strategy
+
+All tests use stdlib `testing` only. Table-driven where appropriate.
+
+**`config_test.go` -- new tests:**
+
+1. **`TestLoadConfig_WithMatcher`**: Valid config with matcher + rules. Verify `Config.Matcher` is non-nil, `Criteria` has correct length and types.
+
+2. **`TestLoadConfig_MatcherOnly`**: Config with matcher and empty rules (`"rules": []`). Verify validation passes. This confirms the relaxation of the empty-rules check.
+
+3. **`TestLoadConfig_NoMatcher`**: Existing config without `matcher` field. Verify backward compatibility: `Config.Matcher` is nil, validation passes, `BuildMatcher()` returns a matcher equivalent to `DefaultMatcher()`.
+
+4. **`TestLoadConfig_MatcherValidationErrors`**: Table-driven with cases:
+   - Unknown criterion type -> error contains `"unknown type"`
+   - `body_fuzzy` missing `paths` -> error contains `"requires non-empty \"paths\""`
+   - `body_fuzzy` with empty `paths` array -> error contains `"requires non-empty \"paths\""`
+   - `body_fuzzy` with invalid path syntax -> error contains `"invalid path syntax"`
+   - `method` with spurious `paths` -> error contains `"does not use \"paths\""`
+   - `path` with spurious `paths` -> error contains `"does not use \"paths\""`
+   - Empty criteria array -> error contains `"must be a non-empty array"`
+   - Missing `type` field -> error contains `"unknown type"` (empty string is unknown)
+
+5. **`TestConfig_BuildMatcher_Default`**: `BuildMatcher()` on config with nil matcher returns a valid `Matcher` (not nil). Verify it matches on method + path (same as `DefaultMatcher`).
+
+6. **`TestConfig_BuildMatcher_Composed`**: Config with `method` + `path` + `body_fuzzy` criteria. Build matcher, test against two tapes with same method/path but different bodies. Verify correct tape is selected.
+
+7. **`TestConfig_BuildMatcher_UnknownType`**: `BuildMatcher()` on config with unknown criterion type (that somehow bypassed validation) returns an error. This tests `BuildMatcher`'s own error handling.
+
+**`cmd/httptape/main_test.go` -- new tests:**
+
+8. **`TestServeWithConfig`**: Write a temp config file with matcher config, invoke `run([]string{"serve", "--fixtures", tmpDir, "--config", configPath, "-h"})`, verify exit code is `exitOK`. This verifies the wiring works without actually starting a server.
+
+9. **`TestServeWithInvalidConfig`**: Write a temp config file with invalid JSON, invoke `run(...)`, verify exit code is `exitRuntime`.
+
+**Integration test (in `config_test.go` or `integration_test.go`):**
+
+10. **`TestBuildMatcher_Integration`**: Create two tapes with the same method and path but different JSON bodies. Build a matcher from config with `method` + `path` + `body_fuzzy`. Construct HTTP requests matching each body. Verify the correct tape is returned for each request. This does not start an HTTP server -- it tests `BuildMatcher` output directly against `Match()`.
+
+#### Alternatives considered
+
+1. **Per-criterion CLI flags (`--match-body-fuzzy`)**: Rejected by PM. Does not compose.
+   Each new criterion type would require a new flag with its own semantics. The existing
+   `Config` JSON infrastructure already solves the composition problem.
+
+2. **CriterionConfig with `json.RawMessage` and per-type structs**: More idiomatic for
+   highly polymorphic types, but overkill when there is only one type-specific field
+   (`paths`) across all three initial criterion types. Would require custom
+   `UnmarshalJSON` on the criteria slice and 3+ additional types. The single-struct
+   approach with per-type validation is simpler and equally correct.
+
+3. **CriterionConfig with `map[string]any` for type-specific fields**: Maximum
+   flexibility but zero type safety at the Go level. Every field access requires type
+   assertions. This pattern is used for `Rule.Fields` (faker specs) because there are
+   12+ faker types with diverse field shapes. For criteria (1 optional field today),
+   the overhead of `map[string]any` is not justified.
+
+4. **Named matcher presets (e.g., `"matcher": "body-aware"`)**: Rejected. Too opinionated.
+   The criteria-array approach is composable and gives users full control. Presets could
+   be added as sugar later without changing the underlying mechanism.
+
+#### Consequences
+
+**Benefits:**
+- Container consumers can now configure matcher composition via a JSON config file
+  mounted into the Docker container, without any Go code changes.
+- The `--config` flag on `httptape serve` is no longer a dead flag. It controls both
+  sanitization rules and matcher composition from a single file.
+- Adding new criterion types to the config is a small, well-defined change: add one
+  entry to the `criterionBuilders` dispatch table, one validation case in `Validate()`,
+  and one `enum` value in the JSON schema. This is a two-minute change per criterion type.
+- Criterion types not yet exposed via config (e.g., `path_regex`, `headers`) continue
+  to work in Go code via direct struct construction. The config surface is additive.
+
+**Costs / trade-offs:**
+- The `CriterionConfig` struct will accumulate fields as more criterion types are
+  exposed. This is manageable -- criteria have at most 1-2 config fields each.
+- Config files that only need matcher composition must still include `"rules": []`
+  because `rules` remains a required field in the JSON schema. This is a minor DX
+  inconvenience that preserves backward compatibility.
+- `Validate()` grows more complex with the matcher validation branch. The existing
+  pattern of collecting all errors into `errs []string` scales well.
+
+**Future implications:**
+- Follow-up issues can expose `path_regex` (adds `pattern` field to `CriterionConfig`),
+  `headers` (adds `key`/`value` fields), `route` (adds `route` field), `query_params`
+  (no additional fields), and `body_hash` (no additional fields) by extending the
+  dispatch table and validation logic.
+- If `Config` eventually needs to support record-mode or proxy-mode specific settings,
+  additional optional top-level fields can be added following the same `omitempty`
+  pointer pattern used by `Matcher`.
+
+---
+
 ## PM Log
 
 ### 2026-04-16

--- a/integration_test.go
+++ b/integration_test.go
@@ -803,3 +803,104 @@ func TestIntegration_SSE_Proxy_E2E(t *testing.T) {
 		t.Errorf("fallback should contain cached events, got: %q", string(fallbackBody))
 	}
 }
+
+// TestIntegration_ConfigDrivenMatcher_BodyFuzzy tests the full config-driven
+// matcher flow: two fixtures at POST /v1/chat/completions are distinguished
+// by body content using a body_fuzzy criterion loaded from a Config.
+// This is end-to-end validation for the Kotlin/Koog demo use case.
+func TestIntegration_ConfigDrivenMatcher_BodyFuzzy(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := t.Context()
+
+	// Tape 1: single user message.
+	tape1 := NewTape("chat", RecordedReq{
+		Method:  "POST",
+		URL:     "https://api.openai.com/v1/chat/completions",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`),
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"id":"resp-1","choices":[{"message":{"role":"assistant","content":"Hi there!"}}]}`),
+	})
+	if err := store.Save(ctx, tape1); err != nil {
+		t.Fatalf("save tape1: %v", err)
+	}
+
+	// Tape 2: multi-turn conversation with tool call.
+	tape2 := NewTape("chat", RecordedReq{
+		Method:  "POST",
+		URL:     "https://api.openai.com/v1/chat/completions",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"search"},{"role":"assistant","content":"searching..."},{"role":"tool","content":"results"}]}`),
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"id":"resp-2","choices":[{"message":{"role":"assistant","content":"Found results."}}]}`),
+	})
+	if err := store.Save(ctx, tape2); err != nil {
+		t.Fatalf("save tape2: %v", err)
+	}
+
+	// Build matcher from config using method + path + body_fuzzy.
+	cfg := &Config{
+		Version: "1",
+		Matcher: &MatcherConfig{
+			Criteria: []CriterionConfig{
+				{Type: "method"},
+				{Type: "path"},
+				{Type: "body_fuzzy", Paths: []string{"$.messages[*].role"}},
+			},
+		},
+		Rules: []Rule{},
+	}
+
+	matcher, err := cfg.BuildMatcher()
+	if err != nil {
+		t.Fatalf("BuildMatcher: %v", err)
+	}
+
+	// Start server with the config-driven matcher.
+	srv := NewServer(store, WithMatcher(matcher))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Request 1: single user message — should match tape1.
+	req1Body := `{"model":"gpt-4","messages":[{"role":"user","content":"different content"}]}`
+	resp1, err := http.Post(ts.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(req1Body))
+	if err != nil {
+		t.Fatalf("POST request 1: %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != 200 {
+		t.Errorf("request 1 status = %d, want 200", resp1.StatusCode)
+	}
+	if !strings.Contains(string(body1), "resp-1") {
+		t.Errorf("request 1 body = %q, want to contain %q", string(body1), "resp-1")
+	}
+
+	// Request 2: multi-turn with tool — should match tape2.
+	req2Body := `{"model":"gpt-4","messages":[{"role":"user","content":"other query"},{"role":"assistant","content":"thinking..."},{"role":"tool","content":"other results"}]}`
+	resp2, err := http.Post(ts.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(req2Body))
+	if err != nil {
+		t.Fatalf("POST request 2: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != 200 {
+		t.Errorf("request 2 status = %d, want 200", resp2.StatusCode)
+	}
+	if !strings.Contains(string(body2), "resp-2") {
+		t.Errorf("request 2 body = %q, want to contain %q", string(body2), "resp-2")
+	}
+
+	// Verify they got different responses (not both hitting the same tape).
+	if string(body1) == string(body2) {
+		t.Error("both requests returned the same response; body_fuzzy matching did not distinguish them")
+	}
+}


### PR DESCRIPTION
Closes #180

## Summary

Implements ADR-39: declarative matcher composition via JSON config file. This enables container consumers (Java/Kotlin/TS demos) to configure the httptape replay server's matching strategy without code changes, by extending the existing `Config` struct with an optional `matcher` field.

### Key design decisions (per ADR-39)

1. **Single `CriterionConfig` struct with type discriminator** -- mirrors the existing `Rule` pattern. `Type` field dispatches to the right criterion constructor. Only `Paths` is needed as a type-specific field (for `body_fuzzy`).

2. **`criterionBuilders` dispatch table** -- maps criterion type names to validate/build function pairs. Extensible for future criterion types without changing the dispatch logic.

3. **Scope limited to `method`, `path`, `body_fuzzy`** -- other types (`path_regex`, `route`, `headers`, `query_params`, `body_hash`) are follow-up issues per architect decision.

4. **`rules` field relaxed** -- `"rules": []` is now valid when a matcher is configured. Existing sanitization-only configs continue to work unchanged.

### Changes

- **`config.go`**: Added `MatcherConfig`, `CriterionConfig` types. Added `Matcher *MatcherConfig` field to `Config`. Added `BuildMatcher()` method with `criterionBuilders` dispatch table. Extended `Validate()` with matcher validation. Relaxed empty-rules check.
- **`config.schema.json`**: Added `matcher` property with `criteria` array schema. Added `if/then` constraints for per-type field validation. Removed `minItems: 1` from `rules`.
- **`cmd/httptape/main.go`**: Wired `--config` flag in `runServe` to load config and build matcher via `WithMatcher()`. Updated flag description. Removed dead TODO comment.
- **`config_test.go`**: 12 new tests covering matcher config loading, validation errors, `BuildMatcher` default/composed/error cases, backward compatibility.
- **`cmd/httptape/main_test.go`**: 3 new tests covering serve with valid matcher config (integration), invalid config, and no config.
- **`integration_test.go`**: End-to-end test with two `POST /v1/chat/completions` fixtures distinguished by `$.messages[*].role` via body_fuzzy criterion loaded from config.
- **`decisions.md`**: ADR-39 added.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [x] Config with no matcher field returns `DefaultMatcher()` (backward compat)
- [x] Config with `method + path + body_fuzzy` composes correct `*CompositeMatcher`
- [x] Unknown criterion type rejected by `Validate()`
- [x] `body_fuzzy` without `paths` rejected
- [x] `method` with `paths` rejected
- [x] Empty `rules` with matcher succeeds; empty `rules` without matcher still fails
- [x] CLI `serve --config` loads matcher and distinguishes body-fuzzy fixtures
- [x] CLI `serve --config` with invalid config exits with error
- [x] Integration test: two POST fixtures at same URL distinguished by body content

🤖 Generated with [Claude Code](https://claude.com/claude-code)