### PR TITLE
feat(#187): Content-Type-driven body shape + ContentNegotiationCriterion + migrate-fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to httptape are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.12.0] - 2026-04-18
+
+### Breaking Changes
+
+- **Content-Type-driven body shape**: The `body` field in fixture JSON now uses
+  Content-Type-aware serialization. JSON bodies (`application/json`, `+json` suffix)
+  are stored as native JSON objects/arrays. Text bodies (`text/*`, `application/xml`)
+  are stored as JSON strings. Binary bodies are stored as base64-encoded strings.
+  Previously, all bodies used Go's default `[]byte` JSON encoding (base64).
+- **Removed `BodyEncoding` type**: The `BodyEncoding` type, `BodyEncodingIdentity`
+  and `BodyEncodingBase64` constants, and `body_encoding` field on `RecordedReq`
+  and `RecordedResp` have been removed. The body encoding is now determined
+  automatically from the Content-Type header.
+- **Custom JSON marshaling**: `RecordedReq` and `RecordedResp` now implement
+  `json.Marshaler` and `json.Unmarshaler` for Content-Type-aware body serialization.
+  The `Body` field's JSON struct tag is now `json:"-"` (excluded from default marshaling).
+
+### Added
+
+- `media_type.go`: New `MediaType` struct and utilities (`ParseMediaType`,
+  `ParseAccept`, `IsJSON`, `IsText`, `IsBinary`, `MatchesMediaRange`, `Specificity`)
+  for Content-Type classification and RFC 7231 content negotiation.
+- `ContentNegotiationCriterion` in `matcher.go`: Matches incoming requests to
+  tapes based on the request's `Accept` header and the tape response's
+  `Content-Type`. Enables multiple fixtures at the same path with different
+  content types. Score: 3-5 (based on specificity).
+- `"content_negotiation"` criterion type in config: Configurable via the
+  declarative JSON config under `matcher.criteria`.
+- `httptape migrate-fixtures` CLI subcommand: Migrates fixtures from v0.11
+  format (base64 bodies with `body_encoding`) to v0.12 format (Content-Type-aware
+  body shape). Supports `--recursive` flag for nested directories.
+
+### Migration
+
+Run the migration tool on all fixture directories before upgrading:
+
+```bash
+httptape migrate-fixtures --recursive ./fixtures
+```
+
+The tool is idempotent and safe to run multiple times. It skips non-tape
+JSON files and reports a summary of migrated/skipped/errored files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ httptape/
   server_test.go
   matcher.go           # Matcher interface, Criterion, CompositeMatcher, ExactMatcher
   matcher_test.go
+  media_type.go        # MediaType parsing, classification (IsJSON/IsText/IsBinary), content negotiation
+  media_type_test.go
   store.go             # Storage port (interface)
   store_file.go        # Filesystem storage adapter (includes FileStoreOption)
   store_file_test.go

--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -5,15 +5,18 @@
 //
 // Commands:
 //
-//	httptape serve    — Replay recorded fixtures as a mock HTTP server
-//	httptape record   — Proxy requests to upstream, record and sanitize responses
-//	httptape proxy    — Forward to upstream with L1/L2 fallback-to-cache
-//	httptape export   — Export fixtures to a tar.gz bundle
-//	httptape import   — Import fixtures from a tar.gz bundle
+//	httptape serve             — Replay recorded fixtures as a mock HTTP server
+//	httptape record            — Proxy requests to upstream, record and sanitize responses
+//	httptape proxy             — Forward to upstream with L1/L2 fallback-to-cache
+//	httptape export            — Export fixtures to a tar.gz bundle
+//	httptape import            — Import fixtures from a tar.gz bundle
+//	httptape migrate-fixtures  — Migrate fixtures from v0.11 to v0.12 format
 package main
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -24,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -62,11 +66,12 @@ Usage:
   httptape <command> [flags]
 
 Commands:
-  serve    Replay recorded fixtures as a mock HTTP server
-  record   Proxy requests to upstream, record and sanitize responses
-  proxy    Forward to upstream with L1/L2 fallback-to-cache
-  export   Export fixtures to a tar.gz bundle
-  import   Import fixtures from a tar.gz bundle
+  serve              Replay recorded fixtures as a mock HTTP server
+  record             Proxy requests to upstream, record and sanitize responses
+  proxy              Forward to upstream with L1/L2 fallback-to-cache
+  export             Export fixtures to a tar.gz bundle
+  import             Import fixtures from a tar.gz bundle
+  migrate-fixtures   Migrate fixtures from v0.11 to v0.12 format
 
 Run 'httptape <command> -h' for details on a specific command.
 `
@@ -100,6 +105,8 @@ func run(args []string) int {
 		err = runExport(cmdArgs)
 	case "import":
 		err = runImport(cmdArgs)
+	case "migrate-fixtures":
+		err = runMigrateFixtures(cmdArgs)
 	default:
 		fmt.Fprintf(os.Stderr, "httptape: unknown command %q\n\n", cmd)
 		fmt.Fprint(os.Stderr, usageText)
@@ -676,5 +683,277 @@ func runImport(args []string) error {
 		return fmt.Errorf("import: %w", err)
 	}
 
+	return nil
+}
+
+// legacyTapeEnvelope is used during migration to detect and decode the legacy
+// body_encoding field from v0.11 fixtures. The new format determines body
+// representation from Content-Type, so body_encoding is removed on migration.
+type legacyTapeEnvelope struct {
+	ID         string          `json:"id"`
+	Route      string          `json:"route"`
+	RecordedAt json.RawMessage `json:"recorded_at"`
+	Request    json.RawMessage `json:"request"`
+	Response   json.RawMessage `json:"response"`
+	Metadata   json.RawMessage `json:"metadata,omitempty"`
+}
+
+// legacyEndpoint extracts body_encoding from a legacy request or response JSON.
+type legacyEndpoint struct {
+	BodyEncoding string `json:"body_encoding"`
+}
+
+// migrateLegacyFixture reads a v0.11 fixture (which may have body_encoding
+// fields) and returns the re-serialized v0.12 content. It handles the case
+// where bodies were base64-encoded regardless of Content-Type in the old format.
+func migrateLegacyFixture(data []byte) ([]byte, error) {
+	// First, check if this has legacy body_encoding fields that need
+	// special handling. Parse the raw envelope to inspect sub-objects.
+	var env legacyTapeEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("parse envelope: %w", err)
+	}
+
+	// Check for legacy body_encoding in request and response.
+	hasLegacy := false
+	var reqLE, respLE legacyEndpoint
+	if len(env.Request) > 0 {
+		_ = json.Unmarshal(env.Request, &reqLE)
+		if reqLE.BodyEncoding != "" {
+			hasLegacy = true
+		}
+	}
+	if len(env.Response) > 0 {
+		_ = json.Unmarshal(env.Response, &respLE)
+		if respLE.BodyEncoding != "" {
+			hasLegacy = true
+		}
+	}
+
+	if hasLegacy {
+		// For legacy fixtures with body_encoding=base64, we need to pre-decode
+		// the body before the new UnmarshalJSON runs, because the new code uses
+		// Content-Type to decide how to interpret string bodies, but legacy
+		// fixtures always stored as base64 regardless of Content-Type.
+		data = removeLegacyBodyEncodingAndDecodeBody(data, reqLE.BodyEncoding, respLE.BodyEncoding)
+	}
+
+	// Now unmarshal with the new Tape type (custom UnmarshalJSON handles
+	// the body based on Content-Type).
+	var tape httptape.Tape
+	if err := json.Unmarshal(data, &tape); err != nil {
+		return nil, fmt.Errorf("unmarshal tape: %w", err)
+	}
+
+	if tape.ID == "" || tape.Request.Method == "" {
+		return nil, fmt.Errorf("not a valid tape (missing id or method)")
+	}
+
+	out, err := json.MarshalIndent(tape, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal tape: %w", err)
+	}
+	return append(out, '\n'), nil
+}
+
+// removeLegacyBodyEncodingAndDecodeBody modifies the raw JSON to:
+// 1. Remove body_encoding fields
+// 2. For base64-encoded bodies with non-JSON Content-Types, decode the body
+//    and replace it with the appropriate representation so the new
+//    UnmarshalJSON interprets it correctly.
+func removeLegacyBodyEncodingAndDecodeBody(data []byte, reqEncoding, respEncoding string) []byte {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return data
+	}
+
+	if req, ok := raw["request"]; ok {
+		raw["request"] = fixLegacyEndpoint(req, reqEncoding)
+	}
+	if resp, ok := raw["response"]; ok {
+		raw["response"] = fixLegacyEndpoint(resp, respEncoding)
+	}
+
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return data
+	}
+	return out
+}
+
+// fixLegacyEndpoint removes body_encoding from an endpoint JSON object and,
+// when the legacy encoding is "base64" and the Content-Type is textual,
+// decodes the base64 body to a plain string so the new format handles it
+// correctly.
+func fixLegacyEndpoint(raw json.RawMessage, encoding string) json.RawMessage {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return raw
+	}
+
+	// Remove the legacy field.
+	delete(fields, "body_encoding")
+
+	if encoding != "base64" {
+		out, err := json.Marshal(fields)
+		if err != nil {
+			return raw
+		}
+		return out
+	}
+
+	// Get the body value.
+	bodyRaw, ok := fields["body"]
+	if !ok || len(bodyRaw) == 0 || string(bodyRaw) == "null" {
+		out, err := json.Marshal(fields)
+		if err != nil {
+			return raw
+		}
+		return out
+	}
+
+	// Body should be a JSON string containing base64-encoded data.
+	var b64 string
+	if err := json.Unmarshal(bodyRaw, &b64); err != nil {
+		// Not a string; leave as-is.
+		out, _ := json.Marshal(fields)
+		return out
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		// Invalid base64; leave as-is.
+		out, _ := json.Marshal(fields)
+		return out
+	}
+
+	// Determine Content-Type to decide how to represent the decoded body.
+	ct := extractContentType(fields)
+	mt, parseErr := httptape.ParseMediaType(ct)
+
+	if parseErr == nil && httptape.IsJSON(mt) {
+		// JSON: write as native JSON value.
+		if json.Valid(decoded) {
+			fields["body"] = json.RawMessage(decoded)
+		} else {
+			// Invalid JSON bytes despite JSON CT: re-encode as base64 string.
+			reEncoded, _ := json.Marshal(b64)
+			fields["body"] = json.RawMessage(reEncoded)
+		}
+	} else if parseErr == nil && httptape.IsText(mt) {
+		// Text: write as JSON string.
+		encoded, _ := json.Marshal(string(decoded))
+		fields["body"] = json.RawMessage(encoded)
+	} else {
+		// Binary or unknown: keep as base64 string (the new format's convention).
+		// Already a base64 string, so leave bodyRaw as-is.
+	}
+
+	out, _ := json.Marshal(fields)
+	return out
+}
+
+// extractContentType reads the Content-Type from a headers field within a
+// request or response JSON object.
+func extractContentType(fields map[string]json.RawMessage) string {
+	headersRaw, ok := fields["headers"]
+	if !ok {
+		return ""
+	}
+	var headers map[string][]string
+	if err := json.Unmarshal(headersRaw, &headers); err != nil {
+		return ""
+	}
+	// http.Header uses canonical form, but JSON fixtures may vary.
+	for k, v := range headers {
+		if strings.EqualFold(k, "content-type") && len(v) > 0 {
+			return v[0]
+		}
+	}
+	return ""
+}
+
+func runMigrateFixtures(args []string) error {
+	fs := flag.NewFlagSet("httptape migrate-fixtures", flag.ContinueOnError)
+	recursive := fs.Bool("recursive", false, "Recurse into subdirectories")
+
+	if err := fs.Parse(args); err != nil {
+		return &usageError{err}
+	}
+
+	dir := fs.Arg(0)
+	if dir == "" {
+		fs.Usage()
+		return &usageError{fmt.Errorf("<dir> argument is required")}
+	}
+
+	// Resolve to absolute path for consistent logging.
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+
+	info, err := os.Stat(absDir)
+	if err != nil {
+		return fmt.Errorf("stat directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", absDir)
+	}
+
+	var migrated, skipped, errored int
+
+	walkFn := func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			logger.Printf("walk error: %s: %v", path, walkErr)
+			errored++
+			return nil // continue walking
+		}
+
+		if d.IsDir() {
+			// If not recursive, skip subdirectories (but not the root).
+			if !*recursive && path != absDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			logger.Printf("skip (read error): %s: %v", path, readErr)
+			errored++
+			return nil
+		}
+
+		out, migrateErr := migrateLegacyFixture(data)
+		if migrateErr != nil {
+			logger.Printf("skip (not a tape): %s", path)
+			skipped++
+			return nil
+		}
+
+		if writeErr := os.WriteFile(path, out, 0644); writeErr != nil {
+			logger.Printf("error (write): %s: %v", path, writeErr)
+			errored++
+			return nil
+		}
+
+		migrated++
+		return nil
+	}
+
+	if walkErr := filepath.WalkDir(absDir, walkFn); walkErr != nil {
+		return fmt.Errorf("walk directory: %w", walkErr)
+	}
+
+	logger.Printf("migrate-fixtures: %d migrated, %d skipped, %d errors", migrated, skipped, errored)
+
+	if errored > 0 {
+		return fmt.Errorf("%d files had errors during migration", errored)
+	}
 	return nil
 }

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -636,6 +636,249 @@ func TestServeNoConfig(t *testing.T) {
 	}
 }
 
+func TestMigrateFixtures_Help(t *testing.T) {
+	got := run([]string{"migrate-fixtures", "-h"})
+	if got != exitOK {
+		t.Errorf("got exit %d, want %d", got, exitOK)
+	}
+}
+
+func TestMigrateFixtures_MissingDir(t *testing.T) {
+	got := run([]string{"migrate-fixtures"})
+	if got != exitUsage {
+		t.Errorf("got exit %d, want %d", got, exitUsage)
+	}
+}
+
+func TestMigrateFixtures_NonexistentDir(t *testing.T) {
+	got := run([]string{"migrate-fixtures", "/nonexistent/path/xyz"})
+	if got != exitRuntime {
+		t.Errorf("got exit %d, want %d", got, exitRuntime)
+	}
+}
+
+func TestMigrateFixtures_NotADirectory(t *testing.T) {
+	f, err := os.CreateTemp("", "httptape-test-*.json")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	defer os.Remove(f.Name())
+	f.Close()
+
+	got := run([]string{"migrate-fixtures", f.Name()})
+	if got != exitRuntime {
+		t.Errorf("got exit %d, want %d", got, exitRuntime)
+	}
+}
+
+func TestMigrateFixtures_MigratesLegacyTape(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a legacy fixture with base64-encoded JSON body and body_encoding field.
+	legacy := `{
+  "id": "test-001",
+  "route": "api",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "request": {
+    "method": "GET",
+    "url": "http://example.com/api/users",
+    "headers": {"Accept": ["application/json"]},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {"Content-Type": ["application/json"]},
+    "body": "eyJuYW1lIjoiYWxpY2UifQ==",
+    "body_encoding": "base64"
+  }
+}`
+	path := filepath.Join(dir, "tape.json")
+	if err := os.WriteFile(path, []byte(legacy), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := run([]string{"migrate-fixtures", dir})
+	if got != exitOK {
+		t.Fatalf("got exit %d, want %d", got, exitOK)
+	}
+
+	// Read the migrated file.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	// Verify body is now native JSON (not base64 string).
+	if !strings.Contains(string(data), `"name"`) {
+		t.Errorf("migrated fixture should contain native JSON body, got:\n%s", data)
+	}
+	// Verify body_encoding field is removed.
+	if strings.Contains(string(data), "body_encoding") {
+		t.Errorf("migrated fixture should not contain body_encoding, got:\n%s", data)
+	}
+	// Verify trailing newline.
+	if data[len(data)-1] != '\n' {
+		t.Error("migrated fixture should end with newline")
+	}
+}
+
+func TestMigrateFixtures_SkipsNonTapeJSON(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a JSON file that is not a valid tape.
+	notTape := `{"foo": "bar"}`
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(notTape), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := run([]string{"migrate-fixtures", dir})
+	if got != exitOK {
+		t.Fatalf("got exit %d, want %d", got, exitOK)
+	}
+
+	// Verify file is unchanged.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != notTape {
+		t.Errorf("non-tape file should be unchanged, got:\n%s", data)
+	}
+}
+
+func TestMigrateFixtures_SkipsNonJSONFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a non-JSON file.
+	path := filepath.Join(dir, "readme.txt")
+	content := "not a json file"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := run([]string{"migrate-fixtures", dir})
+	if got != exitOK {
+		t.Fatalf("got exit %d, want %d", got, exitOK)
+	}
+
+	// Verify file is unchanged.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf("non-JSON file should be unchanged, got:\n%s", data)
+	}
+}
+
+func TestMigrateFixtures_RecursiveFlag(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "subdir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Write a legacy tape in a subdirectory.
+	legacy := `{
+  "id": "test-002",
+  "route": "api",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "request": {
+    "method": "POST",
+    "url": "http://example.com/api/data",
+    "headers": {"Content-Type": ["text/plain"]},
+    "body": "aGVsbG8=",
+    "body_hash": "abc123",
+    "body_encoding": "base64"
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {"Content-Type": ["text/plain"]},
+    "body": "d29ybGQ=",
+    "body_encoding": "base64"
+  }
+}`
+	path := filepath.Join(subDir, "tape.json")
+	if err := os.WriteFile(path, []byte(legacy), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Without --recursive, subdirectories are skipped.
+	got := run([]string{"migrate-fixtures", dir})
+	if got != exitOK {
+		t.Fatalf("got exit %d, want %d", got, exitOK)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// File should still have body_encoding because it wasn't processed.
+	if !strings.Contains(string(data), "body_encoding") {
+		t.Error("without --recursive, subdirectory fixture should be unchanged")
+	}
+
+	// With --recursive, subdirectories are processed.
+	got = run([]string{"migrate-fixtures", "--recursive", dir})
+	if got != exitOK {
+		t.Fatalf("got exit %d, want %d", got, exitOK)
+	}
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(data), "body_encoding") {
+		t.Errorf("with --recursive, fixture should be migrated (no body_encoding), got:\n%s", data)
+	}
+
+	// text/plain body should be a string in the migrated fixture.
+	if !strings.Contains(string(data), `"hello"`) || !strings.Contains(string(data), `"world"`) {
+		t.Errorf("text/plain bodies should be decoded as strings, got:\n%s", data)
+	}
+}
+
+func TestMigrateFixtures_AlreadyMigratedTape(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a tape that is already in the new format (native JSON body).
+	modern := `{
+  "id": "test-003",
+  "route": "api",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "request": {
+    "method": "GET",
+    "url": "http://example.com/api/health",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {"Content-Type": ["application/json"]},
+    "body": {"status": "ok"}
+  }
+}`
+	path := filepath.Join(dir, "tape.json")
+	if err := os.WriteFile(path, []byte(modern), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := run([]string{"migrate-fixtures", dir})
+	if got != exitOK {
+		t.Fatalf("got exit %d, want %d", got, exitOK)
+	}
+
+	// Read and verify the body is still native JSON.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), `"status"`) {
+		t.Errorf("already-migrated fixture should still have native JSON body, got:\n%s", data)
+	}
+}
+
 func itoa(i int) string {
 	const digits = "0123456789"
 	if i == 0 {

--- a/config.go
+++ b/config.go
@@ -53,9 +53,10 @@ type MatcherConfig struct {
 // Type-specific fields are validated based on the Type value.
 //
 // Currently supported types:
-//   - "method":     matches on HTTP method (no type-specific fields)
-//   - "path":       matches on URL path (no type-specific fields)
-//   - "body_fuzzy": matches on specific JSON body fields (requires Paths)
+//   - "method":              matches on HTTP method (no type-specific fields)
+//   - "path":                matches on URL path (no type-specific fields)
+//   - "body_fuzzy":          matches on specific JSON body fields (requires Paths)
+//   - "content_negotiation": matches request Accept against response Content-Type (no type-specific fields)
 type CriterionConfig struct {
 	Type  string   `json:"type"`
 	Paths []string `json:"paths,omitempty"`
@@ -240,9 +241,10 @@ type criterionBuilder struct {
 // criterionBuilders maps criterion type names to their builder definitions.
 // Each entry corresponds to a supported Criterion.Name() value.
 var criterionBuilders = map[string]criterionBuilder{
-	"method":     {validate: validateMethodCriterion, build: buildMethodCriterion},
-	"path":       {validate: validatePathCriterion, build: buildPathCriterion},
-	"body_fuzzy": {validate: validateBodyFuzzyCriterion, build: buildBodyFuzzyCriterion},
+	"method":               {validate: validateMethodCriterion, build: buildMethodCriterion},
+	"path":                 {validate: validatePathCriterion, build: buildPathCriterion},
+	"body_fuzzy":           {validate: validateBodyFuzzyCriterion, build: buildBodyFuzzyCriterion},
+	"content_negotiation":  {validate: validateContentNegotiationCriterion, build: buildContentNegotiationCriterion},
 }
 
 func validateMethodCriterion(cc CriterionConfig) error {
@@ -281,6 +283,17 @@ func validateBodyFuzzyCriterion(cc CriterionConfig) error {
 
 func buildBodyFuzzyCriterion(cc CriterionConfig) (Criterion, error) {
 	return NewBodyFuzzyCriterion(cc.Paths...), nil
+}
+
+func validateContentNegotiationCriterion(cc CriterionConfig) error {
+	if len(cc.Paths) > 0 {
+		return fmt.Errorf("%q does not use \"paths\"", cc.Type)
+	}
+	return nil
+}
+
+func buildContentNegotiationCriterion(_ CriterionConfig) (Criterion, error) {
+	return ContentNegotiationCriterion{}, nil
 }
 
 // BuildMatcher constructs a Matcher from the config's matcher declaration.

--- a/config.schema.json
+++ b/config.schema.json
@@ -28,7 +28,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["method", "path", "body_fuzzy"],
+                "enum": ["method", "path", "body_fuzzy", "content_negotiation"],
                 "description": "Criterion type name. Must match a supported Criterion.Name() value."
               },
               "paths": {
@@ -55,7 +55,7 @@
               },
               {
                 "if": {
-                  "properties": { "type": { "enum": ["method", "path"] } },
+                  "properties": { "type": { "enum": ["method", "path", "content_negotiation"] } },
                   "required": ["type"]
                 },
                 "then": {

--- a/config_test.go
+++ b/config_test.go
@@ -650,6 +650,11 @@ func TestLoadConfig_MatcherValidation(t *testing.T) {
 			wantErr: `"path" does not use "paths"`,
 		},
 		{
+			name:    "content_negotiation with paths",
+			input:   `{"version":"1","matcher":{"criteria":[{"type":"content_negotiation","paths":["$.x"]}]},"rules":[{"action":"redact_headers"}]}`,
+			wantErr: `"content_negotiation" does not use "paths"`,
+		},
+		{
 			name:    "body_fuzzy invalid path syntax",
 			input:   `{"version":"1","matcher":{"criteria":[{"type":"body_fuzzy","paths":["invalid"]}]},"rules":[{"action":"redact_headers"}]}`,
 			wantErr: `invalid path syntax: "invalid"`,
@@ -916,6 +921,55 @@ func TestLoadConfig_MatcherWithRules(t *testing.T) {
 	pipeline := cfg.BuildPipeline()
 	if len(pipeline.funcs) != 1 {
 		t.Errorf("pipeline.funcs len = %d, want 1", len(pipeline.funcs))
+	}
+}
+
+func TestLoadConfig_ContentNegotiationCriterion(t *testing.T) {
+	input := `{
+		"version": "1",
+		"matcher": {
+			"criteria": [
+				{"type": "method"},
+				{"type": "path"},
+				{"type": "content_negotiation"}
+			]
+		},
+		"rules": []
+	}`
+
+	cfg, err := LoadConfig(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Matcher == nil {
+		t.Fatal("Matcher is nil")
+	}
+	if len(cfg.Matcher.Criteria) != 3 {
+		t.Fatalf("len(criteria) = %d, want 3", len(cfg.Matcher.Criteria))
+	}
+	if cfg.Matcher.Criteria[2].Type != "content_negotiation" {
+		t.Errorf("criteria[2].type = %q, want %q", cfg.Matcher.Criteria[2].Type, "content_negotiation")
+	}
+
+	matcher, err := cfg.BuildMatcher()
+	if err != nil {
+		t.Fatalf("BuildMatcher error: %v", err)
+	}
+
+	cm, ok := matcher.(*CompositeMatcher)
+	if !ok {
+		t.Fatalf("expected *CompositeMatcher, got %T", matcher)
+	}
+	if len(cm.criteria) != 3 {
+		t.Fatalf("criteria count = %d, want 3", len(cm.criteria))
+	}
+
+	wantNames := []string{"method", "path", "content_negotiation"}
+	for i, want := range wantNames {
+		if cm.criteria[i].Name() != want {
+			t.Errorf("criteria[%d].Name() = %q, want %q", i, cm.criteria[i].Name(), want)
+		}
 	}
 }
 

--- a/decisions.md
+++ b/decisions.md
@@ -11174,6 +11174,981 @@ The test DOES prove:
 
 ---
 
+### ADR-41: Content-Type-driven body shape + ContentNegotiationCriterion (v0.12.0)
+
+**Date**: 2026-04-18
+**Issue**: #187 (absorbs #188, now closed)
+**Status**: Accepted
+
+#### Context
+
+httptape stores HTTP bodies as `[]byte` in the Go struct and base64-encoded
+strings in fixture JSON. This is correct but hostile to hand-authoring: a JSON
+API response body like `{"id":1,"name":"Alice"}` becomes
+`eyJpZCI6MSwibmFtZSI6IkFsaWNlIn0=` on disk. With the user about to
+integrate httptape into the VibeWarden product (hand-authored fixtures for
+deterministic AI agent testing), base64 bodies are a non-starter.
+
+Separately, multiple fixtures at the same path but different response
+Content-Types (e.g., JSON vs. XML) cannot be distinguished by the current
+matcher stack. Real HTTP APIs use `Accept` / `Content-Type` content negotiation
+for this (RFC 7231 section 5.3.2), and httptape needs a criterion that
+implements it.
+
+Both concerns share one root: **httptape must be Content-Type-aware** at
+two layers:
+
+1. **Storage layer** (body shape in fixture JSON): the fixture format should
+   represent JSON bodies as native JSON, text bodies as strings, and binary
+   bodies as base64.
+2. **Matcher layer** (content negotiation): a new `ContentNegotiationCriterion`
+   that compares the request `Accept` header against the candidate tape's
+   response `Content-Type`, using RFC 7231 specificity and q-value scoring.
+
+Both layers share a common MediaType parsing/classification utility, so they
+are designed, implemented, and shipped as a single atomic v0.12.0 breaking
+change.
+
+#### Open question resolutions
+
+**Q1: Vendor JSON types -- should `Accept: application/json` match `Content-Type: application/vnd.api+json`?**
+
+Decision: **No, strict RFC 7231 semantics. `application/json` does NOT match
+`application/vnd.api+json`.** However, `application/vnd.api+json` IS classified
+as JSON-flavored for the *body shape* layer (Layer 1) because it uses the
+`+json` structured syntax suffix (RFC 6838 section 4.2.8). These are two
+separate concerns:
+
+- Body shape classification: any media type with `+json` suffix or an
+  explicit-list match (`application/json`, `application/ld+json`,
+  `application/problem+json`) emits native JSON in fixtures. This is a
+  format decision, not a matching decision.
+- Content negotiation matching: `Accept: application/json` matches only
+  `Content-Type: application/json`, not `application/vnd.api+json`. To match
+  vendor types, the client must send `Accept: application/vnd.api+json` or
+  `Accept: application/*` or `Accept: */*`. This follows RFC 7231 section
+  5.3.2 literally.
+
+Rationale: violating RFC 7231 matching semantics to be "convenient" would
+create a subset-of-HTTP that surprises users who know the spec. The body shape
+layer can safely be more liberal because it is a display/storage concern, not a
+protocol compliance concern.
+
+**Q2: Charset and parameter handling in matching**
+
+Decision: **Parameters (except `q`) are ignored during content negotiation
+matching.** `text/plain; charset=utf-8` matches `text/plain; charset=ascii`.
+
+Rationale: RFC 7231 section 5.3.2 says parameters in the Accept header's
+media-range narrow the match, but in practice almost no real-world API
+distinguishes fixtures by charset. httptape is a mock server for testing,
+not a conformant HTTP proxy -- pragmatism wins. The `q` parameter is always
+consumed as the quality factor and never compared as a media type parameter.
+
+Implementation note: `ParseMediaType` still *parses* parameters into the
+`Parameters` map (for potential future use), but `Matches` and `MatchScore`
+compare only type and subtype. This decision can be revisited if a real use
+case arises.
+
+**Q3: Body shape for `application/x-www-form-urlencoded`**
+
+Decision: **String.** Form-encoded bodies are stored as JSON strings, e.g.,
+`"body": "username=alice&password=secret"`. No key-value object parsing.
+
+Rationale: parsing form bodies into a JSON object would create a semantic
+transform (the body bytes would no longer round-trip identically through
+encode/decode). httptape replays bodies verbatim -- the Go struct's `Body
+[]byte` is the source of truth. The fixture format is a human-friendly
+*presentation* of those bytes, not a parsed representation. Parsing is a
+separate concern that could be layered on top in the future.
+
+**Q4: Scoring weight for ContentNegotiationCriterion**
+
+Decision: **Score 5.** The weight table becomes:
+
+| Criterion                     | Score |
+|-------------------------------|-------|
+| MethodCriterion               | 1     |
+| PathCriterion                 | 2     |
+| RouteCriterion                | 1     |
+| PathRegexCriterion            | 1     |
+| HeadersCriterion              | 3     |
+| QueryParamsCriterion          | 4     |
+| **ContentNegotiationCriterion** | **5** |
+| BodyFuzzyCriterion            | 6     |
+| BodyHashCriterion             | 8     |
+
+Rationale: Content negotiation is more specific than a generic header match
+(3) or query params (4), but less specific than body-level matching (6, 8).
+Score 5 slots it between query params and body fuzzy, which matches the
+intuitive specificity ordering: discriminating by response format is more
+meaningful than matching on query parameters but less meaningful than matching
+on request body content.
+
+Within the `ContentNegotiationCriterion.Score()` method, the returned score
+is always 5 on match (not variable). The *ranking* among multiple matching
+candidates is handled by the criterion itself returning 0 for non-matching
+candidates, so the CompositeMatcher's scoring loop eliminates them. When
+multiple candidates survive, they have equal content-negotiation scores;
+other criteria (path, body, etc.) break the tie. This is intentionally simple
+for v0.12.0. A future enhancement could return a variable score based on
+specificity/q-value (e.g., exact type match scores higher than wildcard
+match), but this adds complexity without a proven need.
+
+**Refinement -- variable scoring within ContentNegotiationCriterion:**
+
+On further reflection, variable scoring *within* the criterion is valuable
+when the *only* differentiating dimension is Accept/Content-Type (e.g., three
+fixtures for `GET /users` with JSON, XML, CSV responses). In that scenario,
+all three survive method+path scoring equally. The content-negotiation criterion
+must break the tie. The scoring approach:
+
+- Exact type+subtype match: score 5
+- Subtype wildcard match (e.g., `application/*` matching `application/json`): score 4
+- Full wildcard match (`*/*`): score 3
+- No match: score 0
+
+This preserves the general position of content negotiation (3-5 range) in the
+global weight table while allowing intra-criterion ranking. If q-values differ
+among matching media ranges, the highest-q matching range determines the score
+tier; ties within a tier are broken by specificity.
+
+**Q5: Coexistence with `HeadersCriterion("Accept", ...)`**
+
+Decision: **Allowed, not an error, but documented as redundant.** If a user
+configures both `content_negotiation` and `HeadersCriterion{Key: "Accept",
+Value: "..."}`, both contribute independently to the composite score. The
+`HeadersCriterion` performs exact string matching on the Accept *request*
+header (both sides must have it), while `ContentNegotiationCriterion` performs
+RFC 7231 media-range matching against the *response* Content-Type. They test
+different things and their scores add. However, using both is almost certainly
+a mistake -- documenting this in `matcher.go` godoc and `docs/matching.md` is
+sufficient.
+
+`Validate()` does NOT produce an error for this combination -- it is not
+wrong, just unusual. No special interaction logic.
+
+**Q6: Migration tool**
+
+Decision: **In scope.** Add `httptape migrate-fixtures <dir>` as a subcommand
+in `cmd/httptape/main.go`. The tool reads each `.json` file in `<dir>`
+(non-recursively), detects old-format fixtures (body is a base64 string where
+Content-Type indicates it should be a native JSON object or text string),
+converts to new format, writes back with proper indentation + trailing newline.
+
+Behavior details:
+- Files that are already in new format are skipped (idempotent).
+- Files that are not valid Tape JSON are skipped with a warning to stderr.
+- SSE tapes (`sse_events` present and non-empty) are skipped (body is null).
+- Recursive mode via `--recursive` flag (default: non-recursive).
+- Summary printed to stdout: `migrated N files, skipped M files, errors E files`.
+- Exit code 0 on success (even if some files were skipped), non-zero if any
+  write fails.
+
+As part of this PR, run the migration tool against all fixture directories in
+the repo.
+
+**Q7: Empty body representation**
+
+Decision: **`null`.** Empty bodies (nil `Body []byte`) are represented as
+`"body": null` in fixture JSON. This is consistent with the current behavior
+(Go's `encoding/json` marshals `[]byte(nil)` as `null`), maintains backward
+compatibility for existing fixtures that already use `null`, and is
+semantically correct (`null` = "no body", not "empty string body").
+
+An explicitly empty body (`Body = []byte{}`, length 0) is also marshaled as
+`null`. The distinction between nil and empty-but-allocated is not meaningful
+at the HTTP level and should not leak into fixtures.
+
+Omitting the `body` field entirely (via `omitempty`) was considered but
+rejected: the field should always be present for structural consistency and
+to make fixtures self-documenting. A reader should never have to wonder
+whether a missing `body` field means "null body" or "field accidentally
+deleted."
+
+**Q8: File naming**
+
+Decision: **`media_type.go`** (with underscore). Go convention for multi-word
+filenames is underscore-separated (`store_file.go`, `store_memory.go`). The
+test file is `media_type_test.go`.
+
+#### Decision
+
+##### Shared utility -- `media_type.go`
+
+New file at the package root containing media type parsing, classification,
+and matching utilities. Consumed by `tape.go` (body shape dispatch) and
+`matcher.go` (ContentNegotiationCriterion).
+
+**Types:**
+
+```go
+// MediaType represents a parsed media type (e.g., "application/json; charset=utf-8").
+// It is a value type with no I/O.
+type MediaType struct {
+    // Type is the top-level type (e.g., "application", "text", "image").
+    Type string
+    // Subtype is the subtype (e.g., "json", "plain", "png").
+    // For structured syntax suffixes, this includes the full subtype
+    // (e.g., "vnd.api+json").
+    Subtype string
+    // Suffix is the structured syntax suffix without the '+' prefix
+    // (e.g., "json" for "application/vnd.api+json"). Empty if no suffix.
+    Suffix string
+    // Params holds media type parameters (e.g., charset=utf-8).
+    // The "q" parameter is extracted into QValue and not included here.
+    Params map[string]string
+    // QValue is the quality factor from the Accept header (0.0-1.0).
+    // Defaults to 1.0 if not specified.
+    QValue float64
+}
+```
+
+**Functions:**
+
+```go
+// ParseMediaType parses a single media type string (e.g., "application/json;
+// charset=utf-8") into a MediaType. Parameters including q-value are parsed.
+// Returns an error if the string is fundamentally malformed (no "/" separator).
+// Uses mime.ParseMediaType from stdlib internally.
+func ParseMediaType(s string) (MediaType, error)
+
+// ParseAccept parses an Accept header value into a slice of MediaType entries,
+// sorted by precedence (highest q-value first, then specificity).
+// Malformed individual media ranges are silently skipped.
+// An empty or missing Accept header returns a single entry for "*/*" with q=1.0.
+func ParseAccept(accept string) []MediaType
+
+// IsJSON reports whether the media type represents JSON content.
+// True for: application/json, any type with +json suffix,
+// application/ld+json, application/problem+json, etc.
+func IsJSON(mt MediaType) bool
+
+// IsText reports whether the media type represents human-readable text content.
+// True for: text/*, application/xml, application/javascript,
+// application/x-www-form-urlencoded, any type with +xml suffix.
+// False for types that IsJSON returns true for (JSON is handled separately).
+func IsText(mt MediaType) bool
+
+// IsBinary reports whether the media type represents binary content.
+// Returns true when neither IsJSON nor IsText returns true, or when
+// the media type is empty/unknown. This is the fallback classification.
+func IsBinary(mt MediaType) bool
+
+// MatchesMediaRange reports whether a response Content-Type satisfies an
+// Accept media range. Type and subtype are compared; parameters (except q)
+// are ignored per Q2 resolution. Supports wildcards: */* matches anything,
+// type/* matches any subtype of type.
+func MatchesMediaRange(accept, contentType MediaType) bool
+
+// Specificity returns a specificity score for a media range:
+//   3 for exact type/subtype (e.g., application/json)
+//   2 for subtype wildcard (e.g., application/*)
+//   1 for full wildcard (*/* )
+// Used to rank among multiple matching media ranges in an Accept header.
+func Specificity(mt MediaType) int
+```
+
+Implementation notes:
+- `ParseMediaType` wraps `mime.ParseMediaType` from stdlib, extracting the
+  `q` parameter as `QValue` (defaulting to 1.0) and splitting the media type
+  string into `Type`/`Subtype`/`Suffix`.
+- `ParseAccept` splits on comma, calls `ParseMediaType` for each entry,
+  sorts by (QValue desc, Specificity desc), silently skips malformed entries.
+- `IsJSON` checks: `Type == "application" && (Subtype == "json" || Suffix == "json")`.
+- `IsText` checks: `Type == "text"`, or
+  `Type == "application" && Subtype in {"xml", "javascript", "x-www-form-urlencoded"}`,
+  or `Suffix == "xml"`. Returns false if `IsJSON` would return true (JSON
+  takes priority).
+- `IsBinary` returns `!IsJSON(mt) && !IsText(mt)`.
+
+##### Layer 1 -- Content-Type-driven body shape in `tape.go`
+
+**Approach:** custom `MarshalJSON`/`UnmarshalJSON` on `RecordedReq` and
+`RecordedResp`. The Go struct retains `Body []byte` internally. Only the
+on-disk JSON representation changes.
+
+**Removal of `BodyEncoding` field:** The `BodyEncoding` field and
+`BodyEncoding` type are removed from both `RecordedReq` and `RecordedResp`.
+The `body_encoding` JSON field is no longer emitted. The `detectBodyEncoding`
+function is replaced by the `IsJSON`/`IsText`/`IsBinary` classifiers in
+`media_type.go`. This is a breaking change to the fixture JSON schema (the
+`body_encoding` field disappears), but it was an informational field with no
+behavioral effect on replay -- replay always writes `Body` bytes verbatim.
+
+The Recorder and Proxy still need to know the Content-Type for populating
+the body hash and (now) for nothing else in the tape construction. The
+`BodyEncoding` field was set but never read by the library itself -- it was
+purely informational for fixture authors. The new body shape makes it
+redundant because the shape itself conveys the encoding.
+
+**MarshalJSON for RecordedReq and RecordedResp:**
+
+1. Build a map representing all JSON fields except `body`.
+2. Look up the Content-Type from `Headers`.
+3. Classify using `ParseMediaType` + `IsJSON`/`IsText`/`IsBinary`.
+4. If `Body` is nil or empty: emit `"body": null`.
+5. If JSON-flavored: marshal `Body` bytes as `json.RawMessage` into the
+   `"body"` field. This emits the JSON natively (object/array/primitive)
+   without escaping. If the bytes are not valid JSON despite the Content-Type
+   claiming JSON, fall back to base64 string.
+6. If text-y: emit `"body": "<string>"` -- the body bytes interpreted as
+   UTF-8, emitted as a JSON string.
+7. If binary: emit `"body": "<base64>"` -- standard base64 encoding,
+   emitted as a JSON string. This is the same behavior as Go's default
+   `[]byte` JSON encoding.
+8. `body_encoding` is NOT emitted (field removed).
+
+**UnmarshalJSON for RecordedReq and RecordedResp:**
+
+1. Unmarshal all fields except `body` normally.
+2. Extract the raw `body` value using `json.RawMessage`.
+3. If the raw value is `null`: set `Body = nil`.
+4. Determine the JSON token type of the raw value:
+   - If JSON object (`{`) or array (`[`): the body is native JSON.
+     Marshal the raw value back to compact JSON bytes and store as `Body`.
+   - If JSON string (`"`): need to distinguish text from base64.
+     a. Unmarshal the string value.
+     b. Look up Content-Type from the already-parsed `Headers`.
+     c. If Content-Type is JSON-flavored: this is a legacy fixture or a
+        scalar JSON value stored as a string. Try `json.Valid()` on the
+        string bytes; if valid JSON, store as `Body`. Otherwise treat as
+        text.
+     d. If Content-Type is text-y: store the string as UTF-8 bytes directly.
+     e. If Content-Type is binary or unknown: base64-decode the string and
+        store the decoded bytes as `Body`. If base64 decoding fails, store
+        the string as UTF-8 bytes (graceful degradation).
+5. If `body_encoding` field is present in the JSON (legacy fixture), it is
+   silently ignored during unmarshal. The custom unmarshal does not read it.
+
+**Round-trip property:** `Marshal(Unmarshal(json))` produces identical JSON
+for all three body shapes. This is guaranteed by:
+- Native JSON bodies: stored as `json.RawMessage` on marshal, reconstructed
+  from `json.RawMessage` on unmarshal. The raw bytes are preserved exactly
+  (including whitespace from the original fixture, since `json.RawMessage` is
+  round-trip-safe for valid JSON).
+
+  **Correction:** `json.RawMessage` preserves the raw bytes during a single
+  unmarshal, but when we re-marshal the tape, we convert `Body []byte` to
+  `json.RawMessage`. If the original fixture had pretty-printed JSON in the
+  body field, and the body bytes are stored as-is, then re-marshaling will
+  produce the same pretty-printed JSON in the body field. However, if the body
+  bytes were obtained from a real HTTP response (compact JSON), the fixture
+  will show compact JSON in the body field. This is correct behavior -- the
+  body field reflects the actual bytes.
+
+- Text bodies: string <-> UTF-8 bytes is lossless for valid UTF-8.
+- Base64 bodies: base64-encode(bytes) is deterministic.
+
+**Legacy fixture compatibility:** Existing base64-only fixtures are NOT
+auto-migrated by the unmarshaler. When loading an old fixture with
+`"body": "eyJpZCI6MSwi..."` and `Content-Type: application/json`, the
+unmarshaler sees a JSON string token and Content-Type is JSON-flavored.
+It runs `json.Valid()` on the string value. Base64-encoded JSON is NOT valid
+JSON, so it falls through to binary/base64 decode. The base64-decoded bytes
+are stored as `Body`. On re-marshal, the Content-Type is JSON, so the body
+is emitted as a native JSON object. This means loading + saving an old fixture
+implicitly converts it. However, the spec says existing fixtures are migrated
+explicitly via the migration tool -- the implicit conversion on load-then-save
+is an acceptable fallback but not the primary migration path.
+
+**Interaction with sanitization:** The sanitization pipeline operates on
+`Tape` values with `Body []byte`. The sanitizer receives and returns bytes.
+The MarshalJSON/UnmarshalJSON only affects the JSON representation. No changes
+to sanitizer code are needed.
+
+**Interaction with matching:** `BodyFuzzyCriterion` and `BodyHashCriterion`
+operate on `Body []byte` (the in-memory representation). The JSON encoding
+is irrelevant to matching. No changes to matcher scoring logic are needed
+(only the new `ContentNegotiationCriterion` is added).
+
+**Interaction with replay:** `Server.ServeHTTP` writes `tape.Response.Body`
+directly. No changes needed -- the bytes are the same regardless of how they
+were encoded in JSON.
+
+##### Layer 2 -- ContentNegotiationCriterion in `matcher.go`
+
+**New type:**
+
+```go
+// ContentNegotiationCriterion selects tapes whose response Content-Type
+// satisfies the incoming request's Accept header, following RFC 7231
+// section 5.3.2 media range matching with specificity-based scoring.
+//
+// Scoring:
+//   - Exact type/subtype match:     5
+//   - Subtype wildcard match:       4
+//   - Full wildcard (*/*) match:    3
+//   - No match:                     0
+//
+// When the request has no Accept header, it is treated as Accept: */*
+// (per RFC 7231 section 5.3.2). When a candidate tape has no response
+// Content-Type header, it is treated as application/octet-stream.
+//
+// If the Accept header contains multiple media ranges, the criterion
+// uses the highest-specificity range that matches the candidate's
+// Content-Type, weighted by q-value. Media ranges with q=0 explicitly
+// exclude the Content-Type.
+//
+// Malformed Accept headers: individual malformed media ranges are silently
+// skipped. If all ranges are malformed, the Accept header is treated as */*.
+// The criterion never panics on malformed input.
+type ContentNegotiationCriterion struct{}
+
+func (ContentNegotiationCriterion) Score(req *http.Request, candidate Tape) int
+func (ContentNegotiationCriterion) Name() string // returns "content_negotiation"
+```
+
+**Score algorithm:**
+
+1. Parse the request's `Accept` header via `ParseAccept`. If absent or empty,
+   use `[MediaType{Type: "*", Subtype: "*", QValue: 1.0}]`.
+2. Parse the candidate tape's response `Content-Type` via `ParseMediaType`.
+   If absent or empty, use `MediaType{Type: "application", Subtype: "octet-stream"}`.
+3. For each media range in the parsed Accept (already sorted by q-value desc,
+   specificity desc):
+   a. If `q == 0`: if this range matches the Content-Type, immediately return
+      0 (explicitly excluded).
+   b. If `MatchesMediaRange(range, contentType)`: return the specificity score
+      (5 for exact, 4 for subtype wildcard, 3 for full wildcard).
+4. If no range matched: return 0.
+
+The iteration short-circuits on the first match because `ParseAccept` sorts
+by precedence (highest q-value first, then specificity). The first match is
+by definition the best match.
+
+##### Config integration in `config.go`
+
+Add `"content_negotiation"` to the `criterionBuilders` dispatch table:
+
+```go
+"content_negotiation": {validate: validateContentNegotiationCriterion, build: buildContentNegotiationCriterion},
+```
+
+Validation: `content_negotiation` takes no type-specific fields. If `Paths`
+is set, produce an error (same pattern as `method` and `path`).
+
+Builder: returns `ContentNegotiationCriterion{}`.
+
+The `CriterionConfig` struct does not need new fields -- `content_negotiation`
+uses no type-specific configuration.
+
+##### JSON Schema extension (`config.schema.json`)
+
+Add `"content_negotiation"` to the criterion type enum:
+
+```json
+"enum": ["method", "path", "body_fuzzy", "content_negotiation"]
+```
+
+Add an `if/then` constraint to reject `paths` when type is
+`content_negotiation` (same as `method` and `path`):
+
+```json
+{
+  "if": {
+    "properties": { "type": { "enum": ["method", "path", "content_negotiation"] } },
+    "required": ["type"]
+  },
+  "then": {
+    "properties": {
+      "paths": false
+    }
+  }
+}
+```
+
+This replaces the existing `if/then` for `["method", "path"]` -- just add
+`"content_negotiation"` to the enum array.
+
+##### CLI migration subcommand in `cmd/httptape/main.go`
+
+New subcommand `migrate-fixtures`:
+
+```
+httptape migrate-fixtures <dir> [--recursive]
+```
+
+Implementation:
+
+```go
+func runMigrateFixtures(args []string) error
+```
+
+1. Parse flags: `--recursive` (bool, default false).
+2. Read `.json` files from `<dir>` (optionally recursive).
+3. For each file:
+   a. Read file contents.
+   b. Try `json.Unmarshal` into a `Tape`. If it fails, skip with warning.
+   c. Check if migration is needed: look at the `body` field in the raw JSON.
+      If it's a string and the Content-Type indicates JSON or text, migration
+      is needed.
+   d. If migration needed: marshal the tape back to JSON (which uses the new
+      custom MarshalJSON). Write back to the same file.
+   e. Track stats: migrated, skipped, errored.
+4. Print summary.
+
+The migration tool uses the library's own `json.Unmarshal` (which now has
+custom unmarshal logic) followed by `json.MarshalIndent` (which now has
+custom marshal logic). The unmarshal reads the old format correctly (base64
+string bodies are decoded to `Body []byte`), and the marshal writes the new
+format (Content-Type-aware body shape).
+
+##### Removal of `BodyEncoding` type and fields
+
+The following are removed from `tape.go`:
+- `BodyEncoding` type alias
+- `BodyEncodingIdentity` constant
+- `BodyEncodingBase64` constant
+- `RecordedReq.BodyEncoding` field
+- `RecordedResp.BodyEncoding` field
+- `detectBodyEncoding` function
+
+The following are updated:
+- `recorder.go`: remove all `detectBodyEncoding` calls and `BodyEncoding`
+  field assignments in tape construction.
+- `proxy.go`: same removals.
+- `recorder_test.go`: remove `TestDetectBodyEncoding`,
+  `TestRecorder_BinaryBody` BodyEncoding assertion,
+  `TestRecorder_TextBody` BodyEncoding assertion.
+- `server_test.go`: remove `BodyEncoding` field from test tape construction.
+
+#### Types
+
+| Type | File | Description |
+|---|---|---|
+| `MediaType` | `media_type.go` | Parsed media type with type, subtype, suffix, params, q-value |
+| `ContentNegotiationCriterion` | `matcher.go` | Criterion implementing RFC 7231 Accept/Content-Type matching |
+
+Modified types:
+
+| Type | File | Change |
+|---|---|---|
+| `RecordedReq` | `tape.go` | Remove `BodyEncoding` field. Add custom `MarshalJSON`/`UnmarshalJSON`. |
+| `RecordedResp` | `tape.go` | Remove `BodyEncoding` field. Add custom `MarshalJSON`/`UnmarshalJSON`. |
+
+Removed types:
+
+| Type | File | Notes |
+|---|---|---|
+| `BodyEncoding` | `tape.go` | Type alias and both constants removed |
+
+#### Functions and methods
+
+New exported functions:
+
+| Function | Signature | File |
+|---|---|---|
+| `ParseMediaType` | `func ParseMediaType(s string) (MediaType, error)` | `media_type.go` |
+| `ParseAccept` | `func ParseAccept(accept string) []MediaType` | `media_type.go` |
+| `IsJSON` | `func IsJSON(mt MediaType) bool` | `media_type.go` |
+| `IsText` | `func IsText(mt MediaType) bool` | `media_type.go` |
+| `IsBinary` | `func IsBinary(mt MediaType) bool` | `media_type.go` |
+| `MatchesMediaRange` | `func MatchesMediaRange(accept, contentType MediaType) bool` | `media_type.go` |
+| `Specificity` | `func Specificity(mt MediaType) int` | `media_type.go` |
+| `ContentNegotiationCriterion.Score` | `func (ContentNegotiationCriterion) Score(req *http.Request, candidate Tape) int` | `matcher.go` |
+| `ContentNegotiationCriterion.Name` | `func (ContentNegotiationCriterion) Name() string` | `matcher.go` |
+| `RecordedReq.MarshalJSON` | `func (r RecordedReq) MarshalJSON() ([]byte, error)` | `tape.go` |
+| `RecordedReq.UnmarshalJSON` | `func (r *RecordedReq) UnmarshalJSON(data []byte) error` | `tape.go` |
+| `RecordedResp.MarshalJSON` | `func (r RecordedResp) MarshalJSON() ([]byte, error)` | `tape.go` |
+| `RecordedResp.UnmarshalJSON` | `func (r *RecordedResp) UnmarshalJSON(data []byte) error` | `tape.go` |
+
+Removed exported functions/types:
+
+| Symbol | File |
+|---|---|
+| `BodyEncoding` type | `tape.go` |
+| `BodyEncodingIdentity` const | `tape.go` |
+| `BodyEncodingBase64` const | `tape.go` |
+
+Removed unexported functions:
+
+| Symbol | File |
+|---|---|
+| `detectBodyEncoding` | `tape.go` |
+
+#### File layout
+
+**New files:**
+
+| File | Purpose |
+|---|---|
+| `media_type.go` | MediaType struct, ParseMediaType, ParseAccept, IsJSON, IsText, IsBinary, MatchesMediaRange, Specificity |
+| `media_type_test.go` | Comprehensive tests for all media type utilities |
+| `CHANGELOG.md` | Changelog with v0.12.0 entry (created if not existing) |
+
+**Modified files:**
+
+| File | Changes |
+|---|---|
+| `tape.go` | Remove `BodyEncoding` type, constants, `detectBodyEncoding`. Remove `BodyEncoding` fields from `RecordedReq` and `RecordedResp`. Add `MarshalJSON`/`UnmarshalJSON` methods on both types. |
+| `tape_test.go` | Add body marshal/unmarshal tests for all three shapes. Add round-trip tests. Update existing tests that reference `BodyEncoding`. |
+| `matcher.go` | Add `ContentNegotiationCriterion` struct with `Score` and `Name` methods. Add to `CompositeMatcher` godoc score table. |
+| `matcher_test.go` | Add `ContentNegotiationCriterion` tests: exact match, wildcard, q-value, multi-candidate, missing headers, malformed input. |
+| `config.go` | Add `"content_negotiation"` entry to `criterionBuilders`. Add `validateContentNegotiationCriterion` and `buildContentNegotiationCriterion`. Update `CriterionConfig` godoc to list `content_negotiation`. |
+| `config_test.go` | Add tests for `content_negotiation` criterion config loading and BuildMatcher. |
+| `config.schema.json` | Add `"content_negotiation"` to criterion type enum. Update `if/then` constraint. |
+| `recorder.go` | Remove `detectBodyEncoding` calls and `BodyEncoding` field assignments. |
+| `proxy.go` | Remove `detectBodyEncoding` calls and `BodyEncoding` field assignments. |
+| `recorder_test.go` | Remove/update `TestDetectBodyEncoding` and BodyEncoding assertions. |
+| `server_test.go` | Remove `BodyEncoding` fields from test tape construction. |
+| `integration_test.go` | Add end-to-end tests: (a) record+replay with JSON/text/binary bodies, (b) multi-Content-Type fixture serving with config-driven content negotiation matcher. |
+| `cmd/httptape/main.go` | Add `runMigrateFixtures` function and `"migrate-fixtures"` case in command dispatch. |
+| `cmd/httptape/main_test.go` | Add tests for `migrate-fixtures` subcommand. |
+| `docs/fixtures-authoring.md` | New body shape examples (JSON native, text string, binary base64), migration instructions. |
+| `docs/matching.md` | ContentNegotiationCriterion documentation with multi-Content-Type example. |
+| `docs/api-reference.md` | Add MediaType, ParseMediaType, ParseAccept, IsJSON, IsText, IsBinary, ContentNegotiationCriterion entries. Remove BodyEncoding entries. |
+| `docs/cli.md` | Add `migrate-fixtures` subcommand documentation. |
+| `doc.go` | Update package-level doc to mention Content-Type-aware body shape. |
+| `CLAUDE.md` | No structural changes needed. Package structure comment already says `tape.go` has `RecordedReq`/`RecordedResp`. The `media_type.go` file should be added to the package structure comment. |
+
+**Fixture files to migrate:**
+
+| Directory | Files | Action |
+|---|---|---|
+| `examples/java-spring-boot/src/test/resources/fixtures/users/` | `get-user-1.json`, `get-user-999.json`, `get-users.json` | Migrate body from base64 to native JSON |
+| `examples/java-spring-boot/src/test/resources/fixtures/openai/` | `chat-completion-headphones.json` | SSE tape -- body is null, skip |
+| `examples/kotlin-ktor-koog/src/test/resources/fixtures/weather/` | `weather-berlin.json` | Migrate body from base64 to native JSON |
+| `examples/kotlin-ktor-koog/src/test/resources/fixtures/openai/` | `chat-1.json`, `chat-2.json` | Migrate request body from base64 to native JSON; response body is null (SSE) or JSON, migrate accordingly |
+| `testcontainers/testdata/` | `config.json` | Check if it has body fields that need migration |
+
+The `examples/ts-frontend-first/.httptape-cache/fixtures/` directory contains
+machine-generated cache files. These should be migrated too (via the
+migration tool with `--recursive`), or regenerated. The `.httptape-cache`
+is gitignored in most setups, but if committed, migrate.
+
+#### Sequence
+
+**Recording flow (unchanged functionally, just removes BodyEncoding):**
+
+1. `Recorder.RoundTrip` captures request and response body bytes.
+2. Constructs `RecordedReq` and `RecordedResp` with `Body []byte`.
+3. `BodyEncoding` field no longer set (removed).
+4. Tape is passed to sanitizer, then saved to store.
+5. `FileStore.Save` calls `json.MarshalIndent(tape, ...)`.
+6. `RecordedReq.MarshalJSON` and `RecordedResp.MarshalJSON` dispatch on
+   Content-Type to produce the appropriate body shape.
+7. Fixture written to disk with native JSON / string / base64 body.
+
+**Loading flow (enhanced with custom unmarshal):**
+
+1. `FileStore.Load` reads `.json` file and calls `json.Unmarshal`.
+2. `RecordedReq.UnmarshalJSON` and `RecordedResp.UnmarshalJSON` detect the
+   JSON token type of the `body` field and decode accordingly:
+   - Object/array -> re-marshal to bytes -> `Body`
+   - String + text CT -> UTF-8 bytes -> `Body`
+   - String + binary CT -> base64 decode -> `Body`
+   - String + JSON CT -> try json.Valid, if yes store as bytes, else base64 decode -> `Body`
+   - null -> `Body = nil`
+3. The rest of the Tape fields are unmarshaled normally.
+
+**Content negotiation matching flow:**
+
+1. Request arrives at `Server.ServeHTTP` with `Accept: application/json`.
+2. Server calls `matcher.Match(req, candidates)`.
+3. `CompositeMatcher` iterates candidates. For each:
+   a. Other criteria score as usual.
+   b. `ContentNegotiationCriterion.Score` parses `Accept` header, parses
+      candidate's response `Content-Type`, computes specificity score.
+4. Candidates whose Content-Type does not satisfy Accept get score 0 and
+   are eliminated.
+5. Highest-scoring surviving candidate wins.
+
+**Migration flow:**
+
+1. User runs `httptape migrate-fixtures ./fixtures`.
+2. Tool reads each `.json` file.
+3. For each: unmarshal (custom UnmarshalJSON handles old format correctly),
+   then marshal (custom MarshalJSON produces new format).
+4. Write back to file. Print summary.
+
+#### Error cases
+
+| Error | Where | Handling |
+|---|---|---|
+| Malformed Content-Type in headers | `MarshalJSON` | Fall back to binary (base64) encoding. Never fail marshal due to bad CT. |
+| Body claims JSON but is not valid JSON | `MarshalJSON` | Fall back to base64 string. Log nothing (library). |
+| Body is base64 string but base64 decode fails | `UnmarshalJSON` | Store the string as UTF-8 bytes (graceful degradation). |
+| Missing `body` field in fixture JSON | `UnmarshalJSON` | `Body = nil`. Not an error. |
+| Unknown JSON token type for body | `UnmarshalJSON` | Return `fmt.Errorf("unexpected body type")`. |
+| Malformed Accept header | `ContentNegotiationCriterion.Score` | Skip malformed media ranges. If all malformed, treat as `*/*`. Never return error. |
+| Missing Accept header | `ContentNegotiationCriterion.Score` | Treat as `*/*` (RFC 7231). |
+| Missing Content-Type on candidate | `ContentNegotiationCriterion.Score` | Treat as `application/octet-stream`. |
+| Malformed Content-Type on candidate | `ContentNegotiationCriterion.Score` | Return 0 (cannot match). |
+| Migration tool: file is not valid Tape JSON | `runMigrateFixtures` | Skip with warning to stderr. |
+| Migration tool: write permission denied | `runMigrateFixtures` | Report error, continue with next file, exit non-zero. |
+
+#### Test strategy
+
+All tests use stdlib `testing` only. Table-driven where appropriate.
+
+**`media_type_test.go`:**
+
+1. `TestParseMediaType`: table-driven with cases:
+   - Standard types: `application/json`, `text/plain`, `image/png`
+   - With parameters: `text/plain; charset=utf-8`, `application/json; charset=utf-8`
+   - With q-value: `text/html;q=0.9`, `application/xml;q=0`
+   - Vendor types: `application/vnd.api+json`, `application/vnd.github.v3+json`
+   - Suffix extraction: `application/vnd.api+json` -> Suffix = "json"
+   - Malformed: empty string, no slash, whitespace-only, `///invalid`
+   - Edge cases: `*/*`, `application/*`, `text/*`
+
+2. `TestParseAccept`: table-driven:
+   - Single type: `application/json`
+   - Multiple types: `application/json, text/html;q=0.9, */*;q=0.1`
+   - Q-value ordering: verify sorted by q desc then specificity desc
+   - Empty/missing: returns `[*/*]`
+   - All malformed: returns `[*/*]`
+   - Mixed valid/malformed: skips malformed, keeps valid
+
+3. `TestIsJSON`: `application/json` (true), `application/vnd.api+json` (true),
+   `application/ld+json` (true), `text/plain` (false), `image/png` (false),
+   `application/xml` (false)
+
+4. `TestIsText`: `text/plain` (true), `text/html` (true), `application/xml`
+   (true), `application/javascript` (true), `application/x-www-form-urlencoded`
+   (true), `application/json` (false -- IsJSON has priority), `image/png`
+   (false)
+
+5. `TestIsBinary`: `image/png` (true), `application/octet-stream` (true),
+   `application/protobuf` (true), empty/unknown (true), `text/plain` (false),
+   `application/json` (false)
+
+6. `TestMatchesMediaRange`: table-driven:
+   - `application/json` matches `application/json` (true)
+   - `application/*` matches `application/json` (true)
+   - `*/*` matches anything (true)
+   - `application/json` does NOT match `application/vnd.api+json` (false)
+   - `text/plain` does NOT match `text/html` (false)
+   - `text/*` matches `text/html` (true)
+
+7. `TestSpecificity`: `application/json` (3), `application/*` (2), `*/*` (1)
+
+**`tape_test.go` -- body marshal/unmarshal tests:**
+
+8. `TestRecordedReq_MarshalJSON_JSONBody`: request with `Content-Type:
+   application/json` and JSON body bytes. Verify the marshaled JSON has
+   `"body": {"key": "value"}` (native object, not string).
+
+9. `TestRecordedReq_MarshalJSON_TextBody`: request with `Content-Type:
+   text/plain` and text body. Verify `"body": "hello world"`.
+
+10. `TestRecordedReq_MarshalJSON_BinaryBody`: request with `Content-Type:
+    image/png` and binary body. Verify `"body": "<base64>"`.
+
+11. `TestRecordedReq_MarshalJSON_NilBody`: body is nil. Verify `"body": null`.
+
+12. `TestRecordedReq_MarshalJSON_EmptyBody`: body is `[]byte{}`. Verify
+    `"body": null`.
+
+13. `TestRecordedReq_MarshalJSON_InvalidJSONWithJSONCT`: Content-Type claims
+    JSON but body is not valid JSON. Verify fallback to base64.
+
+14. `TestRecordedReq_MarshalJSON_VendorJSON`: Content-Type is
+    `application/vnd.api+json`. Verify native JSON output.
+
+15. `TestRecordedResp_MarshalJSON_*`: parallel tests for response (same
+    cases as above, plus SSE tape where body is null and sse_events is set).
+
+16. `TestRecordedReq_UnmarshalJSON_NativeJSON`: fixture with `"body": {"k": "v"}`.
+    Verify `Body` is `[]byte('{"k":"v"}')` (compact JSON).
+
+17. `TestRecordedReq_UnmarshalJSON_StringText`: fixture with `"body": "hello"`.
+    Verify `Body` is `[]byte("hello")`.
+
+18. `TestRecordedReq_UnmarshalJSON_Base64Binary`: fixture with `"body": "AQID"`
+    and binary Content-Type. Verify `Body` is `[]byte{1, 2, 3}`.
+
+19. `TestRecordedReq_UnmarshalJSON_Null`: fixture with `"body": null`. Verify
+    `Body` is nil.
+
+20. `TestRecordedReq_UnmarshalJSON_LegacyBase64JSON`: fixture with
+    `"body": "eyJrIjoidiJ9"` and `Content-Type: application/json`. Verify
+    `Body` is `[]byte('{"k":"v"}')` (base64-decoded).
+
+21. `TestRoundTrip_JSONBody`: marshal -> unmarshal -> marshal, verify output
+    is identical.
+
+22. `TestRoundTrip_TextBody`: same round-trip test for text.
+
+23. `TestRoundTrip_BinaryBody`: same round-trip test for binary.
+
+24. `TestRoundTrip_NilBody`: same round-trip test for nil body.
+
+**`matcher_test.go` -- ContentNegotiationCriterion tests:**
+
+25. `TestContentNegotiationCriterion_ExactMatch`: Accept `application/json`,
+    candidate CT `application/json`. Expect score 5.
+
+26. `TestContentNegotiationCriterion_SubtypeWildcard`: Accept `application/*`,
+    candidate CT `application/json`. Expect score 4.
+
+27. `TestContentNegotiationCriterion_FullWildcard`: Accept `*/*`, candidate CT
+    `application/json`. Expect score 3.
+
+28. `TestContentNegotiationCriterion_NoMatch`: Accept `text/html`, candidate
+    CT `application/json`. Expect score 0.
+
+29. `TestContentNegotiationCriterion_QValueZeroExcludes`: Accept
+    `application/json;q=0, text/html`. Candidate CT `application/json`.
+    Expect score 0.
+
+30. `TestContentNegotiationCriterion_MissingAccept`: no Accept header.
+    Candidate CT `application/json`. Expect score 3 (treated as `*/*`).
+
+31. `TestContentNegotiationCriterion_MissingContentType`: Accept
+    `application/json`. Candidate has no Content-Type. Expect score 0
+    (treated as `application/octet-stream`, which doesn't match
+    `application/json`).
+
+32. `TestContentNegotiationCriterion_MalformedAccept`: Accept header is
+    garbage. Expect score 3 (treated as `*/*` since all ranges malformed).
+
+33. `TestContentNegotiationCriterion_MultipleRanges`: Accept
+    `text/html;q=0.9, application/json, */*;q=0.1`. Candidate CT
+    `application/json`. Expect score 5 (exact match with q=1.0).
+
+34. `TestContentNegotiationCriterion_MultiCandidate`: 3 candidates with
+    different Content-Types. Verify the matcher selects the correct one based
+    on Accept header.
+
+35. `TestContentNegotiationCriterion_Name`: verify `Name()` returns
+    `"content_negotiation"`.
+
+**`config_test.go`:**
+
+36. `TestLoadConfig_ContentNegotiationCriterion`: valid config with
+    `content_negotiation` criterion type. Verify loads correctly.
+
+37. `TestConfig_BuildMatcher_ContentNegotiation`: build matcher from config
+    with `content_negotiation`, verify it returns a working matcher.
+
+38. `TestLoadConfig_ContentNegotiationWithPaths`: config with
+    `content_negotiation` + paths. Verify validation error.
+
+**`integration_test.go`:**
+
+39. `TestIntegration_ContentTypeBodyShape`: record a JSON response, verify
+    the saved fixture file has native JSON body. Record a text response,
+    verify string body. Record a binary response, verify base64 body. Load
+    all three, verify replay produces correct bytes.
+
+40. `TestIntegration_ContentNegotiation`: load 3 fixtures for the same path
+    with different response Content-Types (JSON, XML, CSV). Configure matcher
+    with method + path + content_negotiation. Send requests with varying
+    Accept headers. Assert correct fixture selected each time.
+
+**`cmd/httptape/main_test.go`:**
+
+41. `TestMigrateFixtures`: create temp dir with old-format fixture, run
+    `migrate-fixtures`, verify file is updated to new format.
+
+42. `TestMigrateFixtures_AlreadyMigrated`: create temp dir with new-format
+    fixture, run `migrate-fixtures`, verify file is unchanged.
+
+43. `TestMigrateFixtures_InvalidJSON`: create temp dir with non-JSON file,
+    run `migrate-fixtures`, verify it's skipped with no error exit.
+
+#### Alternatives considered
+
+1. **Auto-detect body encoding from content (the original #187 spec):**
+   Inspect the body bytes to determine encoding: try JSON parse, check UTF-8
+   validity, fall back to base64. Rejected because: (a) auto-detection is
+   ambiguous -- a valid UTF-8 string could be text or base64-encoded binary
+   that happens to be valid UTF-8; (b) requires heuristics that can produce
+   surprising results; (c) Content-Type is the authoritative signal for body
+   interpretation in HTTP -- ignoring it in favor of content sniffing is
+   an anti-pattern.
+
+2. **Dual encoding with `body` and `bodyText` fields (WireMock style):**
+   Two separate fields where `body` holds base64 and `bodyText` holds string.
+   Rejected because: (a) two fields for the same concept is confusing; (b)
+   requires choosing which field to populate, which is effectively the same
+   decision as the single-field approach but with more surface area; (c)
+   WireMock's approach was designed for a different context (configuration
+   files, not recorded fixtures).
+
+3. **`body_encoding` field as the dispatch signal (the existing approach,
+   enhanced):** Keep `body_encoding` field, add `"json"` as a third value.
+   When `body_encoding: "json"`, the body field contains native JSON.
+   Rejected because: (a) requires fixture authors to manually set
+   `body_encoding` correctly, which is error-prone; (b) the Content-Type
+   header already contains this information -- duplicating it in a separate
+   field violates DRY; (c) the `body_encoding` field has no behavioral effect
+   on replay (it's informational only), so it's already dead weight.
+
+4. **Separate cycles for body shape and content negotiation:** Ship body
+   shape change as v0.12.0, content negotiation as v0.13.0. Rejected because:
+   (a) both features share the MediaType utility -- building it once is
+   cleaner; (b) both touch fixtures and docs; (c) two sequential breaking
+   changes are more disruptive than one atomic change; (d) the user
+   explicitly requested a combined cycle.
+
+5. **External `mime` package for media type parsing:** Go's stdlib
+   `mime.ParseMediaType` handles parameter parsing but not Accept header
+   splitting or q-value extraction. A third-party package could provide a
+   complete RFC 7231 implementation. Rejected because: (a) stdlib-only
+   constraint in v1; (b) the subset of RFC 7231 needed here is small enough
+   to implement correctly in ~100 lines; (c) `mime.ParseMediaType` handles
+   the hard part (parameter parsing with quoted-strings, escaping, etc.) --
+   we only need to add comma-splitting and q-value extraction.
+
+#### Consequences
+
+**Benefits:**
+
+- **Fixture DX transformation:** JSON API responses are now human-readable
+  in fixture files. Hand-authoring, code review, and git diffs become
+  dramatically easier. This was the blocking issue for integrating httptape
+  into VibeWarden.
+- **Content negotiation support:** multi-format APIs (JSON/XML/CSV) can be
+  mocked with separate fixtures at the same path, selected by Accept header.
+  This is a natural extension of httptape's matching system and enables
+  real-world API mocking patterns.
+- **Shared MediaType utility:** the parsing/classification functions are
+  useful beyond these two features -- future work (e.g., response
+  transformation, conditional body processing) can reuse them.
+- **Migration tool:** existing users can upgrade fixtures mechanically
+  rather than manually editing each file.
+- **Cleaner fixture format:** removing the `body_encoding` field eliminates
+  a redundant, informational-only field that added no value.
+
+**Costs / trade-offs:**
+
+- **Breaking change:** fixture JSON format changes. The `body` field shape
+  is now polymorphic (object, string, or base64 string depending on
+  Content-Type). The `body_encoding` field is removed. All existing fixtures
+  must be migrated. Pre-1.0 status makes this acceptable.
+- **Custom MarshalJSON/UnmarshalJSON complexity:** custom JSON encoding adds
+  code to `tape.go` and requires careful testing. The round-trip property
+  must be verified. Edge cases (invalid JSON despite JSON Content-Type,
+  base64 strings that happen to look like valid JSON) require careful
+  handling.
+- **Migration burden:** every fixture in the repo (and every external user's
+  fixtures) must be migrated. The migration tool mitigates this but is still
+  work. External users pinned to v0.11 who upgrade will need to run the tool.
+- **Variable scoring in ContentNegotiationCriterion:** the 3/4/5 scoring
+  scheme (wildcard/subtype-wildcard/exact) works for the common case but
+  does not handle complex q-value scenarios perfectly. For example, two
+  Accept ranges with different q-values matching the same Content-Type at
+  different specificities could theoretically produce counter-intuitive
+  results. This is acceptable for v0.12.0 -- the scoring is deterministic
+  and correct for all practical use cases.
+
+**Future implications:**
+
+- The multi-Content-Type fixture pattern (JSON + XML + CSV at the same path)
+  becomes idiomatic and can be documented as a first-class feature.
+- `docs/fixtures-authoring.md` needs to be updated every time a new body
+  shape is added (unlikely -- the three shapes cover all practical cases).
+- The `body_encoding` removal is permanent. If a future need arises for
+  explicit encoding hints, a new field with a different design should be
+  considered rather than resurrecting the old one.
+- The `media_type.go` utility surface is public API. Adding new classifiers
+  (e.g., `IsMultipart`) is additive and backward-compatible.
+
+---
+
 ## PM Log
 
 ### 2026-04-16

--- a/doc.go
+++ b/doc.go
@@ -39,13 +39,23 @@
 //   - [MemoryStore]: in-memory storage, ideal for tests.
 //   - [FileStore]: filesystem-backed storage with JSON fixtures.
 //
+// # Fixture format
+//
+// Tape fixtures use Content-Type-aware body serialization: JSON bodies are
+// stored as native JSON objects/arrays, text bodies as JSON strings, and
+// binary bodies as base64-encoded strings. This makes fixtures human-readable
+// and diff-friendly. The body shape is determined by the Content-Type header
+// of the request or response.
+//
 // # Matching
 //
 // The [Matcher] interface controls how incoming requests are matched to
 // recorded tapes. [DefaultMatcher] provides method + path matching via a
 // [CompositeMatcher]. Individual [Criterion] implementations (e.g.,
-// [MethodCriterion], [PathCriterion], [QueryParamsCriterion], [BodyHashCriterion])
-// can be composed for custom matching strategies.
+// [MethodCriterion], [PathCriterion], [QueryParamsCriterion], [BodyHashCriterion],
+// [ContentNegotiationCriterion]) can be composed for custom matching strategies.
+// [ContentNegotiationCriterion] enables multi-format fixtures at the same path,
+// selected by the request's Accept header.
 //
 // # Health endpoints (proxy mode)
 //

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,40 +23,56 @@ func NewTape(route string, req RecordedReq, resp RecordedResp) Tape
 
 ```go
 type RecordedReq struct {
-    Method           string       `json:"method"`
-    URL              string       `json:"url"`
-    Headers          http.Header  `json:"headers"`
-    Body             []byte       `json:"body"`
-    BodyHash         string       `json:"body_hash"`
-    BodyEncoding     BodyEncoding `json:"body_encoding,omitempty"`
-    Truncated        bool         `json:"truncated,omitempty"`
-    OriginalBodySize int64        `json:"original_body_size,omitempty"`
+    Method           string      `json:"method"`
+    URL              string      `json:"url"`
+    Headers          http.Header `json:"headers"`
+    Body             []byte      `json:"-"`
+    BodyHash         string      `json:"body_hash"`
+    Truncated        bool        `json:"truncated,omitempty"`
+    OriginalBodySize int64       `json:"original_body_size,omitempty"`
 }
 ```
+
+Implements `json.Marshaler` and `json.Unmarshaler`. The `Body` field is serialized
+based on the Content-Type header: native JSON for `application/json`, string for `text/*`,
+base64 for binary, and `null` for nil/empty.
 
 ### RecordedResp
 
 ```go
 type RecordedResp struct {
-    StatusCode       int          `json:"status_code"`
-    Headers          http.Header  `json:"headers"`
-    Body             []byte       `json:"body"`
-    BodyEncoding     BodyEncoding `json:"body_encoding,omitempty"`
-    Truncated        bool         `json:"truncated,omitempty"`
-    OriginalBodySize int64        `json:"original_body_size,omitempty"`
+    StatusCode       int         `json:"status_code"`
+    Headers          http.Header `json:"headers"`
+    Body             []byte      `json:"-"`
+    Truncated        bool        `json:"truncated,omitempty"`
+    OriginalBodySize int64       `json:"original_body_size,omitempty"`
+    SSEEvents        []SSEEvent  `json:"sse_events,omitempty"`
 }
 ```
 
-### BodyEncoding
+Implements `json.Marshaler` and `json.Unmarshaler` with the same Content-Type-driven
+body shape as `RecordedReq`.
+
+### MediaType
 
 ```go
-type BodyEncoding string
+type MediaType struct {
+    Type    string            // e.g., "application"
+    Subtype string            // e.g., "json"
+    Suffix  string            // e.g., "json" (from "+json" structured syntax suffix)
+    Params  map[string]string // e.g., {"charset": "utf-8"}
+}
 
-const (
-    BodyEncodingIdentity BodyEncoding = "identity" // UTF-8 text
-    BodyEncodingBase64   BodyEncoding = "base64"   // binary content
-)
+func ParseMediaType(s string) (MediaType, error)
+func ParseAccept(accept string) []MediaType
+func IsJSON(mt MediaType) bool
+func IsText(mt MediaType) bool
+func IsBinary(mt MediaType) bool
+func MatchesMediaRange(accept, contentType MediaType) bool
+func Specificity(mt MediaType) int
 ```
+
+Utilities for Content-Type-driven body encoding and content negotiation matching.
 
 ### Utility
 
@@ -277,6 +293,7 @@ func NewCompositeMatcher(criteria ...Criterion) *CompositeMatcher
 | RouteCriterion | `RouteCriterion{Route: route}` | 1 |
 | HeadersCriterion | `HeadersCriterion{Key: key, Value: value}` | 3 |
 | QueryParamsCriterion | `QueryParamsCriterion{}` | 4 |
+| ContentNegotiationCriterion | `ContentNegotiationCriterion{}` | 3-5 |
 | BodyFuzzyCriterion | `NewBodyFuzzyCriterion(paths ...string) *BodyFuzzyCriterion` | 6 |
 | BodyHashCriterion | `BodyHashCriterion{}` | 8 |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -176,6 +176,41 @@ httptape import --fixtures ./fixtures --input bundle.tar.gz
 cat bundle.tar.gz | httptape import --fixtures ./fixtures
 ```
 
+### migrate-fixtures
+
+Migrate fixtures from v0.11 format (base64-encoded bodies with `body_encoding` field) to v0.12 format (Content-Type-driven body shape).
+
+```bash
+httptape migrate-fixtures [--recursive] <dir>
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--recursive` | `false` | Recurse into subdirectories |
+
+The migration tool:
+- Reads each `.json` file in `<dir>`
+- Skips non-tape JSON files (files that don't parse as valid Tape objects)
+- Decodes base64-encoded bodies using the legacy `body_encoding` field
+- Re-serializes the tape with the new Content-Type-aware body shape
+- Removes the `body_encoding` field
+- Prints a summary of migrated, skipped, and errored files
+
+The tool is idempotent: running it on already-migrated fixtures produces the same output.
+
+**Examples:**
+
+```bash
+# Migrate a flat fixtures directory
+httptape migrate-fixtures ./fixtures
+
+# Migrate recursively (e.g., route-based subdirectories)
+httptape migrate-fixtures --recursive ./fixtures
+
+# Migrate example project fixtures
+httptape migrate-fixtures --recursive ./examples/java-spring-boot/src/test/resources/fixtures/
+```
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/fixtures-authoring.md
+++ b/docs/fixtures-authoring.md
@@ -32,7 +32,7 @@ Every fixture file is a single JSON object with these fields:
     "headers": {
       "Content-Type": ["application/json"]
     },
-    "body": "eyJ1c2VycyI6W3siaWQiOjEsIm5hbWUiOiJBbGljZSJ9XX0="
+    "body": {"users": [{"id": 1, "name": "Alice"}]}
   },
   "metadata": {}
 }
@@ -48,29 +48,34 @@ Every fixture file is a single JSON object with these fields:
 | `request.method` | string | Yes | HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`). |
 | `request.url` | string | Yes | Full URL. The path component is used for matching (e.g., `http://mock/api/users`). |
 | `request.headers` | object | No | Request headers. Each key maps to an array of strings. |
-| `request.body` | string/null | No | Base64-encoded request body, or `null` for bodiless requests. |
+| `request.body` | varies | No | Request body. Shape depends on Content-Type (see below). `null` for bodiless requests. |
 | `request.body_hash` | string | No | Hex-encoded SHA-256 hash of the original request body. Required for `BodyHashCriterion`. |
-| `request.body_encoding` | string | No | `"identity"` for UTF-8 text, `"base64"` for binary. Defaults to identity if omitted. |
 | `response.status_code` | int | Yes | HTTP status code (200, 201, 204, 404, 500, etc.). |
 | `response.headers` | object | No | Response headers. Each key maps to an array of strings. |
-| `response.body` | string/null | No | Base64-encoded response body. |
-| `response.body_encoding` | string | No | Same as request body encoding. |
+| `response.body` | varies | No | Response body. Shape depends on Content-Type (see below). |
 | `metadata` | object | No | Key-value pairs for delay/error simulation. Not used for matching. |
 
-### Body encoding
+### Content-Type-driven body shape (v0.12+)
 
-Go's `encoding/json` handles `[]byte` fields as base64 automatically. When authoring by hand:
+The `body` field's JSON representation depends on the `Content-Type` header:
 
-- **JSON response bodies**: base64-encode the JSON string and set the body field
-- **Text responses**: base64-encode the text
-- **No body** (e.g., 204): set body to `null`
+| Content-Type | Body shape | Example |
+|---|---|---|
+| `application/json`, `+json` suffix | Native JSON object/array | `{"name": "Alice"}` |
+| `text/*`, `application/xml`, `application/javascript` | JSON string | `"Hello, world!"` |
+| Binary (`image/*`, `application/octet-stream`, etc.) | Base64-encoded string | `"aGVsbG8="` |
+| Missing or unknown | Base64-encoded string | `"aGVsbG8="` |
+| Nil or empty body | `null` | `null` |
 
-To base64-encode on the command line:
+This means JSON fixtures are human-readable: response bodies appear as native JSON objects, not opaque base64 strings.
+
+**Migrating from v0.11:** Fixtures created with v0.11 used base64 encoding for all bodies and included a `body_encoding` field. Use the migration tool to convert:
 
 ```bash
-echo -n '{"users":[{"id":1,"name":"Alice"}]}' | base64
-# eyJ1c2VycyI6W3siaWQiOjEsIm5hbWUiOiJBbGljZSJ9XX0=
+httptape migrate-fixtures --recursive ./fixtures
 ```
+
+The migration tool reads each `.json` file, decodes any base64 bodies, removes the `body_encoding` field, and writes the fixture in the new Content-Type-aware format. It is safe to run multiple times (idempotent).
 
 ### URL format and matching
 
@@ -104,16 +109,17 @@ The `request.url` field stores a full URL, but the `DefaultMatcher` (used by the
       "Content-Type": ["application/json"],
       "X-Total-Count": ["42"]
     },
-    "body": "eyJ1c2VycyI6W3siaWQiOjEsIm5hbWUiOiJBbGljZSJ9LHsiaWQiOjIsIm5hbWUiOiJCb2IifV19"
+    "body": {
+      "users": [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"}
+      ]
+    }
   }
 }
 ```
 
-The response body decodes to:
-
-```json
-{"users":[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]}
-```
+The response body is native JSON -- no encoding needed.
 
 ### POST returning created resource (201)
 
@@ -139,15 +145,13 @@ The response body decodes to:
       "Content-Type": ["application/json"],
       "Location": ["/api/users/3"]
     },
-    "body": "eyJpZCI6MywibmFtZSI6IkNoYXJsaWUiLCJjcmVhdGVkX2F0IjoiMjAyNS0wMS0xNVQxMDowMDowMFoifQ=="
+    "body": {
+      "id": 3,
+      "name": "Charlie",
+      "created_at": "2025-01-15T10:00:00Z"
+    }
   }
 }
-```
-
-The response body decodes to:
-
-```json
-{"id":3,"name":"Charlie","created_at":"2025-01-15T10:00:00Z"}
 ```
 
 ### DELETE returning 204 No Content
