### PR TITLE
chore(examples): bump httptape image to v0.12.0

### DIFF
--- a/examples/java-spring-boot/README.md
+++ b/examples/java-spring-boot/README.md
@@ -16,18 +16,6 @@ The service calls an LLM via OpenAI's chat completions API. Tests serve a hand-c
 
 The service also calls a regular REST endpoint via Spring's modern `RestClient`. Same Testcontainers + httptape pattern, recorded JSON fixtures.
 
-## Note on httptape version
-
-This demo currently **builds httptape from source** (the repo root `Dockerfile`)
-instead of pulling a pre-built image from GHCR. This is because PR
-[#191](https://github.com/VibeWarden/httptape/pull/191) migrated the fixture
-format to the v0.12 content-type-aware body shape, which is not readable by
-older published images (v0.10.1 and below).
-
-Once v0.12.0 is tagged and pushed to GHCR, a follow-up PR will swap both
-`TestcontainersConfig.java` and `docker-compose.yml` back to
-`ghcr.io/vibewarden/httptape:0.12.0`.
-
 ## Prerequisites
 
 - **Docker** (for Testcontainers and the optional `docker compose` flow)

--- a/examples/java-spring-boot/docker-compose.yml
+++ b/examples/java-spring-boot/docker-compose.yml
@@ -1,11 +1,6 @@
 services:
   httptape:
-    # Builds httptape from source so the demo exercises the matcher code in
-    # this checkout. Once v0.12.0 ships to GHCR, swap back to:
-    #   image: ghcr.io/vibewarden/httptape:0.12.0
-    build:
-      context: ../..
-      dockerfile: Dockerfile
+    image: ghcr.io/vibewarden/httptape:0.12.0
     command: ["serve", "--fixtures", "/fixtures", "--sse-timing=realtime"]
     volumes:
       # All fixtures must be in a single flat directory for FileStore.

--- a/examples/java-spring-boot/src/test/java/dev/httptape/demo/TestcontainersConfig.java
+++ b/examples/java-spring-boot/src/test/java/dev/httptape/demo/TestcontainersConfig.java
@@ -3,7 +3,6 @@ package dev.httptape.demo;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -15,7 +14,6 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.MountableFile;
 
 /**
@@ -35,12 +33,6 @@ import org.testcontainers.utility.MountableFile;
  * <p>Integration tests import this configuration via
  * {@code @Import(TestcontainersConfig.class)}.
  *
- * <p><strong>Build-from-source note:</strong> The container currently builds
- * httptape from source so the demo always exercises the matcher code in this
- * checkout. This is needed while PR #191 (v0.12.0 content-type awareness) is
- * in flight — the migrated fixture format is not readable by older published
- * images. Once v0.12.0 ships to GHCR, swap back to
- * {@code ghcr.io/vibewarden/httptape:0.12.0}.
  */
 @TestConfiguration(proxyBeanMethods = false)
 class TestcontainersConfig {
@@ -49,19 +41,10 @@ class TestcontainersConfig {
      * A single httptape container serving every {@code .json} fixture found
      * on the classpath under {@code fixtures/**}. Realtime SSE timing for a
      * realistic streaming experience.
-     *
-     * <p>Builds httptape from source (repo root) so the demo exercises the
-     * matcher code in this checkout. Once v0.12.0 ships to GHCR, swap back
-     * to {@code ghcr.io/vibewarden/httptape:0.12.0}.
      */
     @Bean
     GenericContainer<?> httptapeContainer() throws IOException {
-        Path repoRoot = Paths.get("../..").toAbsolutePath().normalize();
-        ImageFromDockerfile httptapeImage = new ImageFromDockerfile("httptape-test", false)
-                .withFileFromPath(".", repoRoot)
-                .withFileFromPath("Dockerfile", repoRoot.resolve("Dockerfile"));
-
-        GenericContainer<?> container = new GenericContainer<>(httptapeImage)
+        GenericContainer<?> container = new GenericContainer<>("ghcr.io/vibewarden/httptape:0.12.0")
                 .withCommand("serve", "--fixtures", "/fixtures", "--sse-timing=realtime")
                 .withExposedPorts(8081)
                 .waitingFor(Wait.forHttp("/").forStatusCode(404));

--- a/examples/kotlin-ktor-koog/README.md
+++ b/examples/kotlin-ktor-koog/README.md
@@ -35,22 +35,9 @@ This demo exercises the matcher composition stack from #178, #179, and #180:
 - **#179 (Criterion interface)**: `MethodCriterion`, `PathCriterion`, and `BodyFuzzyCriterion` implement the `Criterion` interface.
 - **#180 (declarative config)**: The `httptape.config.json` file declares the `CompositeMatcher` with all three criteria. No Go code changes needed -- the config drives the matching.
 
-## Note on httptape version
+## httptape version requirement
 
-This demo currently **builds httptape from source** (the repo root `Dockerfile`)
-instead of pulling a pre-built image from GHCR. This is because PR
-[#191](https://github.com/VibeWarden/httptape/pull/191) migrated the fixture
-format to the v0.12 content-type-aware body shape, which is not readable by
-older published images (v0.11.0 and below).
-
-Once v0.12.0 is tagged and pushed to GHCR, a follow-up PR will swap both
-`HttptapeContainer.kt` and `docker-compose.yml` back to
-`ghcr.io/vibewarden/httptape:0.12.0`.
-
-The demo also requires the `--config` flag for `serve` mode (declarative matcher
-composition, introduced in [PR #184](https://github.com/VibeWarden/httptape/pull/184)),
-first shipped in **httptape v0.11.0**. Earlier releases (v0.10.1 and below) do not
-have `--config` support and will fail with the agent looping.
+This demo requires **httptape v0.12.0** or later. v0.12.0 introduced Content-Type-driven body shape in fixtures (PR [#191](https://github.com/VibeWarden/httptape/pull/191)) and includes `--config` support for declarative matcher composition (first shipped in v0.11.0, PR [#184](https://github.com/VibeWarden/httptape/pull/184)). Earlier releases cannot read the migrated fixture format or the matcher config.
 
 ## Prerequisites
 
@@ -127,7 +114,7 @@ IDE users: open [`api.http`](./api.http) -- IntelliJ's HTTP Client and VS Code's
 | Kotest | 6.1.11 (FreeSpec) |
 | Testcontainers | 2.0.4 (single shared container) |
 | Gradle | 9.4.1 (wrapper committed) |
-| httptape | built from source (v0.12.0-dev, see [version note](#note-on-httptape-version)) |
+| httptape | v0.12.0 (ghcr.io/vibewarden/httptape:0.12.0) |
 
 ## Why not...?
 

--- a/examples/kotlin-ktor-koog/docker-compose.yml
+++ b/examples/kotlin-ktor-koog/docker-compose.yml
@@ -1,11 +1,6 @@
 services:
   httptape:
-    # Builds httptape from source so the demo exercises the matcher code in
-    # this checkout. Once v0.12.0 ships to GHCR, swap back to:
-    #   image: ghcr.io/vibewarden/httptape:0.12.0
-    build:
-      context: ../..
-      dockerfile: Dockerfile
+    image: ghcr.io/vibewarden/httptape:0.12.0
     command: ["serve", "--fixtures", "/fixtures", "--config", "/config/httptape.config.json"]
     volumes:
       - ./src/test/resources/fixtures/openai/chat-1.json:/fixtures/chat-1.json:ro

--- a/examples/kotlin-ktor-koog/src/test/kotlin/dev/httptape/demo/HttptapeContainer.kt
+++ b/examples/kotlin-ktor-koog/src/test/kotlin/dev/httptape/demo/HttptapeContainer.kt
@@ -2,9 +2,7 @@ package dev.httptape.demo
 
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.images.builder.ImageFromDockerfile
 import org.testcontainers.utility.MountableFile
-import java.nio.file.Paths
 
 /**
  * JVM-singleton httptape container shared across all test classes.
@@ -15,22 +13,11 @@ import java.nio.file.Paths
  * distinguishes the two POST /v1/chat/completions requests via
  * `body_fuzzy` on `$.messages[*].role`.
  *
- * **Build-from-source note:** The container currently builds httptape from
- * source so the demo always exercises the matcher code in this checkout.
- * This is needed while PR #191 (v0.12.0 content-type awareness) is in
- * flight -- the migrated fixture format is not readable by older published
- * images. Once v0.12.0 ships to GHCR, swap back to
- * `ghcr.io/vibewarden/httptape:0.12.0`.
  */
 object HttptapeContainer {
 
     val instance: GenericContainer<*> by lazy {
-        val repoRoot = Paths.get("../..").toAbsolutePath().normalize()
-        val httptapeImage = ImageFromDockerfile("httptape-test", false)
-            .withFileFromPath(".", repoRoot)
-            .withFileFromPath("Dockerfile", repoRoot.resolve("Dockerfile"))
-
-        GenericContainer(httptapeImage)
+        GenericContainer("ghcr.io/vibewarden/httptape:0.12.0")
             .withCommand(
                 "serve",
                 "--fixtures", "/fixtures",

--- a/examples/ts-frontend-first/docker-compose.yml
+++ b/examples/ts-frontend-first/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   upstream:
-    image: ghcr.io/vibewarden/httptape:0.10.1
+    image: ghcr.io/vibewarden/httptape:0.12.0
     command: ["serve", "--fixtures", "/fixtures"]
     volumes:
       - ./mocks/upstream-fixtures:/fixtures:ro
 
   proxy:
-    image: ghcr.io/vibewarden/httptape:0.10.1
+    image: ghcr.io/vibewarden/httptape:0.12.0
     command:
       - proxy
       - --upstream


### PR DESCRIPTION
## Summary

Swaps the Java (Spring Boot) and Kotlin (Ktor/Koog) demos from build-from-source back to the published `ghcr.io/vibewarden/httptape:0.12.0` image, now that v0.12.0 is tagged (commit `e0e968b`) and the multi-arch image is live on GHCR.

The build-from-source workaround was introduced in PR #191's fix-up commit (`fdfdce0`) because the v0.12-format fixtures were not readable by older published images. With v0.12.0 published, the demos can pull the pre-built image again.

### Files changed

**Java demo (3 files):**
- `examples/java-spring-boot/src/test/java/dev/httptape/demo/TestcontainersConfig.java` -- replaced `ImageFromDockerfile` with `GenericContainer("ghcr.io/vibewarden/httptape:0.12.0")`, removed build-from-source Javadoc notes, removed unused `ImageFromDockerfile`/`Paths` imports
- `examples/java-spring-boot/docker-compose.yml` -- replaced `build: context/dockerfile` with `image: ghcr.io/vibewarden/httptape:0.12.0`
- `examples/java-spring-boot/README.md` -- removed "Note on httptape version" section

**Kotlin demo (3 files):**
- `examples/kotlin-ktor-koog/src/test/kotlin/dev/httptape/demo/HttptapeContainer.kt` -- replaced `ImageFromDockerfile` block with `GenericContainer("ghcr.io/vibewarden/httptape:0.12.0")`, removed build-from-source comment, removed unused `ImageFromDockerfile`/`Paths` imports
- `examples/kotlin-ktor-koog/docker-compose.yml` -- replaced `build: context/dockerfile` with `image: ghcr.io/vibewarden/httptape:0.12.0`
- `examples/kotlin-ktor-koog/README.md` -- replaced "Note on httptape version" section with concise "httptape version requirement" note; updated Stack table from `built from source (v0.12.0-dev)` to `v0.12.0 (ghcr.io/vibewarden/httptape:0.12.0)`

**ts-frontend-first:** does not need changes. It pins `ghcr.io/vibewarden/httptape:0.10.1` in `docker-compose.yml`, and its fixtures are still in the pre-v0.12 format (no `content_type`/`body_encoding` fields). Bumping the TS demo to v0.12.0 would require a separate fixture migration. No change required here.

### Local test results

- **Java demo:** 5 tests, 0 failures, 13.6s total (image pull ~2.4s, container start ~0.6s)
- **Kotlin demo:** BUILD SUCCESSFUL in 3s

Both pass against the published `ghcr.io/vibewarden/httptape:0.12.0` image. Container startup is ~0.6s (image pull + start) vs. the ~30-60s multi-stage Docker build that build-from-source required.

## Correction (commit 5e6828c)

The ts-frontend-first demo's docker-compose.yml was pinned to v0.10.1
despite its fixtures being migrated to v0.12 format in PR #191. CI
didn't catch this because the TS demo's CI job only runs `npm run build`
(Vite static build), not `docker compose up`. Manual verification with
`curl` confirms the demo works end-to-end against v0.12.0:

- `GET /api/profile` -- returns full profile JSON (name, email, card, etc.)
- `GET /api/products` -- returns 3-item product array
- `GET /api/products/1` -- returns single product detail with stock/category
- `GET /api/assist/keyboard` -- returns SSE stream with product recommendation

All four routes return valid responses. No 500s or 404s.

## CI gap note

The ts-frontend-first demo's CI job (`build (ts-frontend-first)`) only runs `npm run build` (Vite static build) and does not exercise `docker compose up`. This means docker-compose version mismatches (like the one fixed in this correction) can slip through silently. A `docker compose up` smoke test with basic `curl` verification would catch this class of breakage. This is a separate concern -- worth filing as a follow-up issue if desired, but out of scope for this PR.

### Merge note

Autonomous-merge-ok -- small mechanical change, same pattern as the v0.11.0 image swap.

Generated with [Claude Code](https://claude.com/claude-code)