@@ -202,10 +206,39 @@ The response body decodes to:
       "X-Per-Page": ["10"],
       "Link": ["<http://mock/api/users?page=3&per_page=10>; rel=\"next\""]
     },
-    "body": "eyJ1c2VycyI6W3siaWQiOjExLCJuYW1lIjoiS2FyZW4ifV19"
+    "body": {
+      "users": [{"id": 11, "name": "Karen"}]
+    }
   }
 }
 ```
+
+### GET returning text (text/plain)
+
+**File:** `fixtures/get-health.json`
+
+```json
+{
+  "id": "get-health",
+  "route": "health",
+  "request": {
+    "method": "GET",
+    "url": "http://mock/health",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["text/plain"]
+    },
+    "body": "OK"
+  }
+}
+```
+
+Text bodies are stored as JSON strings -- no base64 encoding needed.
 
 ## Metadata: delay and error simulation
 
@@ -230,7 +263,7 @@ Add a `delay` key with a Go duration string:
     "headers": {
       "Content-Type": ["application/json"]
     },
-    "body": "eyJzdGF0dXMiOiJjb21wbGV0ZSJ9"
+    "body": {"status": "complete"}
   },
   "metadata": {
     "delay": "2s"
@@ -261,7 +294,7 @@ Add an `error` key with a `status` code and optional `body`:
     "headers": {
       "Content-Type": ["application/json"]
     },
-    "body": "eyJvayI6dHJ1ZX0="
+    "body": {"ok": true}
   },
   "metadata": {
     "error": {
@@ -321,7 +354,7 @@ store, err := httptape.NewFileStore(httptape.WithDirectory("./testdata/api-fixtu
 
 **Keep the `route` consistent.** If you plan to filter fixtures by route (e.g., to run tests against a subset), use the same route string across related fixtures.
 
-**Omit optional fields.** Fields like `body_hash`, `body_encoding`, `recorded_at`, and `metadata` can be omitted entirely:
+**Omit optional fields.** Fields like `body_hash`, `recorded_at`, and `metadata` can be omitted entirely:
 
 ```json
 {
@@ -338,20 +371,12 @@ store, err := httptape.NewFileStore(httptape.WithDirectory("./testdata/api-fixtu
     "headers": {
       "Content-Type": ["application/json"]
     },
-    "body": "eyJzdGF0dXMiOiJvayJ9"
+    "body": {"status": "ok"}
   }
 }
 ```
 
-**Base64 helper script.** Create a shell alias for encoding response bodies:
-
-```bash
-alias b64='python3 -c "import sys,base64; print(base64.b64encode(sys.stdin.buffer.read()).decode())"'
-
-# Usage:
-echo -n '{"status":"ok"}' | b64
-# eyJzdGF0dXMiOiJvayJ9
-```
+**Write JSON bodies as native JSON.** Since v0.12, JSON response bodies are written as native JSON objects -- no base64 encoding needed. Just write the JSON inline in the `body` field.
 
 **Validate your fixtures.** Load fixtures with `FileStore` and check for JSON parse errors:
 

--- a/docs/matching.md
+++ b/docs/matching.md
@@ -147,6 +147,27 @@ Using both `BodyFuzzyCriterion` and `BodyHashCriterion` in the same matcher is s
 
 **Score: 6**
 
+### ContentNegotiationCriterion
+
+```go
+httptape.ContentNegotiationCriterion{}
+```
+
+Matches based on RFC 7231 content negotiation: the incoming request's `Accept` header is compared against the tape response's `Content-Type`. This enables multiple fixtures at the same path with different content types (e.g., JSON and XML).
+
+Scoring uses a two-pass algorithm:
+1. **Exclusion pass**: any tape whose Content-Type matches a `q=0` range in Accept is eliminated (score 0).
+2. **Match pass**: the best matching Accept range determines the score based on specificity:
+   - **Exact match** (e.g., `application/json` matches `application/json`): score 5
+   - **Subtype wildcard** (e.g., `application/*` matches `application/json`): score 4
+   - **Full wildcard** (`*/*` matches anything): score 3
+
+If the incoming request has no `Accept` header, the criterion defaults to `*/*` (matches all content types with score 3). Charset and other parameters (except `q`) are ignored.
+
+**Score: 3-5** (variable based on specificity)
+
+**Note:** Using `ContentNegotiationCriterion` alongside `HeadersCriterion{Key: "Accept", ...}` is allowed but redundant.
+
 ## Score weight table
 
 | Criterion | Score | Purpose |
@@ -156,6 +177,7 @@ Using both `BodyFuzzyCriterion` and `BodyHashCriterion` in the same matcher is s
 | PathRegexCriterion | 1 | Regex URL path |
 | RouteCriterion | 1 | Route label |
 | HeadersCriterion | 3 | Header key-value |
+| ContentNegotiationCriterion | 3-5 | Accept/Content-Type |
 | QueryParamsCriterion | 4 | Query parameters |
 | BodyFuzzyCriterion | 6 | Partial body fields |
 | BodyHashCriterion | 8 | Exact body hash |
@@ -198,6 +220,18 @@ matcher := httptape.NewCompositeMatcher(
     httptape.HeadersCriterion{Key: "Accept", Value: "application/vnd.api.v2+json"},
 )
 ```
+
+### Method + path + content negotiation (multi-format APIs)
+
+```go
+matcher := httptape.NewCompositeMatcher(
+    httptape.MethodCriterion{},
+    httptape.PathCriterion{},
+    httptape.ContentNegotiationCriterion{},
+)
+```
+
+This pattern enables multiple fixtures at the same endpoint that return different content types. For example, `GET /api/data` could have a JSON fixture and an XML fixture, selected based on the client's `Accept` header.
 
 ### Method + regex path + fuzzy body (complex POST APIs)
 

--- a/examples/java-spring-boot/README.md
+++ b/examples/java-spring-boot/README.md
@@ -16,6 +16,18 @@ The service calls an LLM via OpenAI's chat completions API. Tests serve a hand-c
 
 The service also calls a regular REST endpoint via Spring's modern `RestClient`. Same Testcontainers + httptape pattern, recorded JSON fixtures.
 
+## Note on httptape version
+
+This demo currently **builds httptape from source** (the repo root `Dockerfile`)
+instead of pulling a pre-built image from GHCR. This is because PR
+[#191](https://github.com/VibeWarden/httptape/pull/191) migrated the fixture
+format to the v0.12 content-type-aware body shape, which is not readable by
+older published images (v0.10.1 and below).
+
+Once v0.12.0 is tagged and pushed to GHCR, a follow-up PR will swap both
+`TestcontainersConfig.java` and `docker-compose.yml` back to
+`ghcr.io/vibewarden/httptape:0.12.0`.
+
 ## Prerequisites
 
 - **Docker** (for Testcontainers and the optional `docker compose` flow)

--- a/examples/java-spring-boot/docker-compose.yml
+++ b/examples/java-spring-boot/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   httptape:
-    image: ghcr.io/vibewarden/httptape:0.10.1
+    # Builds httptape from source so the demo exercises the matcher code in
+    # this checkout. Once v0.12.0 ships to GHCR, swap back to:
+    #   image: ghcr.io/vibewarden/httptape:0.12.0
+    build:
+      context: ../..
+      dockerfile: Dockerfile
     command: ["serve", "--fixtures", "/fixtures", "--sse-timing=realtime"]
     volumes:
       # All fixtures must be in a single flat directory for FileStore.

--- a/examples/java-spring-boot/src/test/java/dev/httptape/demo/TestcontainersConfig.java
+++ b/examples/java-spring-boot/src/test/java/dev/httptape/demo/TestcontainersConfig.java
@@ -3,6 +3,7 @@ package dev.httptape.demo;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -14,6 +15,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.MountableFile;
 
 /**
@@ -32,6 +34,13 @@ import org.testcontainers.utility.MountableFile;
  *
  * <p>Integration tests import this configuration via
  * {@code @Import(TestcontainersConfig.class)}.
+ *
+ * <p><strong>Build-from-source note:</strong> The container currently builds
+ * httptape from source so the demo always exercises the matcher code in this
+ * checkout. This is needed while PR #191 (v0.12.0 content-type awareness) is
+ * in flight — the migrated fixture format is not readable by older published
+ * images. Once v0.12.0 ships to GHCR, swap back to
+ * {@code ghcr.io/vibewarden/httptape:0.12.0}.
  */
 @TestConfiguration(proxyBeanMethods = false)
 class TestcontainersConfig {
@@ -40,10 +49,19 @@ class TestcontainersConfig {
      * A single httptape container serving every {@code .json} fixture found
      * on the classpath under {@code fixtures/**}. Realtime SSE timing for a
      * realistic streaming experience.
+     *
+     * <p>Builds httptape from source (repo root) so the demo exercises the
+     * matcher code in this checkout. Once v0.12.0 ships to GHCR, swap back
+     * to {@code ghcr.io/vibewarden/httptape:0.12.0}.
      */
     @Bean
     GenericContainer<?> httptapeContainer() throws IOException {
-        GenericContainer<?> container = new GenericContainer<>("ghcr.io/vibewarden/httptape:0.10.1")
+        Path repoRoot = Paths.get("../..").toAbsolutePath().normalize();
+        ImageFromDockerfile httptapeImage = new ImageFromDockerfile("httptape-test", false)
+                .withFileFromPath(".", repoRoot)
+                .withFileFromPath("Dockerfile", repoRoot.resolve("Dockerfile"));
+
+        GenericContainer<?> container = new GenericContainer<>(httptapeImage)
                 .withCommand("serve", "--fixtures", "/fixtures", "--sse-timing=realtime")
                 .withExposedPorts(8081)
                 .waitingFor(Wait.forHttp("/").forStatusCode(404));

--- a/examples/java-spring-boot/src/test/resources/fixtures/openai/chat-completion-headphones.json
+++ b/examples/java-spring-boot/src/test/resources/fixtures/openai/chat-completion-headphones.json
@@ -6,8 +6,12 @@
     "method": "POST",
     "url": "/v1/chat/completions",
     "headers": {
-      "Content-Type": ["application/json"],
-      "Authorization": ["Bearer sk-placeholder"]
+      "Authorization": [
+        "Bearer sk-placeholder"
+      ],
+      "Content-Type": [
+        "application/json"
+      ]
     },
     "body": null,
     "body_hash": ""
@@ -15,9 +19,15 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["text/event-stream"],
-      "Cache-Control": ["no-cache"],
-      "Connection": ["keep-alive"]
+      "Cache-Control": [
+        "no-cache"
+      ],
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "text/event-stream"
+      ]
     },
     "body": null,
     "sse_events": [

--- a/examples/java-spring-boot/src/test/resources/fixtures/users/get-user-1.json
+++ b/examples/java-spring-boot/src/test/resources/fixtures/users/get-user-1.json
@@ -12,8 +12,14 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJpZCI6MSwibmFtZSI6IkFsaWNlIEpvaG5zb24iLCJlbWFpbCI6ImFsaWNlQGV4YW1wbGUuY29tIn0="
+    "body": {
+      "id": 1,
+      "name": "Alice Johnson",
+      "email": "alice@example.com"
+    }
   }
 }

--- a/examples/java-spring-boot/src/test/resources/fixtures/users/get-user-999.json
+++ b/examples/java-spring-boot/src/test/resources/fixtures/users/get-user-999.json
@@ -12,8 +12,12 @@
   "response": {
     "status_code": 404,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJlcnJvciI6InVzZXIgbm90IGZvdW5kIn0="
+    "body": {
+      "error": "user not found"
+    }
   }
 }

--- a/examples/java-spring-boot/src/test/resources/fixtures/users/get-users.json
+++ b/examples/java-spring-boot/src/test/resources/fixtures/users/get-users.json
@@ -12,8 +12,21 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "W3siaWQiOjEsIm5hbWUiOiJBbGljZSBKb2huc29uIiwiZW1haWwiOiJhbGljZUBleGFtcGxlLmNvbSJ9LHsiaWQiOjIsIm5hbWUiOiJCb2IgU21pdGgiLCJlbWFpbCI6ImJvYkBleGFtcGxlLmNvbSJ9XQ=="
+    "body": [
+      {
+        "id": 1,
+        "name": "Alice Johnson",
+        "email": "alice@example.com"
+      },
+      {
+        "id": 2,
+        "name": "Bob Smith",
+        "email": "bob@example.com"
+      }
+    ]
   }
 }

--- a/examples/kotlin-ktor-koog/README.md
+++ b/examples/kotlin-ktor-koog/README.md
@@ -35,13 +35,22 @@ This demo exercises the matcher composition stack from #178, #179, and #180:
 - **#179 (Criterion interface)**: `MethodCriterion`, `PathCriterion`, and `BodyFuzzyCriterion` implement the `Criterion` interface.
 - **#180 (declarative config)**: The `httptape.config.json` file declares the `CompositeMatcher` with all three criteria. No Go code changes needed -- the config drives the matching.
 
-## httptape version requirement
+## Note on httptape version
 
-This demo uses the `--config` flag for `serve` mode (declarative matcher composition,
-introduced in [PR #184](https://github.com/VibeWarden/httptape/pull/184)) — first
-shipped in **httptape v0.11.0**. The demo pulls `ghcr.io/vibewarden/httptape:0.11.0`
-in both `HttptapeContainer.kt` and `docker-compose.yml`. Earlier releases (v0.10.1
-and below) do not have `--config` support and will fail with the agent looping.
+This demo currently **builds httptape from source** (the repo root `Dockerfile`)
+instead of pulling a pre-built image from GHCR. This is because PR
+[#191](https://github.com/VibeWarden/httptape/pull/191) migrated the fixture
+format to the v0.12 content-type-aware body shape, which is not readable by
+older published images (v0.11.0 and below).
+
+Once v0.12.0 is tagged and pushed to GHCR, a follow-up PR will swap both
+`HttptapeContainer.kt` and `docker-compose.yml` back to
+`ghcr.io/vibewarden/httptape:0.12.0`.
+
+The demo also requires the `--config` flag for `serve` mode (declarative matcher
+composition, introduced in [PR #184](https://github.com/VibeWarden/httptape/pull/184)),
+first shipped in **httptape v0.11.0**. Earlier releases (v0.10.1 and below) do not
+have `--config` support and will fail with the agent looping.
 
 ## Prerequisites
 
@@ -118,7 +127,7 @@ IDE users: open [`api.http`](./api.http) -- IntelliJ's HTTP Client and VS Code's
 | Kotest | 6.1.11 (FreeSpec) |
 | Testcontainers | 2.0.4 (single shared container) |
 | Gradle | 9.4.1 (wrapper committed) |
-| httptape | v0.11.0 (`ghcr.io/vibewarden/httptape:0.11.0`) |
+| httptape | built from source (v0.12.0-dev, see [version note](#note-on-httptape-version)) |
 
 ## Why not...?
 

--- a/examples/kotlin-ktor-koog/docker-compose.yml
+++ b/examples/kotlin-ktor-koog/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   httptape:
-    image: ghcr.io/vibewarden/httptape:0.11.0
+    # Builds httptape from source so the demo exercises the matcher code in
+    # this checkout. Once v0.12.0 ships to GHCR, swap back to:
+    #   image: ghcr.io/vibewarden/httptape:0.12.0
+    build:
+      context: ../..
+      dockerfile: Dockerfile
     command: ["serve", "--fixtures", "/fixtures", "--config", "/config/httptape.config.json"]
     volumes:
       - ./src/test/resources/fixtures/openai/chat-1.json:/fixtures/chat-1.json:ro

--- a/examples/kotlin-ktor-koog/src/test/kotlin/dev/httptape/demo/HttptapeContainer.kt
+++ b/examples/kotlin-ktor-koog/src/test/kotlin/dev/httptape/demo/HttptapeContainer.kt
@@ -2,7 +2,9 @@ package dev.httptape.demo
 
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.ImageFromDockerfile
 import org.testcontainers.utility.MountableFile
+import java.nio.file.Paths
 
 /**
  * JVM-singleton httptape container shared across all test classes.
@@ -12,11 +14,23 @@ import org.testcontainers.utility.MountableFile
  * serves three fixture files and uses a declarative matcher config that
  * distinguishes the two POST /v1/chat/completions requests via
  * `body_fuzzy` on `$.messages[*].role`.
+ *
+ * **Build-from-source note:** The container currently builds httptape from
+ * source so the demo always exercises the matcher code in this checkout.
+ * This is needed while PR #191 (v0.12.0 content-type awareness) is in
+ * flight -- the migrated fixture format is not readable by older published
+ * images. Once v0.12.0 ships to GHCR, swap back to
+ * `ghcr.io/vibewarden/httptape:0.12.0`.
  */
 object HttptapeContainer {
 
     val instance: GenericContainer<*> by lazy {
-        GenericContainer("ghcr.io/vibewarden/httptape:0.11.0")
+        val repoRoot = Paths.get("../..").toAbsolutePath().normalize()
+        val httptapeImage = ImageFromDockerfile("httptape-test", false)
+            .withFileFromPath(".", repoRoot)
+            .withFileFromPath("Dockerfile", repoRoot.resolve("Dockerfile"))
+
+        GenericContainer(httptapeImage)
             .withCommand(
                 "serve",
                 "--fixtures", "/fixtures",
@@ -25,7 +39,7 @@ object HttptapeContainer {
             .withExposedPorts(8081)
             .waitingFor(Wait.forHttp("/").forStatusCode(404))
             .apply {
-                // Mount fixtures — flatten subdirectories into /fixtures/
+                // Mount fixtures -- flatten subdirectories into /fixtures/
                 copyFixture("fixtures/openai/chat-1.json")
                 copyFixture("fixtures/openai/chat-2.json")
                 copyFixture("fixtures/weather/weather-berlin.json")

--- a/examples/kotlin-ktor-koog/src/test/resources/fixtures/openai/chat-1.json
+++ b/examples/kotlin-ktor-koog/src/test/resources/fixtures/openai/chat-1.json
@@ -6,17 +6,63 @@
     "method": "POST",
     "url": "/v1/chat/completions",
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJtb2RlbCI6ImdwdC00by1taW5pIiwibWVzc2FnZXMiOlt7InJvbGUiOiJzeXN0ZW0iLCJjb250ZW50IjoiWW91IGFyZSBhIGhlbHBmdWwgd2VhdGhlciBhZHZpc29yLiJ9LHsicm9sZSI6InVzZXIiLCJjb250ZW50IjoiV2hhdCdzIHRoZSB3ZWF0aGVyIGluIEJlcmxpbj8gU2hvdWxkIEkgYnJpbmcgYW4gdW1icmVsbGE/In1dLCJzdHJlYW0iOmZhbHNlfQ==",
+    "body": {
+      "model": "gpt-4o-mini",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You are a helpful weather advisor."
+        },
+        {
+          "role": "user",
+          "content": "What's the weather in Berlin? Should I bring an umbrella?"
+        }
+      ],
+      "stream": false
+    },
     "body_hash": ""
   },
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJpZCI6ImNoYXRjbXBsLXRjMSIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbiIsImNyZWF0ZWQiOjE3MTMyNjQwMDAsIm1vZGVsIjoiZ3B0LTRvLW1pbmkiLCJjaG9pY2VzIjpbeyJpbmRleCI6MCwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6bnVsbCwidG9vbF9jYWxscyI6W3siaWQiOiJjYWxsX3dlYXRoZXJfMSIsInR5cGUiOiJmdW5jdGlvbiIsImZ1bmN0aW9uIjp7Im5hbWUiOiJnZXRXZWF0aGVyIiwiYXJndW1lbnRzIjoie1wiY2l0eVwiOlwiQmVybGluXCJ9In19XX0sImZpbmlzaF9yZWFzb24iOiJ0b29sX2NhbGxzIn1dLCJ1c2FnZSI6eyJwcm9tcHRfdG9rZW5zIjo1MCwiY29tcGxldGlvbl90b2tlbnMiOjIwLCJ0b3RhbF90b2tlbnMiOjcwfX0=",
-    "body_hash": ""
+    "body": {
+      "id": "chatcmpl-tc1",
+      "object": "chat.completion",
+      "created": 1713264000,
+      "model": "gpt-4o-mini",
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [
+              {
+                "id": "call_weather_1",
+                "type": "function",
+                "function": {
+                  "name": "getWeather",
+                  "arguments": "{\"city\":\"Berlin\"}"
+                }
+              }
+            ]
+          },
+          "finish_reason": "tool_calls"
+        }
+      ],
+      "usage": {
+        "prompt_tokens": 50,
+        "completion_tokens": 20,
+        "total_tokens": 70
+      }
+    }
   }
 }

--- a/examples/kotlin-ktor-koog/src/test/resources/fixtures/openai/chat-2.json
+++ b/examples/kotlin-ktor-koog/src/test/resources/fixtures/openai/chat-2.json
@@ -6,17 +6,72 @@
     "method": "POST",
     "url": "/v1/chat/completions",
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJtb2RlbCI6ImdwdC00by1taW5pIiwibWVzc2FnZXMiOlt7InJvbGUiOiJzeXN0ZW0iLCJjb250ZW50IjoiWW91IGFyZSBhIGhlbHBmdWwgd2VhdGhlciBhZHZpc29yLiJ9LHsicm9sZSI6InVzZXIiLCJjb250ZW50IjoiV2hhdCdzIHRoZSB3ZWF0aGVyIGluIEJlcmxpbj8gU2hvdWxkIEkgYnJpbmcgYW4gdW1icmVsbGE/In0seyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6bnVsbCwidG9vbF9jYWxscyI6W3siaWQiOiJjYWxsX3dlYXRoZXJfMSIsInR5cGUiOiJmdW5jdGlvbiIsImZ1bmN0aW9uIjp7Im5hbWUiOiJnZXRXZWF0aGVyIiwiYXJndW1lbnRzIjoie1wiY2l0eVwiOlwiQmVybGluXCJ9In19XX0seyJyb2xlIjoidG9vbCIsInRvb2xfY2FsbF9pZCI6ImNhbGxfd2VhdGhlcl8xIiwiY29udGVudCI6IntcImNpdHlcIjpcIkJlcmxpblwiLFwidGVtcFwiOjEyLFwiY29uZGl0aW9uXCI6XCJyYWluXCIsXCJodW1pZGl0eVwiOjgyLFwid2luZF9rcGhcIjoxNSxcImZlZWxzX2xpa2VcIjo5fSJ9XSwic3RyZWFtIjpmYWxzZX0=",
+    "body": {
+      "model": "gpt-4o-mini",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You are a helpful weather advisor."
+        },
+        {
+          "role": "user",
+          "content": "What's the weather in Berlin? Should I bring an umbrella?"
+        },
+        {
+          "role": "assistant",
+          "content": null,
+          "tool_calls": [
+            {
+              "id": "call_weather_1",
+              "type": "function",
+              "function": {
+                "name": "getWeather",
+                "arguments": "{\"city\":\"Berlin\"}"
+              }
+            }
+          ]
+        },
+        {
+          "role": "tool",
+          "tool_call_id": "call_weather_1",
+          "content": "{\"city\":\"Berlin\",\"temp\":12,\"condition\":\"rain\",\"humidity\":82,\"wind_kph\":15,\"feels_like\":9}"
+        }
+      ],
+      "stream": false
+    },
     "body_hash": ""
   },
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJpZCI6ImNoYXRjbXBsLXRjMiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbiIsImNyZWF0ZWQiOjE3MTMyNjQwMDIsIm1vZGVsIjoiZ3B0LTRvLW1pbmkiLCJjaG9pY2VzIjpbeyJpbmRleCI6MCwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6IkJhc2VkIG9uIHRoZSB3ZWF0aGVyIGluIEJlcmxpbiwgeWVzLCBicmluZyBhbiB1bWJyZWxsYS4gSXQgaXMgY3VycmVudGx5IHJhaW5pbmcgd2l0aCBhIHRlbXBlcmF0dXJlIG9mIDEyIGRlZ3JlZXMgQ2Vsc2l1cyBhbmQgaGlnaCBodW1pZGl0eSBhdCA4MiUuIn0sImZpbmlzaF9yZWFzb24iOiJzdG9wIn1dLCJ1c2FnZSI6eyJwcm9tcHRfdG9rZW5zIjoxMjAsImNvbXBsZXRpb25fdG9rZW5zIjozNSwidG90YWxfdG9rZW5zIjoxNTV9fQ==",
-    "body_hash": ""
+    "body": {
+      "id": "chatcmpl-tc2",
+      "object": "chat.completion",
+      "created": 1713264002,
+      "model": "gpt-4o-mini",
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": "Based on the weather in Berlin, yes, bring an umbrella. It is currently raining with a temperature of 12 degrees Celsius and high humidity at 82%."
+          },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "prompt_tokens": 120,
+        "completion_tokens": 35,
+        "total_tokens": 155
+      }
+    }
   }
 }

--- a/examples/kotlin-ktor-koog/src/test/resources/fixtures/weather/weather-berlin.json
+++ b/examples/kotlin-ktor-koog/src/test/resources/fixtures/weather/weather-berlin.json
@@ -12,9 +12,17 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJjaXR5IjoiQmVybGluIiwidGVtcCI6MTIsImNvbmRpdGlvbiI6InJhaW4iLCJodW1pZGl0eSI6ODIsIndpbmRfa3BoIjoxNSwiZmVlbHNfbGlrZSI6OX0=",
-    "body_hash": ""
+    "body": {
+      "city": "Berlin",
+      "temp": 12,
+      "condition": "rain",
+      "humidity": 82,
+      "wind_kph": 15,
+      "feels_like": 9
+    }
   }
 }

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-headphones.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-headphones.json
@@ -12,37 +12,118 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["text/event-stream"],
-      "Cache-Control": ["no-cache"],
-      "Connection": ["keep-alive"]
+      "Cache-Control": [
+        "no-cache"
+      ],
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "text/event-stream"
+      ]
     },
     "body": null,
     "sse_events": [
-      { "offset_ms": 100, "data": "{\"delta\":\"For office\"}" },
-      { "offset_ms": 180, "data": "{\"delta\":\" use, the\"}" },
-      { "offset_ms": 255, "data": "{\"delta\":\" Noise-Cancelling Headphones\"}" },
-      { "offset_ms": 340, "data": "{\"delta\":\" are the\"}" },
-      { "offset_ms": 410, "data": "{\"delta\":\" best pick.\"}" },
-      { "offset_ms": 495, "data": "{\"delta\":\" With 30-hour\"}" },
-      { "offset_ms": 575, "data": "{\"delta\":\" battery life\"}" },
-      { "offset_ms": 650, "data": "{\"delta\":\" and hybrid\"}" },
-      { "offset_ms": 740, "data": "{\"delta\":\" ANC, you\"}" },
-      { "offset_ms": 820, "data": "{\"delta\":\" can focus\"}" },
-      { "offset_ms": 895, "data": "{\"delta\":\" through meetings\"}" },
-      { "offset_ms": 985, "data": "{\"delta\":\" or commutes\"}" },
-      { "offset_ms": 1055, "data": "{\"delta\":\" without hearing\"}" },
-      { "offset_ms": 1140, "data": "{\"delta\":\" coworkers, planes,\"}" },
-      { "offset_ms": 1215, "data": "{\"delta\":\" or cafe\"}" },
-      { "offset_ms": 1300, "data": "{\"delta\":\" noise. They\"}" },
-      { "offset_ms": 1380, "data": "{\"delta\":\" fold flat\"}" },
-      { "offset_ms": 1455, "data": "{\"delta\":\" for travel\"}" },
-      { "offset_ms": 1545, "data": "{\"delta\":\" and the\"}" },
-      { "offset_ms": 1620, "data": "{\"delta\":\" multipoint Bluetooth\"}" },
-      { "offset_ms": 1710, "data": "{\"delta\":\" lets you\"}" },
-      { "offset_ms": 1785, "data": "{\"delta\":\" switch between\"}" },
-      { "offset_ms": 1870, "data": "{\"delta\":\" laptop and\"}" },
-      { "offset_ms": 1940, "data": "{\"delta\":\" phone seamlessly.\"}" },
-      { "offset_ms": 1950, "data": "[DONE]" }
+      {
+        "offset_ms": 100,
+        "data": "{\"delta\":\"For office\"}"
+      },
+      {
+        "offset_ms": 180,
+        "data": "{\"delta\":\" use, the\"}"
+      },
+      {
+        "offset_ms": 255,
+        "data": "{\"delta\":\" Noise-Cancelling Headphones\"}"
+      },
+      {
+        "offset_ms": 340,
+        "data": "{\"delta\":\" are the\"}"
+      },
+      {
+        "offset_ms": 410,
+        "data": "{\"delta\":\" best pick.\"}"
+      },
+      {
+        "offset_ms": 495,
+        "data": "{\"delta\":\" With 30-hour\"}"
+      },
+      {
+        "offset_ms": 575,
+        "data": "{\"delta\":\" battery life\"}"
+      },
+      {
+        "offset_ms": 650,
+        "data": "{\"delta\":\" and hybrid\"}"
+      },
+      {
+        "offset_ms": 740,
+        "data": "{\"delta\":\" ANC, you\"}"
+      },
+      {
+        "offset_ms": 820,
+        "data": "{\"delta\":\" can focus\"}"
+      },
+      {
+        "offset_ms": 895,
+        "data": "{\"delta\":\" through meetings\"}"
+      },
+      {
+        "offset_ms": 985,
+        "data": "{\"delta\":\" or commutes\"}"
+      },
+      {
+        "offset_ms": 1055,
+        "data": "{\"delta\":\" without hearing\"}"
+      },
+      {
+        "offset_ms": 1140,
+        "data": "{\"delta\":\" coworkers, planes,\"}"
+      },
+      {
+        "offset_ms": 1215,
+        "data": "{\"delta\":\" or cafe\"}"
+      },
+      {
+        "offset_ms": 1300,
+        "data": "{\"delta\":\" noise. They\"}"
+      },
+      {
+        "offset_ms": 1380,
+        "data": "{\"delta\":\" fold flat\"}"
+      },
+      {
+        "offset_ms": 1455,
+        "data": "{\"delta\":\" for travel\"}"
+      },
+      {
+        "offset_ms": 1545,
+        "data": "{\"delta\":\" and the\"}"
+      },
+      {
+        "offset_ms": 1620,
+        "data": "{\"delta\":\" multipoint Bluetooth\"}"
+      },
+      {
+        "offset_ms": 1710,
+        "data": "{\"delta\":\" lets you\"}"
+      },
+      {
+        "offset_ms": 1785,
+        "data": "{\"delta\":\" switch between\"}"
+      },
+      {
+        "offset_ms": 1870,
+        "data": "{\"delta\":\" laptop and\"}"
+      },
+      {
+        "offset_ms": 1940,
+        "data": "{\"delta\":\" phone seamlessly.\"}"
+      },
+      {
+        "offset_ms": 1950,
+        "data": "[DONE]"
+      }
     ]
   }
 }

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-hub.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-hub.json
@@ -12,37 +12,118 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["text/event-stream"],
-      "Cache-Control": ["no-cache"],
-      "Connection": ["keep-alive"]
+      "Cache-Control": [
+        "no-cache"
+      ],
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "text/event-stream"
+      ]
     },
     "body": null,
     "sse_events": [
-      { "offset_ms": 100, "data": "{\"delta\":\"The USB-C\"}" },
-      { "offset_ms": 175, "data": "{\"delta\":\" Hub handles\"}" },
-      { "offset_ms": 260, "data": "{\"delta\":\" both needs\"}" },
-      { "offset_ms": 340, "data": "{\"delta\":\" perfectly. The\"}" },
-      { "offset_ms": 415, "data": "{\"delta\":\" 4K HDMI\"}" },
-      { "offset_ms": 500, "data": "{\"delta\":\" output drives\"}" },
-      { "offset_ms": 575, "data": "{\"delta\":\" external monitors\"}" },
-      { "offset_ms": 660, "data": "{\"delta\":\" at full\"}" },
-      { "offset_ms": 735, "data": "{\"delta\":\" resolution, while\"}" },
-      { "offset_ms": 820, "data": "{\"delta\":\" 100W passthrough\"}" },
-      { "offset_ms": 900, "data": "{\"delta\":\" charging keeps\"}" },
-      { "offset_ms": 975, "data": "{\"delta\":\" your laptop\"}" },
-      { "offset_ms": 1060, "data": "{\"delta\":\" powered all\"}" },
-      { "offset_ms": 1135, "data": "{\"delta\":\" day. The\"}" },
-      { "offset_ms": 1220, "data": "{\"delta\":\" built-in SD\"}" },
-      { "offset_ms": 1300, "data": "{\"delta\":\" card reader\"}" },
-      { "offset_ms": 1380, "data": "{\"delta\":\" and three\"}" },
-      { "offset_ms": 1460, "data": "{\"delta\":\" USB-A ports\"}" },
-      { "offset_ms": 1535, "data": "{\"delta\":\" connect all\"}" },
-      { "offset_ms": 1620, "data": "{\"delta\":\" your peripherals\"}" },
-      { "offset_ms": 1700, "data": "{\"delta\":\" without any\"}" },
-      { "offset_ms": 1775, "data": "{\"delta\":\" dongles. At\"}" },
-      { "offset_ms": 1860, "data": "{\"delta\":\" $34.50, it's\"}" },
-      { "offset_ms": 1935, "data": "{\"delta\":\" a no-brainer.\"}" },
-      { "offset_ms": 1950, "data": "[DONE]" }
+      {
+        "offset_ms": 100,
+        "data": "{\"delta\":\"The USB-C\"}"
+      },
+      {
+        "offset_ms": 175,
+        "data": "{\"delta\":\" Hub handles\"}"
+      },
+      {
+        "offset_ms": 260,
+        "data": "{\"delta\":\" both needs\"}"
+      },
+      {
+        "offset_ms": 340,
+        "data": "{\"delta\":\" perfectly. The\"}"
+      },
+      {
+        "offset_ms": 415,
+        "data": "{\"delta\":\" 4K HDMI\"}"
+      },
+      {
+        "offset_ms": 500,
+        "data": "{\"delta\":\" output drives\"}"
+      },
+      {
+        "offset_ms": 575,
+        "data": "{\"delta\":\" external monitors\"}"
+      },
+      {
+        "offset_ms": 660,
+        "data": "{\"delta\":\" at full\"}"
+      },
+      {
+        "offset_ms": 735,
+        "data": "{\"delta\":\" resolution, while\"}"
+      },
+      {
+        "offset_ms": 820,
+        "data": "{\"delta\":\" 100W passthrough\"}"
+      },
+      {
+        "offset_ms": 900,
+        "data": "{\"delta\":\" charging keeps\"}"
+      },
+      {
+        "offset_ms": 975,
+        "data": "{\"delta\":\" your laptop\"}"
+      },
+      {
+        "offset_ms": 1060,
+        "data": "{\"delta\":\" powered all\"}"
+      },
+      {
+        "offset_ms": 1135,
+        "data": "{\"delta\":\" day. The\"}"
+      },
+      {
+        "offset_ms": 1220,
+        "data": "{\"delta\":\" built-in SD\"}"
+      },
+      {
+        "offset_ms": 1300,
+        "data": "{\"delta\":\" card reader\"}"
+      },
+      {
+        "offset_ms": 1380,
+        "data": "{\"delta\":\" and three\"}"
+      },
+      {
+        "offset_ms": 1460,
+        "data": "{\"delta\":\" USB-A ports\"}"
+      },
+      {
+        "offset_ms": 1535,
+        "data": "{\"delta\":\" connect all\"}"
+      },
+      {
+        "offset_ms": 1620,
+        "data": "{\"delta\":\" your peripherals\"}"
+      },
+      {
+        "offset_ms": 1700,
+        "data": "{\"delta\":\" without any\"}"
+      },
+      {
+        "offset_ms": 1775,
+        "data": "{\"delta\":\" dongles. At\"}"
+      },
+      {
+        "offset_ms": 1860,
+        "data": "{\"delta\":\" $34.50, it's\"}"
+      },
+      {
+        "offset_ms": 1935,
+        "data": "{\"delta\":\" a no-brainer.\"}"
+      },
+      {
+        "offset_ms": 1950,
+        "data": "[DONE]"
+      }
     ]
   }
 }

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-keyboard.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-assist-keyboard.json
@@ -12,37 +12,118 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["text/event-stream"],
-      "Cache-Control": ["no-cache"],
-      "Connection": ["keep-alive"]
+      "Cache-Control": [
+        "no-cache"
+      ],
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "text/event-stream"
+      ]
     },
     "body": null,
     "sse_events": [
-      { "offset_ms": 100, "data": "{\"delta\":\"The Wireless\"}" },
-      { "offset_ms": 185, "data": "{\"delta\":\" Keyboard is\"}" },
-      { "offset_ms": 260, "data": "{\"delta\":\" the top\"}" },
-      { "offset_ms": 345, "data": "{\"delta\":\" choice for\"}" },
-      { "offset_ms": 420, "data": "{\"delta\":\" developers. Low-profile\"}" },
-      { "offset_ms": 500, "data": "{\"delta\":\" mechanical switches\"}" },
-      { "offset_ms": 580, "data": "{\"delta\":\" give you\"}" },
-      { "offset_ms": 660, "data": "{\"delta\":\" fast, precise\"}" },
-      { "offset_ms": 735, "data": "{\"delta\":\" typing with\"}" },
-      { "offset_ms": 820, "data": "{\"delta\":\" satisfying tactile\"}" },
-      { "offset_ms": 900, "data": "{\"delta\":\" feedback, and\"}" },
-      { "offset_ms": 975, "data": "{\"delta\":\" the customizable\"}" },
-      { "offset_ms": 1060, "data": "{\"delta\":\" RGB backlight\"}" },
-      { "offset_ms": 1140, "data": "{\"delta\":\" keeps every\"}" },
-      { "offset_ms": 1215, "data": "{\"delta\":\" key visible\"}" },
-      { "offset_ms": 1300, "data": "{\"delta\":\" during late-night\"}" },
-      { "offset_ms": 1375, "data": "{\"delta\":\" coding sessions.\"}" },
-      { "offset_ms": 1460, "data": "{\"delta\":\" At $49.95,\"}" },
-      { "offset_ms": 1540, "data": "{\"delta\":\" it pairs\"}" },
-      { "offset_ms": 1620, "data": "{\"delta\":\" over Bluetooth\"}" },
-      { "offset_ms": 1695, "data": "{\"delta\":\" with up\"}" },
-      { "offset_ms": 1780, "data": "{\"delta\":\" to three\"}" },
-      { "offset_ms": 1860, "data": "{\"delta\":\" devices at\"}" },
-      { "offset_ms": 1935, "data": "{\"delta\":\" once.\"}" },
-      { "offset_ms": 1950, "data": "[DONE]" }
+      {
+        "offset_ms": 100,
+        "data": "{\"delta\":\"The Wireless\"}"
+      },
+      {
+        "offset_ms": 185,
+        "data": "{\"delta\":\" Keyboard is\"}"
+      },
+      {
+        "offset_ms": 260,
+        "data": "{\"delta\":\" the top\"}"
+      },
+      {
+        "offset_ms": 345,
+        "data": "{\"delta\":\" choice for\"}"
+      },
+      {
+        "offset_ms": 420,
+        "data": "{\"delta\":\" developers. Low-profile\"}"
+      },
+      {
+        "offset_ms": 500,
+        "data": "{\"delta\":\" mechanical switches\"}"
+      },
+      {
+        "offset_ms": 580,
+        "data": "{\"delta\":\" give you\"}"
+      },
+      {
+        "offset_ms": 660,
+        "data": "{\"delta\":\" fast, precise\"}"
+      },
+      {
+        "offset_ms": 735,
+        "data": "{\"delta\":\" typing with\"}"
+      },
+      {
+        "offset_ms": 820,
+        "data": "{\"delta\":\" satisfying tactile\"}"
+      },
+      {
+        "offset_ms": 900,
+        "data": "{\"delta\":\" feedback, and\"}"
+      },
+      {
+        "offset_ms": 975,
+        "data": "{\"delta\":\" the customizable\"}"
+      },
+      {
+        "offset_ms": 1060,
+        "data": "{\"delta\":\" RGB backlight\"}"
+      },
+      {
+        "offset_ms": 1140,
+        "data": "{\"delta\":\" keeps every\"}"
+      },
+      {
+        "offset_ms": 1215,
+        "data": "{\"delta\":\" key visible\"}"
+      },
+      {
+        "offset_ms": 1300,
+        "data": "{\"delta\":\" during late-night\"}"
+      },
+      {
+        "offset_ms": 1375,
+        "data": "{\"delta\":\" coding sessions.\"}"
+      },
+      {
+        "offset_ms": 1460,
+        "data": "{\"delta\":\" At $49.95,\"}"
+      },
+      {
+        "offset_ms": 1540,
+        "data": "{\"delta\":\" it pairs\"}"
+      },
+      {
+        "offset_ms": 1620,
+        "data": "{\"delta\":\" over Bluetooth\"}"
+      },
+      {
+        "offset_ms": 1695,
+        "data": "{\"delta\":\" with up\"}"
+      },
+      {
+        "offset_ms": 1780,
+        "data": "{\"delta\":\" to three\"}"
+      },
+      {
+        "offset_ms": 1860,
+        "data": "{\"delta\":\" devices at\"}"
+      },
+      {
+        "offset_ms": 1935,
+        "data": "{\"delta\":\" once.\"}"
+      },
+      {
+        "offset_ms": 1950,
+        "data": "[DONE]"
+      }
     ]
   }
 }

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-product-1.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-product-1.json
@@ -12,8 +12,17 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJpZCI6MSwibmFtZSI6IldpcmVsZXNzIEtleWJvYXJkIiwicHJpY2UiOjQ5Ljk1LCJkZXNjcmlwdGlvbiI6IkNvbXBhY3Qgd2lyZWxlc3Mga2V5Ym9hcmQgd2l0aCBjdXN0b21pemFibGUgUkdCIGJhY2tsaWdodCBhbmQgbG93LXByb2ZpbGUgbWVjaGFuaWNhbCBzd2l0Y2hlcyIsInN0b2NrIjo0MiwiY2F0ZWdvcnkiOiJwZXJpcGhlcmFscyJ9"
+    "body": {
+      "id": 1,
+      "name": "Wireless Keyboard",
+      "price": 49.95,
+      "description": "Compact wireless keyboard with customizable RGB backlight and low-profile mechanical switches",
+      "stock": 42,
+      "category": "peripherals"
+    }
   }
 }

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-products.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-products.json
@@ -12,8 +12,29 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "W3siaWQiOjEsIm5hbWUiOiJXaXJlbGVzcyBLZXlib2FyZCIsInByaWNlIjo0OS45NSwiZGVzY3JpcHRpb24iOiJDb21wYWN0IHdpcmVsZXNzIGtleWJvYXJkIHdpdGggY3VzdG9taXphYmxlIFJHQiBiYWNrbGlnaHQgYW5kIGxvdy1wcm9maWxlIG1lY2hhbmljYWwgc3dpdGNoZXMifSx7ImlkIjoyLCJuYW1lIjoiVVNCLUMgSHViIiwicHJpY2UiOjM0LjUwLCJkZXNjcmlwdGlvbiI6IjctaW4tMSBVU0ItQyBodWIgd2l0aCA0SyBIRE1JLCAxMDBXIHBhc3N0aHJvdWdoIGNoYXJnaW5nLCBhbmQgU0QgY2FyZCByZWFkZXIifSx7ImlkIjozLCJuYW1lIjoiTm9pc2UtQ2FuY2VsbGluZyBIZWFkcGhvbmVzIiwicHJpY2UiOjEyOS45NSwiZGVzY3JpcHRpb24iOiJPdmVyLWVhciBoZWFkcGhvbmVzIHdpdGggaHlicmlkIGFjdGl2ZSBub2lzZSBjYW5jZWxsYXRpb24gYW5kIDMwLWhvdXIgYmF0dGVyeSBsaWZlIn1d"
+    "body": [
+      {
+        "id": 1,
+        "name": "Wireless Keyboard",
+        "price": 49.95,
+        "description": "Compact wireless keyboard with customizable RGB backlight and low-profile mechanical switches"
+      },
+      {
+        "id": 2,
+        "name": "USB-C Hub",
+        "price": 34.50,
+        "description": "7-in-1 USB-C hub with 4K HDMI, 100W passthrough charging, and SD card reader"
+      },
+      {
+        "id": 3,
+        "name": "Noise-Cancelling Headphones",
+        "price": 129.95,
+        "description": "Over-ear headphones with hybrid active noise cancellation and 30-hour battery life"
+      }
+    ]
   }
 }

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/get-profile.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/get-profile.json
@@ -12,8 +12,20 @@
   "response": {
     "status_code": 200,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJuYW1lIjoiQWxpY2UgSm9obnNvbiIsImVtYWlsIjoiYWxpY2Uuam9obnNvbkBhY21lLWNvcnAuY29tIiwicGhvbmUiOiIrMS01NTUtODY3LTUzMDkiLCJjYXJkIjp7Im51bWJlciI6IjQ1MzItMDE1OC0yNzM2LTk4NDEiLCJleHBpcnkiOiIwMy8yOCIsImN2diI6Ijg0NyJ9LCJhZGRyZXNzIjoiNzQyIEV2ZXJncmVlbiBUZXJyYWNlLCBTcHJpbmdmaWVsZCJ9"
+    "body": {
+      "name": "Alice Johnson",
+      "email": "alice.johnson@acme-corp.com",
+      "phone": "+1-555-867-5309",
+      "card": {
+        "number": "4532-0158-2736-9841",
+        "expiry": "03/28",
+        "cvv": "847"
+      },
+      "address": "742 Evergreen Terrace, Springfield"
+    }
   }
 }

--- a/examples/ts-frontend-first/mocks/upstream-fixtures/post-cart.json
+++ b/examples/ts-frontend-first/mocks/upstream-fixtures/post-cart.json
@@ -6,7 +6,9 @@
     "method": "POST",
     "url": "/api/cart",
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
     "body": null,
     "body_hash": ""
@@ -14,8 +16,14 @@
   "response": {
     "status_code": 201,
     "headers": {
-      "Content-Type": ["application/json"]
+      "Content-Type": [
+        "application/json"
+      ]
     },
-    "body": "eyJjYXJ0X2lkIjoiY2FydC1hYmMtMTIzIiwiaXRlbXMiOltdLCJjcmVhdGVkX2F0IjoiMjAyNi0wMy0zMFQxMjowMjowMFoifQ=="
+    "body": {
+      "cart_id": "cart-abc-123",
+      "items": [],
+      "created_at": "2026-03-30T12:02:00Z"
+    }
   }
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -904,3 +904,101 @@ func TestIntegration_ConfigDrivenMatcher_BodyFuzzy(t *testing.T) {
 		t.Error("both requests returned the same response; body_fuzzy matching did not distinguish them")
 	}
 }
+
+// TestIntegration_ContentNegotiation_MultiCT tests the content negotiation
+// matching flow: two fixtures at the same path return different Content-Types
+// (JSON vs XML), and the ContentNegotiationCriterion selects the right one
+// based on the Accept header.
+func TestIntegration_ContentNegotiation_MultiCT(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := t.Context()
+
+	// Tape 1: JSON response.
+	tape1 := NewTape("api", RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/api/data",
+		Headers: http.Header{"Accept": {"application/json"}},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"format":"json","value":42}`),
+	})
+	if err := store.Save(ctx, tape1); err != nil {
+		t.Fatalf("save tape1: %v", err)
+	}
+
+	// Tape 2: XML response.
+	tape2 := NewTape("api", RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/api/data",
+		Headers: http.Header{"Accept": {"application/xml"}},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/xml"}},
+		Body:       []byte(`<data><format>xml</format><value>42</value></data>`),
+	})
+	if err := store.Save(ctx, tape2); err != nil {
+		t.Fatalf("save tape2: %v", err)
+	}
+
+	// Build matcher using method + path + content_negotiation.
+	cfg := &Config{
+		Version: "1",
+		Matcher: &MatcherConfig{
+			Criteria: []CriterionConfig{
+				{Type: "method"},
+				{Type: "path"},
+				{Type: "content_negotiation"},
+			},
+		},
+		Rules: []Rule{},
+	}
+
+	matcher, err := cfg.BuildMatcher()
+	if err != nil {
+		t.Fatalf("BuildMatcher: %v", err)
+	}
+
+	srv := NewServer(store, WithMatcher(matcher))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Request with Accept: application/json -- should get JSON tape.
+	req1, _ := http.NewRequest("GET", ts.URL+"/api/data", nil)
+	req1.Header.Set("Accept", "application/json")
+	resp1, err := http.DefaultClient.Do(req1)
+	if err != nil {
+		t.Fatalf("GET (json): %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != 200 {
+		t.Errorf("json status = %d, want 200", resp1.StatusCode)
+	}
+	if !strings.Contains(string(body1), `"format":"json"`) {
+		t.Errorf("json body = %q, want JSON response", string(body1))
+	}
+
+	// Request with Accept: application/xml -- should get XML tape.
+	req2, _ := http.NewRequest("GET", ts.URL+"/api/data", nil)
+	req2.Header.Set("Accept", "application/xml")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("GET (xml): %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != 200 {
+		t.Errorf("xml status = %d, want 200", resp2.StatusCode)
+	}
+	if !strings.Contains(string(body2), "<format>xml</format>") {
+		t.Errorf("xml body = %q, want XML response", string(body2))
+	}
+
+	// Verify they got different responses.
+	if string(body1) == string(body2) {
+		t.Error("both requests returned the same response; content negotiation did not distinguish them")
+	}
+}

--- a/matcher.go
+++ b/matcher.go
@@ -485,6 +485,81 @@ func (c *BodyFuzzyCriterion) Score(req *http.Request, candidate Tape) int {
 // Name returns "body_fuzzy".
 func (c *BodyFuzzyCriterion) Name() string { return "body_fuzzy" }
 
+// ContentNegotiationCriterion selects tapes whose response Content-Type
+// satisfies the incoming request's Accept header, following RFC 7231
+// section 5.3.2 media range matching with specificity-based scoring.
+//
+// Scoring:
+//   - Exact type/subtype match:     5
+//   - Subtype wildcard match:       4
+//   - Full wildcard (*/*) match:    3
+//   - No match:                     0
+//
+// When the request has no Accept header, it is treated as Accept: */*
+// (per RFC 7231 section 5.3.2). When a candidate tape has no response
+// Content-Type header, it is treated as application/octet-stream.
+//
+// If the Accept header contains multiple media ranges, the criterion
+// uses the highest-specificity range that matches the candidate's
+// Content-Type, weighted by q-value. Media ranges with q=0 explicitly
+// exclude the Content-Type.
+//
+// Note: using both ContentNegotiationCriterion and HeadersCriterion with
+// Key="Accept" in the same CompositeMatcher is allowed but almost certainly
+// redundant. ContentNegotiationCriterion performs RFC 7231 media-range
+// matching against the response Content-Type, while HeadersCriterion
+// performs exact string matching on the request header. They test different
+// things and their scores add independently.
+type ContentNegotiationCriterion struct{}
+
+// Score returns 3-5 if the candidate's response Content-Type satisfies the
+// request's Accept header, 0 otherwise.
+func (ContentNegotiationCriterion) Score(req *http.Request, candidate Tape) int {
+	// Parse Accept header from request.
+	acceptStr := req.Header.Get("Accept")
+	acceptRanges := ParseAccept(acceptStr)
+
+	// Parse Content-Type from candidate's response.
+	ctStr := ""
+	if candidate.Response.Headers != nil {
+		ctStr = candidate.Response.Headers.Get("Content-Type")
+	}
+	var ct MediaType
+	if ctStr == "" {
+		ct = MediaType{Type: "application", Subtype: "octet-stream"}
+	} else {
+		var err error
+		ct, err = ParseMediaType(ctStr)
+		if err != nil {
+			return 0 // malformed Content-Type: cannot match
+		}
+	}
+
+	// First pass: check q=0 exclusions. Per RFC 7231, q=0 means the media
+	// type is explicitly not acceptable, regardless of other ranges.
+	for _, ar := range acceptRanges {
+		if ar.QValue == 0 && MatchesMediaRange(ar, ct) {
+			return 0
+		}
+	}
+
+	// Second pass: find the best matching range (sorted by q desc, specificity desc).
+	for _, ar := range acceptRanges {
+		if ar.QValue == 0 {
+			continue
+		}
+		if MatchesMediaRange(ar, ct) {
+			// Map specificity to score: exact=5, subtype-wildcard=4, full-wildcard=3.
+			return Specificity(ar) + 2
+		}
+	}
+
+	return 0 // no range matched
+}
+
+// Name returns "content_negotiation".
+func (ContentNegotiationCriterion) Name() string { return "content_negotiation" }
+
 // CompositeMatcher evaluates a list of Criterion implementations against
 // candidate tapes and returns the highest-scoring match. If all criteria
 // return a positive score for a candidate, the candidate's total score is
@@ -493,14 +568,15 @@ func (c *BodyFuzzyCriterion) Name() string { return "body_fuzzy" }
 //
 // Score weight table for built-in criteria:
 //
-//	MethodCriterion:      1
-//	PathCriterion:        2
-//	RouteCriterion:       1
-//	PathRegexCriterion:   1
-//	HeadersCriterion:     3
-//	QueryParamsCriterion: 4
-//	BodyFuzzyCriterion:   6
-//	BodyHashCriterion:    8
+//	MethodCriterion:               1
+//	PathCriterion:                 2
+//	RouteCriterion:                1
+//	PathRegexCriterion:            1
+//	HeadersCriterion:              3
+//	QueryParamsCriterion:          4
+//	ContentNegotiationCriterion:   3-5
+//	BodyFuzzyCriterion:            6
+//	BodyHashCriterion:             8
 //
 // The original design (ADR-4) used powers-of-two-ish weights so each
 // higher-specificity criterion dominates all lower ones combined. Later

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1938,3 +1938,134 @@ func BenchmarkCompositeMatcher_Match(b *testing.B) {
 		}
 	})
 }
+
+// --- ContentNegotiationCriterion tests ---
+
+func TestContentNegotiationCriterion_Name(t *testing.T) {
+	c := ContentNegotiationCriterion{}
+	if c.Name() != "content_negotiation" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "content_negotiation")
+	}
+}
+
+func TestContentNegotiationCriterion_Score(t *testing.T) {
+	tests := []struct {
+		name      string
+		accept    string // request Accept header
+		ct        string // candidate response Content-Type
+		wantScore int
+	}{
+		{"exact match", "application/json", "application/json", 5},
+		{"exact match with charset", "application/json", "application/json; charset=utf-8", 5},
+		{"subtype wildcard", "application/*", "application/json", 4},
+		{"full wildcard", "*/*", "application/json", 3},
+		{"missing Accept treated as wildcard", "", "application/json", 3},
+		{"missing CT treated as octet-stream", "application/octet-stream", "", 5},
+		{"no match", "text/html", "application/json", 0},
+		{"q=0 excludes", "application/json;q=0, */*", "application/json", 0},
+		{"multi-range best match", "text/html;q=0.9, application/json", "application/json", 5},
+		{"vendor type not matched by application/json", "application/json", "application/vnd.api+json", 0},
+		{"vendor type matched by exact accept", "application/vnd.api+json", "application/vnd.api+json", 5},
+		{"vendor type matched by application/*", "application/*", "application/vnd.api+json", 4},
+		{"text/plain match", "text/plain", "text/plain", 5},
+		{"text wildcard matches text/html", "text/*", "text/html", 4},
+		{"xml match", "application/xml", "application/xml", 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := ContentNegotiationCriterion{}
+
+			req := httptest.NewRequest("GET", "/api/data", nil)
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+
+			tape := Tape{
+				Response: RecordedResp{
+					StatusCode: 200,
+				},
+			}
+			if tt.ct != "" {
+				tape.Response.Headers = http.Header{"Content-Type": {tt.ct}}
+			}
+
+			got := c.Score(req, tape)
+			if got != tt.wantScore {
+				t.Errorf("Score() = %d, want %d", got, tt.wantScore)
+			}
+		})
+	}
+}
+
+func TestContentNegotiationCriterion_MultiCandidate(t *testing.T) {
+	jsonTape := Tape{
+		ID: "json-tape",
+		Request: RecordedReq{
+			Method: "GET",
+			URL:    "http://example.com/users",
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/json"}},
+			Body:       []byte(`{"users":[]}`),
+		},
+	}
+	xmlTape := Tape{
+		ID: "xml-tape",
+		Request: RecordedReq{
+			Method: "GET",
+			URL:    "http://example.com/users",
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/xml"}},
+			Body:       []byte(`<users/>`),
+		},
+	}
+	csvTape := Tape{
+		ID: "csv-tape",
+		Request: RecordedReq{
+			Method: "GET",
+			URL:    "http://example.com/users",
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"text/csv"}},
+			Body:       []byte("id,name\n1,Alice"),
+		},
+	}
+
+	candidates := []Tape{jsonTape, xmlTape, csvTape}
+
+	matcher := NewCompositeMatcher(
+		MethodCriterion{},
+		PathCriterion{},
+		ContentNegotiationCriterion{},
+	)
+
+	tests := []struct {
+		name   string
+		accept string
+		wantID string
+	}{
+		{"accept json", "application/json", "json-tape"},
+		{"accept xml", "application/xml", "xml-tape"},
+		{"accept csv", "text/csv", "csv-tape"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/users", nil)
+			req.Header.Set("Accept", tt.accept)
+
+			tape, ok := matcher.Match(req, candidates)
+			if !ok {
+				t.Fatal("expected match, got none")
+			}
+			if tape.ID != tt.wantID {
+				t.Errorf("matched tape ID = %q, want %q", tape.ID, tt.wantID)
+			}
+		})
+	}
+}

--- a/media_type.go
+++ b/media_type.go
@@ -1,0 +1,212 @@
+package httptape
+
+import (
+	"mime"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// MediaType represents a parsed media type (e.g., "application/json; charset=utf-8").
+// It is a value type with no I/O.
+type MediaType struct {
+	// Type is the top-level type (e.g., "application", "text", "image").
+	Type string
+	// Subtype is the subtype (e.g., "json", "plain", "png").
+	// For structured syntax suffixes, this includes the full subtype
+	// (e.g., "vnd.api+json").
+	Subtype string
+	// Suffix is the structured syntax suffix without the '+' prefix
+	// (e.g., "json" for "application/vnd.api+json"). Empty if no suffix.
+	Suffix string
+	// Params holds media type parameters (e.g., charset=utf-8).
+	// The "q" parameter is extracted into QValue and not included here.
+	Params map[string]string
+	// QValue is the quality factor from the Accept header (0.0-1.0).
+	// Defaults to 1.0 if not specified.
+	QValue float64
+}
+
+// ParseMediaType parses a single media type string (e.g., "application/json;
+// charset=utf-8") into a MediaType. Parameters including q-value are parsed.
+// Returns an error if the string is fundamentally malformed (no "/" separator).
+// Uses mime.ParseMediaType from stdlib internally.
+func ParseMediaType(s string) (MediaType, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return MediaType{}, &mediaTypeError{input: s, reason: "empty media type"}
+	}
+
+	mediaType, params, err := mime.ParseMediaType(s)
+	if err != nil {
+		return MediaType{}, &mediaTypeError{input: s, reason: err.Error()}
+	}
+
+	slashIdx := strings.IndexByte(mediaType, '/')
+	if slashIdx < 0 {
+		return MediaType{}, &mediaTypeError{input: s, reason: "missing '/' separator"}
+	}
+
+	typ := mediaType[:slashIdx]
+	subtype := mediaType[slashIdx+1:]
+
+	// Extract structured syntax suffix (e.g., "+json" from "vnd.api+json").
+	var suffix string
+	if plusIdx := strings.LastIndexByte(subtype, '+'); plusIdx >= 0 {
+		suffix = subtype[plusIdx+1:]
+	}
+
+	// Extract q-value from params.
+	qvalue := 1.0
+	filteredParams := make(map[string]string, len(params))
+	for k, v := range params {
+		if strings.EqualFold(k, "q") {
+			if q, parseErr := strconv.ParseFloat(v, 64); parseErr == nil {
+				if q < 0 {
+					q = 0
+				}
+				if q > 1 {
+					q = 1
+				}
+				qvalue = q
+			}
+			continue
+		}
+		filteredParams[k] = v
+	}
+
+	return MediaType{
+		Type:    typ,
+		Subtype: subtype,
+		Suffix:  suffix,
+		Params:  filteredParams,
+		QValue:  qvalue,
+	}, nil
+}
+
+// ParseAccept parses an Accept header value into a slice of MediaType entries,
+// sorted by precedence (highest q-value first, then specificity descending).
+// Malformed individual media ranges are silently skipped.
+// An empty or missing Accept header returns a single entry for "*/*" with q=1.0.
+func ParseAccept(accept string) []MediaType {
+	accept = strings.TrimSpace(accept)
+	if accept == "" {
+		return []MediaType{{Type: "*", Subtype: "*", QValue: 1.0}}
+	}
+
+	parts := strings.Split(accept, ",")
+	var result []MediaType
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		mt, err := ParseMediaType(part)
+		if err != nil {
+			continue // silently skip malformed entries
+		}
+		result = append(result, mt)
+	}
+
+	if len(result) == 0 {
+		return []MediaType{{Type: "*", Subtype: "*", QValue: 1.0}}
+	}
+
+	// Sort by q-value descending, then specificity descending.
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].QValue != result[j].QValue {
+			return result[i].QValue > result[j].QValue
+		}
+		return Specificity(result[i]) > Specificity(result[j])
+	})
+
+	return result
+}
+
+// IsJSON reports whether the media type represents JSON content.
+// True for: application/json, any type with +json suffix,
+// application/ld+json, application/problem+json, etc.
+func IsJSON(mt MediaType) bool {
+	if mt.Type == "application" && mt.Subtype == "json" {
+		return true
+	}
+	return mt.Suffix == "json"
+}
+
+// IsText reports whether the media type represents human-readable text content.
+// True for: text/*, application/xml, application/javascript,
+// application/x-www-form-urlencoded, any type with +xml suffix.
+// False for types that IsJSON returns true for (JSON is handled separately).
+func IsText(mt MediaType) bool {
+	if IsJSON(mt) {
+		return false
+	}
+	if mt.Type == "text" {
+		return true
+	}
+	if mt.Type == "application" {
+		switch mt.Subtype {
+		case "xml", "javascript", "x-www-form-urlencoded":
+			return true
+		}
+	}
+	if mt.Suffix == "xml" {
+		return true
+	}
+	return false
+}
+
+// IsBinary reports whether the media type represents binary content.
+// Returns true when neither IsJSON nor IsText returns true, or when
+// the media type is empty/unknown. This is the fallback classification.
+func IsBinary(mt MediaType) bool {
+	return !IsJSON(mt) && !IsText(mt)
+}
+
+// MatchesMediaRange reports whether a response Content-Type satisfies an
+// Accept media range. Type and subtype are compared; parameters (except q)
+// are ignored per ADR-41 Q2 resolution. Supports wildcards: */* matches
+// anything, type/* matches any subtype of type.
+func MatchesMediaRange(accept, contentType MediaType) bool {
+	// Full wildcard matches anything.
+	if accept.Type == "*" && accept.Subtype == "*" {
+		return true
+	}
+	// Type must match (case-insensitive, but already lowered by mime.ParseMediaType).
+	if !strings.EqualFold(accept.Type, contentType.Type) {
+		return false
+	}
+	// Subtype wildcard matches any subtype of the same type.
+	if accept.Subtype == "*" {
+		return true
+	}
+	// Exact subtype match.
+	return strings.EqualFold(accept.Subtype, contentType.Subtype)
+}
+
+// Specificity returns a specificity score for a media range:
+//
+//	3 for exact type/subtype (e.g., application/json)
+//	2 for subtype wildcard (e.g., application/*)
+//	1 for full wildcard (*/* )
+//
+// Used to rank among multiple matching media ranges in an Accept header.
+func Specificity(mt MediaType) int {
+	if mt.Type == "*" && mt.Subtype == "*" {
+		return 1
+	}
+	if mt.Subtype == "*" {
+		return 2
+	}
+	return 3
+}
+
+// mediaTypeError describes a media type parsing failure.
+type mediaTypeError struct {
+	input  string
+	reason string
+}
+
+func (e *mediaTypeError) Error() string {
+	return "httptape: invalid media type " + strconv.Quote(e.input) + ": " + e.reason
+}

--- a/media_type_test.go
+++ b/media_type_test.go
@@ -1,0 +1,441 @@
+package httptape
+
+import (
+	"testing"
+)
+
+func TestParseMediaType(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantType    string
+		wantSubtype string
+		wantSuffix  string
+		wantQ       float64
+		wantErr     bool
+	}{
+		{
+			name:        "application/json",
+			input:       "application/json",
+			wantType:    "application",
+			wantSubtype: "json",
+			wantQ:       1.0,
+		},
+		{
+			name:        "text/plain",
+			input:       "text/plain",
+			wantType:    "text",
+			wantSubtype: "plain",
+			wantQ:       1.0,
+		},
+		{
+			name:        "image/png",
+			input:       "image/png",
+			wantType:    "image",
+			wantSubtype: "png",
+			wantQ:       1.0,
+		},
+		{
+			name:        "with charset parameter",
+			input:       "text/plain; charset=utf-8",
+			wantType:    "text",
+			wantSubtype: "plain",
+			wantQ:       1.0,
+		},
+		{
+			name:        "json with charset",
+			input:       "application/json; charset=utf-8",
+			wantType:    "application",
+			wantSubtype: "json",
+			wantQ:       1.0,
+		},
+		{
+			name:        "q-value",
+			input:       "text/html;q=0.9",
+			wantType:    "text",
+			wantSubtype: "html",
+			wantQ:       0.9,
+		},
+		{
+			name:        "q-value zero",
+			input:       "application/xml;q=0",
+			wantType:    "application",
+			wantSubtype: "xml",
+			wantQ:       0.0,
+		},
+		{
+			name:        "vendor json suffix",
+			input:       "application/vnd.api+json",
+			wantType:    "application",
+			wantSubtype: "vnd.api+json",
+			wantSuffix:  "json",
+			wantQ:       1.0,
+		},
+		{
+			name:        "github vendor json",
+			input:       "application/vnd.github.v3+json",
+			wantType:    "application",
+			wantSubtype: "vnd.github.v3+json",
+			wantSuffix:  "json",
+			wantQ:       1.0,
+		},
+		{
+			name:        "xml suffix",
+			input:       "application/atom+xml",
+			wantType:    "application",
+			wantSubtype: "atom+xml",
+			wantSuffix:  "xml",
+			wantQ:       1.0,
+		},
+		{
+			name:        "full wildcard",
+			input:       "*/*",
+			wantType:    "*",
+			wantSubtype: "*",
+			wantQ:       1.0,
+		},
+		{
+			name:        "subtype wildcard",
+			input:       "application/*",
+			wantType:    "application",
+			wantSubtype: "*",
+			wantQ:       1.0,
+		},
+		{
+			name:        "text wildcard",
+			input:       "text/*",
+			wantType:    "text",
+			wantSubtype: "*",
+			wantQ:       1.0,
+		},
+		{
+			name:        "with q-value and charset",
+			input:       "application/json; charset=utf-8; q=0.9",
+			wantType:    "application",
+			wantSubtype: "json",
+			wantQ:       0.9,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mt, err := ParseMediaType(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseMediaType(%q) error = nil, want error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseMediaType(%q) unexpected error: %v", tt.input, err)
+			}
+			if mt.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", mt.Type, tt.wantType)
+			}
+			if mt.Subtype != tt.wantSubtype {
+				t.Errorf("Subtype = %q, want %q", mt.Subtype, tt.wantSubtype)
+			}
+			if tt.wantSuffix != "" && mt.Suffix != tt.wantSuffix {
+				t.Errorf("Suffix = %q, want %q", mt.Suffix, tt.wantSuffix)
+			}
+			if mt.QValue != tt.wantQ {
+				t.Errorf("QValue = %f, want %f", mt.QValue, tt.wantQ)
+			}
+		})
+	}
+}
+
+func TestParseMediaType_ParamsExcludeQ(t *testing.T) {
+	mt, err := ParseMediaType("text/plain; charset=utf-8; q=0.5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := mt.Params["q"]; ok {
+		t.Error("Params should not contain 'q' -- it should be in QValue")
+	}
+	if mt.Params["charset"] != "utf-8" {
+		t.Errorf("Params[charset] = %q, want %q", mt.Params["charset"], "utf-8")
+	}
+	if mt.QValue != 0.5 {
+		t.Errorf("QValue = %f, want 0.5", mt.QValue)
+	}
+}
+
+func TestParseAccept(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantLen    int
+		wantFirst  string // type/subtype of first entry
+		wantFirstQ float64
+	}{
+		{
+			name:       "single type",
+			input:      "application/json",
+			wantLen:    1,
+			wantFirst:  "application/json",
+			wantFirstQ: 1.0,
+		},
+		{
+			name:       "multiple types sorted by q",
+			input:      "text/html;q=0.9, application/json, */*;q=0.1",
+			wantLen:    3,
+			wantFirst:  "application/json",
+			wantFirstQ: 1.0,
+		},
+		{
+			name:       "empty string",
+			input:      "",
+			wantLen:    1,
+			wantFirst:  "*/*",
+			wantFirstQ: 1.0,
+		},
+		{
+			name:       "all malformed",
+			input:      "///invalid, , ",
+			wantLen:    1,
+			wantFirst:  "*/*",
+			wantFirstQ: 1.0,
+		},
+		{
+			name:       "mixed valid and malformed",
+			input:      "application/json, ///invalid, text/html;q=0.5",
+			wantLen:    2,
+			wantFirst:  "application/json",
+			wantFirstQ: 1.0,
+		},
+		{
+			name:       "same q-value sorted by specificity",
+			input:      "*/*;q=0.5, application/*;q=0.5, application/json;q=0.5",
+			wantLen:    3,
+			wantFirst:  "application/json",
+			wantFirstQ: 0.5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseAccept(tt.input)
+			if len(result) != tt.wantLen {
+				t.Fatalf("ParseAccept(%q) returned %d entries, want %d", tt.input, len(result), tt.wantLen)
+			}
+			first := result[0].Type + "/" + result[0].Subtype
+			if first != tt.wantFirst {
+				t.Errorf("first entry = %q, want %q", first, tt.wantFirst)
+			}
+			if result[0].QValue != tt.wantFirstQ {
+				t.Errorf("first q-value = %f, want %f", result[0].QValue, tt.wantFirstQ)
+			}
+		})
+	}
+}
+
+func TestParseAccept_Ordering(t *testing.T) {
+	result := ParseAccept("text/html;q=0.9, application/json, */*;q=0.1")
+	if len(result) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(result))
+	}
+	// Should be: application/json (q=1.0), text/html (q=0.9), */* (q=0.1)
+	expected := []struct {
+		typ, subtype string
+		q            float64
+	}{
+		{"application", "json", 1.0},
+		{"text", "html", 0.9},
+		{"*", "*", 0.1},
+	}
+	for i, e := range expected {
+		if result[i].Type != e.typ || result[i].Subtype != e.subtype {
+			t.Errorf("entry[%d] = %s/%s, want %s/%s", i, result[i].Type, result[i].Subtype, e.typ, e.subtype)
+		}
+		if result[i].QValue != e.q {
+			t.Errorf("entry[%d] q = %f, want %f", i, result[i].QValue, e.q)
+		}
+	}
+}
+
+func TestIsJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input MediaType
+		want  bool
+	}{
+		{"application/json", MediaType{Type: "application", Subtype: "json"}, true},
+		{"vendor +json", MediaType{Type: "application", Subtype: "vnd.api+json", Suffix: "json"}, true},
+		{"ld+json", MediaType{Type: "application", Subtype: "ld+json", Suffix: "json"}, true},
+		{"problem+json", MediaType{Type: "application", Subtype: "problem+json", Suffix: "json"}, true},
+		{"text/plain", MediaType{Type: "text", Subtype: "plain"}, false},
+		{"image/png", MediaType{Type: "image", Subtype: "png"}, false},
+		{"application/xml", MediaType{Type: "application", Subtype: "xml"}, false},
+		{"application/octet-stream", MediaType{Type: "application", Subtype: "octet-stream"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsJSON(tt.input)
+			if got != tt.want {
+				t.Errorf("IsJSON(%+v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input MediaType
+		want  bool
+	}{
+		{"text/plain", MediaType{Type: "text", Subtype: "plain"}, true},
+		{"text/html", MediaType{Type: "text", Subtype: "html"}, true},
+		{"text/csv", MediaType{Type: "text", Subtype: "csv"}, true},
+		{"application/xml", MediaType{Type: "application", Subtype: "xml"}, true},
+		{"application/javascript", MediaType{Type: "application", Subtype: "javascript"}, true},
+		{"application/x-www-form-urlencoded", MediaType{Type: "application", Subtype: "x-www-form-urlencoded"}, true},
+		{"atom+xml suffix", MediaType{Type: "application", Subtype: "atom+xml", Suffix: "xml"}, true},
+		{"application/json", MediaType{Type: "application", Subtype: "json"}, false},
+		{"vendor +json", MediaType{Type: "application", Subtype: "vnd.api+json", Suffix: "json"}, false},
+		{"image/png", MediaType{Type: "image", Subtype: "png"}, false},
+		{"application/octet-stream", MediaType{Type: "application", Subtype: "octet-stream"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsText(tt.input)
+			if got != tt.want {
+				t.Errorf("IsText(%+v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBinary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input MediaType
+		want  bool
+	}{
+		{"image/png", MediaType{Type: "image", Subtype: "png"}, true},
+		{"application/octet-stream", MediaType{Type: "application", Subtype: "octet-stream"}, true},
+		{"application/protobuf", MediaType{Type: "application", Subtype: "protobuf"}, true},
+		{"audio/mpeg", MediaType{Type: "audio", Subtype: "mpeg"}, true},
+		{"video/mp4", MediaType{Type: "video", Subtype: "mp4"}, true},
+		{"empty type", MediaType{}, true},
+		{"text/plain", MediaType{Type: "text", Subtype: "plain"}, false},
+		{"application/json", MediaType{Type: "application", Subtype: "json"}, false},
+		{"application/xml", MediaType{Type: "application", Subtype: "xml"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsBinary(tt.input)
+			if got != tt.want {
+				t.Errorf("IsBinary(%+v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesMediaRange(t *testing.T) {
+	tests := []struct {
+		name        string
+		accept      MediaType
+		contentType MediaType
+		want        bool
+	}{
+		{
+			name:        "exact match",
+			accept:      MediaType{Type: "application", Subtype: "json"},
+			contentType: MediaType{Type: "application", Subtype: "json"},
+			want:        true,
+		},
+		{
+			name:        "subtype wildcard",
+			accept:      MediaType{Type: "application", Subtype: "*"},
+			contentType: MediaType{Type: "application", Subtype: "json"},
+			want:        true,
+		},
+		{
+			name:        "full wildcard",
+			accept:      MediaType{Type: "*", Subtype: "*"},
+			contentType: MediaType{Type: "application", Subtype: "json"},
+			want:        true,
+		},
+		{
+			name:        "full wildcard matches binary",
+			accept:      MediaType{Type: "*", Subtype: "*"},
+			contentType: MediaType{Type: "image", Subtype: "png"},
+			want:        true,
+		},
+		{
+			name:        "no vendor fallback",
+			accept:      MediaType{Type: "application", Subtype: "json"},
+			contentType: MediaType{Type: "application", Subtype: "vnd.api+json", Suffix: "json"},
+			want:        false,
+		},
+		{
+			name:        "text mismatch",
+			accept:      MediaType{Type: "text", Subtype: "plain"},
+			contentType: MediaType{Type: "text", Subtype: "html"},
+			want:        false,
+		},
+		{
+			name:        "text wildcard matches html",
+			accept:      MediaType{Type: "text", Subtype: "*"},
+			contentType: MediaType{Type: "text", Subtype: "html"},
+			want:        true,
+		},
+		{
+			name:        "type mismatch",
+			accept:      MediaType{Type: "text", Subtype: "plain"},
+			contentType: MediaType{Type: "application", Subtype: "json"},
+			want:        false,
+		},
+		{
+			name:        "exact vendor match",
+			accept:      MediaType{Type: "application", Subtype: "vnd.api+json"},
+			contentType: MediaType{Type: "application", Subtype: "vnd.api+json"},
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchesMediaRange(tt.accept, tt.contentType)
+			if got != tt.want {
+				t.Errorf("MatchesMediaRange(%v, %v) = %v, want %v", tt.accept, tt.contentType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpecificity(t *testing.T) {
+	tests := []struct {
+		name  string
+		input MediaType
+		want  int
+	}{
+		{"exact", MediaType{Type: "application", Subtype: "json"}, 3},
+		{"subtype wildcard", MediaType{Type: "application", Subtype: "*"}, 2},
+		{"full wildcard", MediaType{Type: "*", Subtype: "*"}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Specificity(tt.input)
+			if got != tt.want {
+				t.Errorf("Specificity(%+v) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -397,24 +397,18 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	// 6. Detect body encodings.
-	reqBodyEncoding := detectBodyEncoding(req.Header.Get("Content-Type"))
-	respBodyEncoding := detectBodyEncoding(resp.Header.Get("Content-Type"))
-
-	// 7. Build raw tape.
+	// 6. Build raw tape.
 	recordedReq := RecordedReq{
-		Method:       req.Method,
-		URL:          req.URL.String(),
-		Headers:      req.Header.Clone(),
-		Body:         reqBody,
-		BodyHash:     BodyHashFromBytes(reqBody),
-		BodyEncoding: reqBodyEncoding,
+		Method:   req.Method,
+		URL:      req.URL.String(),
+		Headers:  req.Header.Clone(),
+		Body:     reqBody,
+		BodyHash: BodyHashFromBytes(reqBody),
 	}
 	recordedResp := RecordedResp{
-		StatusCode:   resp.StatusCode,
-		Headers:      resp.Header.Clone(),
-		Body:         respBody,
-		BodyEncoding: respBodyEncoding,
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header.Clone(),
+		Body:       respBody,
 	}
 
 	rawTape := NewTape(p.route, recordedReq, recordedResp)
@@ -492,15 +486,12 @@ func (p *Proxy) roundTripSSE(req *http.Request, resp *http.Response, reqBody []b
 	startTime := time.Now()
 	respHeaders := resp.Header.Clone()
 
-	reqBodyEncoding := detectBodyEncoding(req.Header.Get("Content-Type"))
-
 	recordedReq := RecordedReq{
-		Method:       req.Method,
-		URL:          req.URL.String(),
-		Headers:      req.Header.Clone(),
-		Body:         reqBody,
-		BodyHash:     BodyHashFromBytes(reqBody),
-		BodyEncoding: reqBodyEncoding,
+		Method:   req.Method,
+		URL:      req.URL.String(),
+		Headers:  req.Header.Clone(),
+		Body:     reqBody,
+		BodyHash: BodyHashFromBytes(reqBody),
 	}
 
 	var mu sync.Mutex

--- a/recorder.go
+++ b/recorder.go
@@ -304,10 +304,6 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	// Detect body encodings based on Content-Type headers.
-	reqBodyEncoding := detectBodyEncoding(req.Header.Get("Content-Type"))
-	respBodyEncoding := detectBodyEncoding(resp.Header.Get("Content-Type"))
-
 	// Apply body truncation if maxBodySize is set.
 	var reqTruncated, respTruncated bool
 	var reqOrigSize, respOrigSize int64
@@ -338,7 +334,6 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 		Headers:          req.Header.Clone(),
 		Body:             reqBody,
 		BodyHash:         BodyHashFromBytes(reqBody),
-		BodyEncoding:     reqBodyEncoding,
 		Truncated:        reqTruncated,
 		OriginalBodySize: reqOrigSize,
 	}
@@ -346,7 +341,6 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 		StatusCode:       resp.StatusCode,
 		Headers:          resp.Header.Clone(),
 		Body:             respBody,
-		BodyEncoding:     respBodyEncoding,
 		Truncated:        respTruncated,
 		OriginalBodySize: respOrigSize,
 	}
@@ -373,8 +367,6 @@ func (r *Recorder) roundTripSSE(req *http.Request, resp *http.Response, reqBody 
 	var mu sync.Mutex
 	var events []SSEEvent
 
-	reqBodyEncoding := detectBodyEncoding(req.Header.Get("Content-Type"))
-
 	// Apply body truncation to request body if configured.
 	var reqTruncated bool
 	var reqOrigSize int64
@@ -394,7 +386,6 @@ func (r *Recorder) roundTripSSE(req *http.Request, resp *http.Response, reqBody 
 		Headers:          req.Header.Clone(),
 		Body:             reqBody,
 		BodyHash:         BodyHashFromBytes(reqBody),
-		BodyEncoding:     reqBodyEncoding,
 		Truncated:        reqTruncated,
 		OriginalBodySize: reqOrigSize,
 	}

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -1374,47 +1374,10 @@ func BenchmarkRecorderRoundTrip_Sync(b *testing.B) {
 	}
 }
 
-// --- ADR-17: Edge case tests ---
-
-// TestDetectBodyEncoding verifies that detectBodyEncoding classifies
-// Content-Type headers into identity (text) vs base64 (binary).
-func TestDetectBodyEncoding(t *testing.T) {
-	tests := []struct {
-		name        string
-		contentType string
-		want        BodyEncoding
-	}{
-		{"empty", "", BodyEncodingIdentity},
-		{"text/plain", "text/plain", BodyEncodingIdentity},
-		{"text/html", "text/html; charset=utf-8", BodyEncodingIdentity},
-		{"application/json", "application/json", BodyEncodingIdentity},
-		{"json with charset", "application/json; charset=utf-8", BodyEncodingIdentity},
-		{"json suffix", "application/vnd.api+json", BodyEncodingIdentity},
-		{"application/xml", "application/xml", BodyEncodingIdentity},
-		{"xml suffix", "application/atom+xml", BodyEncodingIdentity},
-		{"image/png", "image/png", BodyEncodingBase64},
-		{"image/jpeg", "image/jpeg", BodyEncodingBase64},
-		{"audio/mpeg", "audio/mpeg", BodyEncodingBase64},
-		{"video/mp4", "video/mp4", BodyEncodingBase64},
-		{"octet-stream", "application/octet-stream", BodyEncodingBase64},
-		{"protobuf", "application/protobuf", BodyEncodingBase64},
-		{"grpc", "application/grpc", BodyEncodingBase64},
-		{"x-protobuf", "application/x-protobuf", BodyEncodingBase64},
-		{"unparseable", "///invalid", BodyEncodingIdentity},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := detectBodyEncoding(tt.contentType)
-			if got != tt.want {
-				t.Errorf("detectBodyEncoding(%q) = %q, want %q", tt.contentType, got, tt.want)
-			}
-		})
-	}
-}
+// --- ADR-17/ADR-41: Edge case tests ---
 
 // TestRecorder_BinaryBody verifies that binary response bodies are recorded
-// with BodyEncoding set to base64.
+// and preserved correctly.
 func TestRecorder_BinaryBody(t *testing.T) {
 	binaryData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A} // PNG header
 
@@ -1445,15 +1408,12 @@ func TestRecorder_BinaryBody(t *testing.T) {
 	}
 
 	tape := tapes[0]
-	if tape.Response.BodyEncoding != BodyEncodingBase64 {
-		t.Errorf("response BodyEncoding = %q, want %q", tape.Response.BodyEncoding, BodyEncodingBase64)
-	}
 	if !bytes.Equal(tape.Response.Body, binaryData) {
 		t.Error("binary body not preserved correctly")
 	}
 }
 
-// TestRecorder_TextBody verifies that text response bodies get BodyEncodingIdentity.
+// TestRecorder_TextBody verifies that text response bodies are recorded correctly.
 func TestRecorder_TextBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1479,8 +1439,8 @@ func TestRecorder_TextBody(t *testing.T) {
 	if len(tapes) != 1 {
 		t.Fatalf("expected 1 tape, got %d", len(tapes))
 	}
-	if tapes[0].Response.BodyEncoding != BodyEncodingIdentity {
-		t.Errorf("response BodyEncoding = %q, want %q", tapes[0].Response.BodyEncoding, BodyEncodingIdentity)
+	if string(tapes[0].Response.Body) != `{"ok":true}` {
+		t.Errorf("response body = %q, want %q", string(tapes[0].Response.Body), `{"ok":true}`)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -550,10 +550,9 @@ func TestServer_ReplayBinaryBody(t *testing.T) {
 		Method: "GET",
 		URL:    "/image.png",
 	}, RecordedResp{
-		StatusCode:   200,
-		Headers:      http.Header{"Content-Type": {"image/png"}},
-		Body:         binaryData,
-		BodyEncoding: BodyEncodingBase64,
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"image/png"}},
+		Body:       binaryData,
 	})
 	if err := store.Save(context.Background(), tape); err != nil {
 		t.Fatalf("save tape: %v", err)

--- a/tape.go
+++ b/tape.go
@@ -1,28 +1,15 @@
 package httptape
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
-	"mime"
 	"net/http"
-	"strings"
 	"time"
-)
-
-// BodyEncoding indicates how the body was encoded for storage.
-// "identity" means UTF-8 text stored as-is by JSON marshaling.
-// "base64" means binary content (Go's encoding/json handles this
-// transparently for []byte fields).
-type BodyEncoding string
-
-const (
-	// BodyEncodingIdentity indicates the body is UTF-8 text.
-	BodyEncodingIdentity BodyEncoding = "identity"
-	// BodyEncodingBase64 indicates the body is binary, base64-encoded by
-	// Go's encoding/json marshaler.
-	BodyEncodingBase64 BodyEncoding = "base64"
 )
 
 // Tape represents a single recorded HTTP interaction (request + response pair).
@@ -51,6 +38,13 @@ type Tape struct {
 }
 
 // RecordedReq captures the essential parts of an HTTP request for matching and replay.
+//
+// The Body field is always stored as []byte in Go. When marshaled to JSON,
+// the body representation depends on the Content-Type header:
+//   - JSON Content-Type (application/json, +json suffix): native JSON object/array
+//   - Text Content-Type (text/*, application/xml, etc.): JSON string
+//   - Binary or missing Content-Type: base64-encoded JSON string
+//   - Nil or empty body: JSON null
 type RecordedReq struct {
 	// Method is the HTTP method (GET, POST, etc.).
 	Method string `json:"method"`
@@ -63,15 +57,11 @@ type RecordedReq struct {
 	Headers http.Header `json:"headers"`
 
 	// Body is the full request body bytes. May be nil for bodiless requests.
-	Body []byte `json:"body"`
+	Body []byte `json:"-"`
 
 	// BodyHash is a hex-encoded SHA-256 hash of the original request body.
 	// Used for matching without comparing full bodies.
 	BodyHash string `json:"body_hash"`
-
-	// BodyEncoding describes how the body is encoded in the JSON fixture.
-	// Set automatically by the Recorder based on Content-Type detection.
-	BodyEncoding BodyEncoding `json:"body_encoding,omitempty"`
 
 	// Truncated is true if the body was truncated due to exceeding the
 	// configured maximum body size.
@@ -84,9 +74,11 @@ type RecordedReq struct {
 
 // RecordedResp captures the essential parts of an HTTP response for replay.
 //
-// For SSE (text/event-stream) responses, the discrete events are stored in
-// SSEEvents and Body is nil. The two fields are mutually exclusive by
-// construction: the Recorder populates one or the other, never both.
+// The Body field is always stored as []byte in Go. When marshaled to JSON,
+// the body representation depends on the Content-Type header (same rules as
+// RecordedReq). For SSE (text/event-stream) responses, the discrete events
+// are stored in SSEEvents and Body is nil.
+//
 // During replay, if SSEEvents is non-nil and non-empty the tape is treated
 // as an SSE tape and Body is ignored (even if present).
 type RecordedResp struct {
@@ -97,11 +89,7 @@ type RecordedResp struct {
 	Headers http.Header `json:"headers"`
 
 	// Body is the full response body bytes.
-	Body []byte `json:"body"`
-
-	// BodyEncoding describes how the body is encoded in the JSON fixture.
-	// Set automatically by the Recorder based on Content-Type detection.
-	BodyEncoding BodyEncoding `json:"body_encoding,omitempty"`
+	Body []byte `json:"-"`
 
 	// Truncated is true if the body was truncated due to exceeding the
 	// configured maximum body size, or if an SSE stream was disconnected
@@ -126,6 +114,240 @@ func (r RecordedResp) IsSSE() bool {
 	return len(r.SSEEvents) > 0
 }
 
+// MarshalJSON implements json.Marshaler for RecordedReq.
+// The body field's JSON representation depends on the Content-Type from Headers:
+//   - JSON Content-Type: native JSON value (object/array/primitive)
+//   - Text Content-Type: JSON string (UTF-8)
+//   - Binary or missing Content-Type: base64-encoded JSON string
+//   - Nil or empty body: JSON null
+func (r RecordedReq) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		Method           string      `json:"method"`
+		URL              string      `json:"url"`
+		Headers          http.Header `json:"headers"`
+		Body             any         `json:"body"`
+		BodyHash         string      `json:"body_hash"`
+		Truncated        bool        `json:"truncated,omitempty"`
+		OriginalBodySize int64       `json:"original_body_size,omitempty"`
+	}
+
+	a := alias{
+		Method:           r.Method,
+		URL:              r.URL,
+		Headers:          r.Headers,
+		Body:             nil, // default: null
+		BodyHash:         r.BodyHash,
+		Truncated:        r.Truncated,
+		OriginalBodySize: r.OriginalBodySize,
+	}
+
+	a.Body = marshalBody(r.Body, r.Headers)
+	return json.Marshal(a)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for RecordedReq.
+// It detects the JSON token type of the body field and decodes accordingly:
+//   - JSON object/array: body stored as compact JSON bytes
+//   - JSON string: text or base64 based on Content-Type
+//   - JSON null: body is nil
+func (r *RecordedReq) UnmarshalJSON(data []byte) error {
+	type alias struct {
+		Method           string          `json:"method"`
+		URL              string          `json:"url"`
+		Headers          http.Header     `json:"headers"`
+		Body             json.RawMessage `json:"body"`
+		BodyHash         string          `json:"body_hash"`
+		Truncated        bool            `json:"truncated,omitempty"`
+		OriginalBodySize int64           `json:"original_body_size,omitempty"`
+	}
+
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return fmt.Errorf("unmarshal RecordedReq: %w", err)
+	}
+
+	r.Method = a.Method
+	r.URL = a.URL
+	r.Headers = a.Headers
+	r.BodyHash = a.BodyHash
+	r.Truncated = a.Truncated
+	r.OriginalBodySize = a.OriginalBodySize
+
+	body, err := unmarshalBody(a.Body, a.Headers)
+	if err != nil {
+		return fmt.Errorf("unmarshal RecordedReq body: %w", err)
+	}
+	r.Body = body
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for RecordedResp.
+// The body field's JSON representation depends on the Content-Type from Headers
+// (same rules as RecordedReq.MarshalJSON).
+func (r RecordedResp) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		StatusCode       int        `json:"status_code"`
+		Headers          http.Header `json:"headers"`
+		Body             any         `json:"body"`
+		Truncated        bool        `json:"truncated,omitempty"`
+		OriginalBodySize int64       `json:"original_body_size,omitempty"`
+		SSEEvents        []SSEEvent  `json:"sse_events,omitempty"`
+	}
+
+	a := alias{
+		StatusCode:       r.StatusCode,
+		Headers:          r.Headers,
+		Body:             nil,
+		Truncated:        r.Truncated,
+		OriginalBodySize: r.OriginalBodySize,
+		SSEEvents:        r.SSEEvents,
+	}
+
+	a.Body = marshalBody(r.Body, r.Headers)
+	return json.Marshal(a)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for RecordedResp.
+// It detects the JSON token type of the body field and decodes accordingly
+// (same rules as RecordedReq.UnmarshalJSON).
+func (r *RecordedResp) UnmarshalJSON(data []byte) error {
+	type alias struct {
+		StatusCode       int             `json:"status_code"`
+		Headers          http.Header     `json:"headers"`
+		Body             json.RawMessage `json:"body"`
+		Truncated        bool            `json:"truncated,omitempty"`
+		OriginalBodySize int64           `json:"original_body_size,omitempty"`
+		SSEEvents        []SSEEvent      `json:"sse_events,omitempty"`
+	}
+
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return fmt.Errorf("unmarshal RecordedResp: %w", err)
+	}
+
+	r.StatusCode = a.StatusCode
+	r.Headers = a.Headers
+	r.Truncated = a.Truncated
+	r.OriginalBodySize = a.OriginalBodySize
+	r.SSEEvents = a.SSEEvents
+
+	body, err := unmarshalBody(a.Body, a.Headers)
+	if err != nil {
+		return fmt.Errorf("unmarshal RecordedResp body: %w", err)
+	}
+	r.Body = body
+	return nil
+}
+
+// marshalBody returns the appropriate JSON value for the body field based on
+// the Content-Type from headers. Returns nil for nil/empty bodies.
+func marshalBody(body []byte, headers http.Header) any {
+	if len(body) == 0 {
+		return nil
+	}
+
+	ct := ""
+	if headers != nil {
+		ct = headers.Get("Content-Type")
+	}
+
+	mt, err := ParseMediaType(ct)
+	if err != nil || ct == "" {
+		// Unknown/missing CT: base64
+		return base64.StdEncoding.EncodeToString(body)
+	}
+
+	if IsJSON(mt) {
+		// Verify the body is valid JSON before emitting as native.
+		if json.Valid(body) {
+			return json.RawMessage(body)
+		}
+		// Invalid JSON despite JSON CT: fall back to base64.
+		return base64.StdEncoding.EncodeToString(body)
+	}
+
+	if IsText(mt) {
+		return string(body)
+	}
+
+	// Binary: base64
+	return base64.StdEncoding.EncodeToString(body)
+}
+
+// unmarshalBody decodes the body JSON value based on its token type and the
+// Content-Type from headers. Returns nil for JSON null or missing body.
+func unmarshalBody(raw json.RawMessage, headers http.Header) ([]byte, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+
+	// Determine the JSON token type.
+	firstByte := raw[0]
+
+	switch {
+	case firstByte == '{' || firstByte == '[':
+		// Native JSON object or array: compact to normalize whitespace.
+		// This ensures consistent Body bytes regardless of fixture indentation,
+		// which is critical for BodyHashCriterion and round-trip consistency.
+		var buf bytes.Buffer
+		if err := json.Compact(&buf, []byte(raw)); err != nil {
+			// If compact fails, store the raw bytes as-is.
+			return []byte(raw), nil
+		}
+		return buf.Bytes(), nil
+
+	case firstByte == '"':
+		// JSON string: could be text or base64.
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, fmt.Errorf("decode body string: %w", err)
+		}
+
+		ct := ""
+		if headers != nil {
+			ct = headers.Get("Content-Type")
+		}
+
+		mt, parseErr := ParseMediaType(ct)
+
+		if parseErr == nil && IsJSON(mt) {
+			// JSON CT with string value: could be a legacy base64-encoded body
+			// or a scalar JSON string value.
+			if json.Valid([]byte(s)) {
+				return []byte(s), nil
+			}
+			// Not valid JSON: try base64 decode (legacy fixture).
+			decoded, b64Err := base64.StdEncoding.DecodeString(s)
+			if b64Err == nil {
+				return decoded, nil
+			}
+			// Neither valid JSON nor valid base64: store as UTF-8 bytes.
+			return []byte(s), nil
+		}
+
+		if parseErr == nil && IsText(mt) {
+			// Text CT: store string as UTF-8 bytes.
+			return []byte(s), nil
+		}
+
+		// Binary or unknown CT: base64-decode.
+		decoded, b64Err := base64.StdEncoding.DecodeString(s)
+		if b64Err == nil {
+			return decoded, nil
+		}
+		// Graceful degradation: store as UTF-8 if base64 decode fails.
+		return []byte(s), nil
+
+	case firstByte == 't' || firstByte == 'f':
+		// JSON boolean: unexpected for body, store raw.
+		return raw, nil
+
+	default:
+		// JSON number or other: store raw.
+		return raw, nil
+	}
+}
+
 // NewTape creates a new Tape with a generated ID and the current UTC timestamp.
 func NewTape(route string, req RecordedReq, resp RecordedResp) Tape {
 	return Tape{
@@ -145,34 +367,6 @@ func BodyHashFromBytes(b []byte) string {
 	}
 	h := sha256.Sum256(b)
 	return hex.EncodeToString(h[:])
-}
-
-// detectBodyEncoding returns BodyEncodingBase64 if the Content-Type header
-// indicates a binary content type, otherwise BodyEncodingIdentity.
-// Binary types: image/*, audio/*, video/*, application/octet-stream,
-// application/protobuf, application/grpc, application/x-protobuf,
-// or any type with a non-text, non-json, non-xml primary type.
-func detectBodyEncoding(contentType string) BodyEncoding {
-	if contentType == "" {
-		return BodyEncodingIdentity
-	}
-	mediaType, _, _ := mime.ParseMediaType(contentType)
-	if mediaType == "" {
-		return BodyEncodingIdentity
-	}
-	// Text types are identity.
-	if strings.HasPrefix(mediaType, "text/") {
-		return BodyEncodingIdentity
-	}
-	// JSON and XML are text-like.
-	if mediaType == "application/json" ||
-		strings.HasSuffix(mediaType, "+json") ||
-		mediaType == "application/xml" ||
-		strings.HasSuffix(mediaType, "+xml") {
-		return BodyEncodingIdentity
-	}
-	// Everything else is binary.
-	return BodyEncodingBase64
 }
 
 // newUUID generates a UUID v4 string using crypto/rand.

--- a/tape_test.go
+++ b/tape_test.go
@@ -1,6 +1,9 @@
 package httptape
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -114,5 +117,498 @@ func TestBodyHashFromBytes_Deterministic(t *testing.T) {
 
 	if hash1 != hash2 {
 		t.Errorf("BodyHashFromBytes() not deterministic: %q != %q", hash1, hash2)
+	}
+}
+
+// --- ADR-41: Body marshal/unmarshal tests ---
+
+func TestRecordedReq_MarshalJSON_JSONBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/api",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    []byte(`{"key":"value"}`),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// The body should appear as native JSON, not a string.
+	if !strings.Contains(string(data), `"body":{"key":"value"}`) {
+		t.Errorf("expected native JSON body, got: %s", data)
+	}
+}
+
+func TestRecordedReq_MarshalJSON_TextBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/api",
+		Headers: http.Header{"Content-Type": {"text/plain"}},
+		Body:    []byte("hello world"),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"body":"hello world"`) {
+		t.Errorf("expected text string body, got: %s", data)
+	}
+}
+
+func TestRecordedReq_MarshalJSON_BinaryBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/image",
+		Headers: http.Header{"Content-Type": {"image/png"}},
+		Body:    []byte{0x89, 0x50, 0x4E, 0x47},
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// Should be base64 string "iVBORw==" for {0x89, 0x50, 0x4E, 0x47}.
+	if !strings.Contains(string(data), `"body":"iVBORw=="`) {
+		t.Errorf("expected base64 body, got: %s", data)
+	}
+}
+
+func TestRecordedReq_MarshalJSON_NilBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/api",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    nil,
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"body":null`) {
+		t.Errorf("expected null body, got: %s", data)
+	}
+}
+
+func TestRecordedReq_MarshalJSON_EmptyBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/api",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    []byte{},
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"body":null`) {
+		t.Errorf("expected null body for empty slice, got: %s", data)
+	}
+}
+
+func TestRecordedReq_MarshalJSON_InvalidJSONWithJSONCT(t *testing.T) {
+	r := RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/api",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    []byte("not valid json {{{"),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// Should fall back to base64 since the body is not valid JSON.
+	if strings.Contains(string(data), `"body":"not valid json`) {
+		t.Errorf("expected base64 fallback, but got raw text: %s", data)
+	}
+	// Should still have a "body" field.
+	if !strings.Contains(string(data), `"body":`) {
+		t.Errorf("missing body field: %s", data)
+	}
+}
+
+func TestRecordedReq_MarshalJSON_VendorJSON(t *testing.T) {
+	r := RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/api",
+		Headers: http.Header{"Content-Type": {"application/vnd.api+json"}},
+		Body:    []byte(`{"data":{"type":"users","id":"1"}}`),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// Should emit native JSON for vendor +json types.
+	if !strings.Contains(string(data), `"body":{"data":{"type":"users","id":"1"}}`) {
+		t.Errorf("expected native JSON body for vendor +json, got: %s", data)
+	}
+}
+
+func TestRecordedResp_MarshalJSON_JSONBody(t *testing.T) {
+	r := RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`[1,2,3]`),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"body":[1,2,3]`) {
+		t.Errorf("expected native JSON array body, got: %s", data)
+	}
+}
+
+func TestRecordedResp_MarshalJSON_NilBodyWithSSE(t *testing.T) {
+	r := RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/event-stream"}},
+		Body:       nil,
+		SSEEvents:  []SSEEvent{{Data: "hello"}},
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"body":null`) {
+		t.Errorf("expected null body for SSE tape, got: %s", data)
+	}
+	if !strings.Contains(string(data), `"sse_events"`) {
+		t.Errorf("expected sse_events field, got: %s", data)
+	}
+}
+
+func TestRecordedReq_MarshalJSON_MissingCT(t *testing.T) {
+	r := RecordedReq{
+		Method: "POST",
+		URL:    "http://example.com/api",
+		Body:   []byte("some data"),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// No Content-Type -> binary -> base64.
+	if strings.Contains(string(data), `"body":"some data"`) {
+		t.Errorf("expected base64, got raw text: %s", data)
+	}
+}
+
+// --- Unmarshal tests ---
+
+func TestRecordedReq_UnmarshalJSON_NativeJSON(t *testing.T) {
+	input := `{
+		"method": "POST",
+		"url": "http://example.com/api",
+		"headers": {"Content-Type": ["application/json"]},
+		"body": {"key": "value"},
+		"body_hash": ""
+	}`
+
+	var r RecordedReq
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	// Body should be compact JSON bytes.
+	want := `{"key":"value"}`
+	if string(r.Body) != want {
+		t.Errorf("Body = %q, want %q", string(r.Body), want)
+	}
+}
+
+func TestRecordedReq_UnmarshalJSON_StringText(t *testing.T) {
+	input := `{
+		"method": "POST",
+		"url": "http://example.com/api",
+		"headers": {"Content-Type": ["text/plain"]},
+		"body": "hello world",
+		"body_hash": ""
+	}`
+
+	var r RecordedReq
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if string(r.Body) != "hello world" {
+		t.Errorf("Body = %q, want %q", string(r.Body), "hello world")
+	}
+}
+
+func TestRecordedReq_UnmarshalJSON_Base64Binary(t *testing.T) {
+	// AQID is base64 for []byte{1, 2, 3}
+	input := `{
+		"method": "GET",
+		"url": "http://example.com/image",
+		"headers": {"Content-Type": ["image/png"]},
+		"body": "AQID",
+		"body_hash": ""
+	}`
+
+	var r RecordedReq
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	want := []byte{1, 2, 3}
+	if !bytes.Equal(r.Body, want) {
+		t.Errorf("Body = %v, want %v", r.Body, want)
+	}
+}
+
+func TestRecordedReq_UnmarshalJSON_Null(t *testing.T) {
+	input := `{
+		"method": "GET",
+		"url": "http://example.com/api",
+		"headers": {},
+		"body": null,
+		"body_hash": ""
+	}`
+
+	var r RecordedReq
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if r.Body != nil {
+		t.Errorf("Body = %v, want nil", r.Body)
+	}
+}
+
+func TestRecordedReq_UnmarshalJSON_LegacyBase64JSON(t *testing.T) {
+	// eyJrIjoidiJ9 is base64 for {"k":"v"}
+	input := `{
+		"method": "POST",
+		"url": "http://example.com/api",
+		"headers": {"Content-Type": ["application/json"]},
+		"body": "eyJrIjoidiJ9",
+		"body_hash": ""
+	}`
+
+	var r RecordedReq
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	want := `{"k":"v"}`
+	if string(r.Body) != want {
+		t.Errorf("Body = %q, want %q", string(r.Body), want)
+	}
+}
+
+func TestRecordedReq_UnmarshalJSON_LegacyBodyEncoding(t *testing.T) {
+	// Legacy fixtures may have body_encoding field -- it should be silently ignored.
+	input := `{
+		"method": "POST",
+		"url": "http://example.com/api",
+		"headers": {"Content-Type": ["application/json"]},
+		"body": {"ok": true},
+		"body_hash": "",
+		"body_encoding": "identity"
+	}`
+
+	var r RecordedReq
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	want := `{"ok":true}`
+	if string(r.Body) != want {
+		t.Errorf("Body = %q, want %q", string(r.Body), want)
+	}
+}
+
+func TestRecordedReq_UnmarshalJSON_NativeJSONArray(t *testing.T) {
+	input := `{
+		"method": "POST",
+		"url": "http://example.com/api",
+		"headers": {"Content-Type": ["application/json"]},
+		"body": [1, 2, 3],
+		"body_hash": ""
+	}`
+
+	var r RecordedReq
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	want := `[1,2,3]`
+	if string(r.Body) != want {
+		t.Errorf("Body = %q, want %q", string(r.Body), want)
+	}
+}
+
+// --- Round-trip tests ---
+
+func TestRoundTrip_JSONBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/api",
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Body:    []byte(`{"key":"value","nested":{"a":1}}`),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var r2 RecordedReq
+	if err := json.Unmarshal(data, &r2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !bytes.Equal(r.Body, r2.Body) {
+		t.Errorf("round-trip body mismatch:\n  original: %q\n  result:   %q", string(r.Body), string(r2.Body))
+	}
+}
+
+func TestRoundTrip_TextBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/api",
+		Headers: http.Header{"Content-Type": {"text/plain"}},
+		Body:    []byte("hello world"),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var r2 RecordedReq
+	if err := json.Unmarshal(data, &r2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !bytes.Equal(r.Body, r2.Body) {
+		t.Errorf("round-trip body mismatch:\n  original: %q\n  result:   %q", string(r.Body), string(r2.Body))
+	}
+}
+
+func TestRoundTrip_BinaryBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/image",
+		Headers: http.Header{"Content-Type": {"image/png"}},
+		Body:    []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A},
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var r2 RecordedReq
+	if err := json.Unmarshal(data, &r2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !bytes.Equal(r.Body, r2.Body) {
+		t.Errorf("round-trip body mismatch:\n  original: %v\n  result:   %v", r.Body, r2.Body)
+	}
+}
+
+func TestRoundTrip_NilBody(t *testing.T) {
+	r := RecordedReq{
+		Method:  "GET",
+		URL:     "http://example.com/api",
+		Headers: http.Header{},
+		Body:    nil,
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var r2 RecordedReq
+	if err := json.Unmarshal(data, &r2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if r2.Body != nil {
+		t.Errorf("round-trip nil body: got %v, want nil", r2.Body)
+	}
+}
+
+func TestRoundTrip_Resp_JSONBody(t *testing.T) {
+	r := RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"users":[{"id":1,"name":"Alice"}]}`),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var r2 RecordedResp
+	if err := json.Unmarshal(data, &r2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !bytes.Equal(r.Body, r2.Body) {
+		t.Errorf("round-trip body mismatch:\n  original: %q\n  result:   %q", string(r.Body), string(r2.Body))
+	}
+}
+
+func TestRecordedReq_UnmarshalJSON_FormUrlencoded(t *testing.T) {
+	input := `{
+		"method": "POST",
+		"url": "http://example.com/login",
+		"headers": {"Content-Type": ["application/x-www-form-urlencoded"]},
+		"body": "username=alice&password=secret",
+		"body_hash": ""
+	}`
+
+	var r RecordedReq
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	want := "username=alice&password=secret"
+	if string(r.Body) != want {
+		t.Errorf("Body = %q, want %q", string(r.Body), want)
+	}
+}
+
+func TestRecordedReq_MarshalJSON_FormUrlencoded(t *testing.T) {
+	r := RecordedReq{
+		Method:  "POST",
+		URL:     "http://example.com/login",
+		Headers: http.Header{"Content-Type": {"application/x-www-form-urlencoded"}},
+		Body:    []byte("username=alice&password=secret"),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// Form data is classified as text, should be a JSON string.
+	if !strings.Contains(string(data), `"body":"username=alice\u0026password=secret"`) &&
+		!strings.Contains(string(data), `"body":"username=alice&password=secret"`) {
+		t.Errorf("expected text string body for form data, got: %s", data)
 	}
 }


### PR DESCRIPTION
Closes #187

## Summary

- **Content-Type-driven body shape (Layer 1)**: Custom `MarshalJSON`/`UnmarshalJSON` on `RecordedReq` and `RecordedResp` serialize body fields based on Content-Type header: native JSON for `application/json` (and `+json` suffix types), JSON string for `text/*` and text-like types, base64 string for binary. Removes `BodyEncoding` type, constants, and fields.
- **Shared utility (`media_type.go`)**: `MediaType` struct with `ParseMediaType`, `ParseAccept`, `IsJSON`, `IsText`, `IsBinary`, `MatchesMediaRange`, `Specificity` -- consumed by both tape.go and matcher.go.
- **ContentNegotiationCriterion (Layer 2)**: RFC 7231 Accept/Content-Type matching criterion for `CompositeMatcher`. Two-pass scoring: q=0 exclusion pass, then specificity-based scoring (exact=5, subtype-wildcard=4, full-wildcard=3). Config-driven via `"content_negotiation"` criterion type.
- **`httptape migrate-fixtures` CLI**: Reads v0.11 fixtures (base64 bodies with `body_encoding` field), decodes legacy format, re-serializes with new body shape. Supports `--recursive` flag. Idempotent.
- **Migrated all fixture files** in `examples/java-spring-boot`, `examples/kotlin-ktor-koog`, and `examples/ts-frontend-first/mocks/upstream-fixtures`.
- **Documentation updates**: `fixtures-authoring.md`, `matching.md`, `api-reference.md`, `cli.md`, `doc.go`, `CLAUDE.md`, `CHANGELOG.md`.

### Breaking changes (pre-1.0)

- `BodyEncoding` type, `BodyEncodingIdentity`/`BodyEncodingBase64` constants removed
- `RecordedReq.BodyEncoding` and `RecordedResp.BodyEncoding` fields removed
- `body_encoding` field no longer emitted in fixture JSON
- Body field now uses Content-Type-aware serialization (custom JSON marshal/unmarshal)
- Existing fixtures must be migrated: `httptape migrate-fixtures --recursive <dir>`

## Test plan

- [ ] `go test ./...` passes (all existing + new tests)
- [ ] `go vet ./...` clean
- [ ] `go test -race ./...` passes
- [ ] New unit tests for `media_type.go` (ParseMediaType, ParseAccept, IsJSON, IsText, IsBinary, MatchesMediaRange, Specificity)
- [ ] New unit tests for `tape.go` marshal/unmarshal (JSON body, text body, binary body, nil body, round-trip, legacy base64 compatibility)
- [ ] New unit tests for `ContentNegotiationCriterion` (exact match, wildcard, q-value exclusion, multi-candidate)
- [ ] New unit tests for config `content_negotiation` criterion (validation, loading, building)
- [ ] New unit tests for `migrate-fixtures` CLI (help, missing dir, non-tape files, recursive, legacy tape, already-migrated tape)
- [ ] New integration test for multi-Content-Type fixture serving with content negotiation matcher
- [ ] Fixture migration verified: no `body_encoding` fields remain in committed fixtures
- [ ] JSON response bodies are native JSON objects in migrated fixtures

Generated with [Claude Code](https://claude.com/claude-code)