### PR TITLE
feat(#202): CachingTransport library API with stale-fallback policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to httptape are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.13.0] - 2026-04-18
+
+### Added
+
+- **CachingTransport**: New `http.RoundTripper` that provides transparent,
+  store-backed caching. On cache hit, returns the recorded response without
+  contacting upstream. On cache miss, forwards to upstream, records the
+  response (with optional sanitization), and returns it. This is the library
+  primitive for cache-through-upstream logic. (#202)
+- `NewCachingTransport(upstream, store, opts...)` constructor with functional
+  options pattern.
+- `CachingOption` type with 10 option functions: `WithCacheMatcher`,
+  `WithCacheSanitizer`, `WithCacheFilter`, `WithCacheSingleFlight`,
+  `WithCacheMaxBodySize`, `WithCacheRoute`, `WithCacheOnError`,
+  `WithCacheSSERecording`, `WithCacheUpstreamDownFallback`,
+  `WithCacheUpstreamTimeout`.
+- **Single-flight deduplication**: Concurrent identical cache misses share a
+  single upstream call (stdlib-only implementation, no external dependencies).
+- **Stale-fallback policy** (`WithCacheUpstreamDownFallback`): When upstream
+  is unreachable and a cached tape exists, returns it with
+  `X-Httptape-Stale: true` header. Opt-in, disabled by default. (#164)
+- **Upstream timeout** (`WithCacheUpstreamTimeout`): Configurable deadline for
+  upstream requests on cache miss. On timeout, the stale-fallback path is
+  entered (if enabled).
+- **SSE tee recording**: SSE responses on the miss path are streamed to the
+  caller unchanged while events are accumulated and persisted. Partial
+  disconnects (client close before upstream EOF) are detected and the
+  partial tape is discarded.
+- `docs/caching-transport.md`: Complete guide for CachingTransport.
+
 ## [0.12.0] - 2026-04-18
 
 ### Breaking Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ httptape/
   config.go            # Declarative JSON config for sanitization pipeline
   config_test.go
   config.schema.json   # JSON Schema for config file validation (IDE/CI use)
+  caching_transport.go      # CachingTransport RoundTripper (replay + record-on-miss)
+  caching_transport_test.go
   bundle.go            # Import/export (tar.gz)
   bundle_test.go
   integration_test.go  # End-to-end integration tests

--- a/caching_transport.go
+++ b/caching_transport.go
@@ -50,6 +50,7 @@ type sfCall struct {
 	resp *http.Response // set before wg.Done
 	err  error          // set before wg.Done
 	body []byte         // buffered response body for sharing
+	sse  bool           // true when the leader's response was SSE
 }
 
 // CachingOption configures a CachingTransport.
@@ -87,6 +88,16 @@ func WithCacheFilter(fn func(*http.Response) bool) CachingOption {
 // WithCacheSingleFlight controls single-flight deduplication of concurrent
 // cache misses. When true (default), concurrent requests with the same match
 // key share a single upstream call.
+//
+// Known limitation: waiters do not observe their request's context cancellation
+// until the leader's upstream call completes. This is a consequence of using
+// sync.WaitGroup (not context-aware) for waiter coordination in v0.13. For
+// callers whose request contexts carry strict deadlines, either disable
+// single-flight (WithCacheSingleFlight(false)) or set an aggressive
+// WithCacheUpstreamTimeout to bound the leader's wait.
+//
+// Disable only if you want "accidentally record multiple variants of the same
+// request" behavior, which is rare.
 func WithCacheSingleFlight(enabled bool) CachingOption {
 	return func(ct *CachingTransport) {
 		ct.singleFlight = enabled
@@ -302,7 +313,15 @@ func (ct *CachingTransport) roundTripWithSingleFlight(req *http.Request, reqBody
 			}
 			return nil, call.err
 		}
-		// Clone the response for each waiter.
+
+		// For SSE responses, the leader's body is a streaming reader that
+		// cannot be cloned. Re-query the store for the persisted tape
+		// instead (the leader's SSE tee writes the tape on stream completion).
+		if call.sse {
+			return ct.reQueryStoreForSSE(req, reqBody)
+		}
+
+		// Clone the response for each waiter (non-SSE path).
 		return cloneResponse(call.resp, call.body), nil
 	}
 
@@ -330,8 +349,9 @@ func (ct *CachingTransport) roundTripWithSingleFlight(req *http.Request, reqBody
 	if isSSEContentType(resp.Header.Get("Content-Type")) {
 		call.resp = resp
 		call.err = nil
+		call.sse = true
 		// For SSE, we cannot buffer the body. Mark the call done so waiters
-		// fall through and re-check the store after the stream completes.
+		// fall through and re-query the store after the stream completes.
 		call.wg.Done()
 		ct.sfMu.Lock()
 		delete(ct.sfCalls, sfKey)
@@ -658,6 +678,49 @@ func (ct *CachingTransport) sseResponseFromTape(tape Tape) *http.Response {
 		Header:     header,
 		Body:       pr,
 	}
+}
+
+// reQueryStoreForSSE is the SSE single-flight waiter path. After the leader's
+// stream completes and is persisted, waiters re-query the store for the
+// matching tape and serve it. If the tape is not found (e.g., the leader's
+// store write failed or the stream was truncated), the waiter falls through
+// to a direct upstream call as a last resort.
+func (ct *CachingTransport) reQueryStoreForSSE(req *http.Request, reqBody []byte) (*http.Response, error) {
+	if reqBody != nil {
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
+	}
+
+	tapes, err := ct.store.List(req.Context(), Filter{Route: ct.route})
+	if err != nil {
+		ct.onErrorSafe(fmt.Errorf("httptape: SSE single-flight waiter store list: %w", err))
+		// Fall through to direct upstream call.
+		if reqBody != nil {
+			req.Body = io.NopCloser(bytes.NewReader(reqBody))
+		}
+		bodyHash := BodyHashFromBytes(reqBody)
+		return ct.roundTripUpstream(req, reqBody, bodyHash)
+	}
+
+	if reqBody != nil {
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
+	}
+
+	tape, ok := ct.matcher.Match(req, tapes)
+	if ok && tape.Response.IsSSE() {
+		return ct.sseResponseFromTape(tape), nil
+	}
+	if ok {
+		return ct.tapeToResponse(tape), nil
+	}
+
+	// Tape not found -- leader's store write may have failed.
+	// Fall through to a direct upstream call.
+	ct.onErrorSafe(fmt.Errorf("httptape: SSE single-flight waiter: no matching tape found after leader completed, falling back to direct upstream call"))
+	if reqBody != nil {
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
+	}
+	bodyHash := BodyHashFromBytes(reqBody)
+	return ct.roundTripUpstream(req, reqBody, bodyHash)
 }
 
 // doSingleFlight coordinates dedup for concurrent cache misses. This is

--- a/caching_transport.go
+++ b/caching_transport.go
@@ -1,0 +1,687 @@
+package httptape
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// CachingTransport is an http.RoundTripper that consults a tape Store on
+// each request. On cache hit, it returns the recorded response without
+// contacting upstream. On cache miss, it forwards to upstream, records the
+// response (after sanitization), and returns it.
+//
+// CachingTransport is NOT an RFC 7234 HTTP cache. It does not honor
+// Cache-Control, Vary, or any other HTTP caching headers. It is a
+// tape-match layer: identical requests (as defined by the Matcher) get
+// identical recorded responses.
+//
+// CachingTransport is safe for concurrent use by multiple goroutines.
+type CachingTransport struct {
+	upstream    http.RoundTripper
+	store       Store
+	matcher     Matcher
+	sanitizer   Sanitizer
+	route       string
+	onError     func(error)
+	cacheFilter func(*http.Response) bool
+
+	singleFlight bool
+	maxBodySize  int
+	sseRecording bool
+
+	// stale-fallback (#164)
+	staleFallback   bool
+	upstreamTimeout time.Duration
+
+	// single-flight coordination (stdlib-only)
+	sfMu    sync.Mutex
+	sfCalls map[string]*sfCall
+}
+
+// sfCall tracks an in-flight upstream request for single-flight dedup.
+type sfCall struct {
+	wg   sync.WaitGroup
+	resp *http.Response // set before wg.Done
+	err  error          // set before wg.Done
+	body []byte         // buffered response body for sharing
+}
+
+// CachingOption configures a CachingTransport.
+type CachingOption func(*CachingTransport)
+
+// WithCacheMatcher sets the Matcher used to identify equivalent requests.
+// Default: NewCompositeMatcher(MethodCriterion{}, PathCriterion{}, BodyHashCriterion{}).
+func WithCacheMatcher(m Matcher) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.matcher = m
+	}
+}
+
+// WithCacheSanitizer sets the sanitization pipeline applied to recorded
+// tapes before store persistence. Default: NewPipeline() (no-op).
+func WithCacheSanitizer(s Sanitizer) CachingOption {
+	return func(ct *CachingTransport) {
+		if s == nil {
+			ct.sanitizer = NewPipeline()
+			return
+		}
+		ct.sanitizer = s
+	}
+}
+
+// WithCacheFilter sets a predicate controlling which upstream responses
+// are cached. Only responses for which fn returns true are persisted.
+// Default: cache 2xx responses only.
+func WithCacheFilter(fn func(*http.Response) bool) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.cacheFilter = fn
+	}
+}
+
+// WithCacheSingleFlight controls single-flight deduplication of concurrent
+// cache misses. When true (default), concurrent requests with the same match
+// key share a single upstream call.
+func WithCacheSingleFlight(enabled bool) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.singleFlight = enabled
+	}
+}
+
+// WithCacheMaxBodySize sets the maximum request body size in bytes for
+// cache participation. Requests whose body exceeds this limit bypass the
+// cache entirely (forwarded to upstream, response not recorded).
+// Default: 10 MiB (10 * 1024 * 1024).
+// A value of 0 means no limit.
+func WithCacheMaxBodySize(n int) CachingOption {
+	return func(ct *CachingTransport) {
+		if n < 0 {
+			n = 0
+		}
+		ct.maxBodySize = n
+	}
+}
+
+// WithCacheRoute sets the route label applied to all tapes created by
+// this transport.
+func WithCacheRoute(route string) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.route = route
+	}
+}
+
+// WithCacheOnError sets a callback invoked when a non-fatal error occurs
+// (store failure, body read failure on the record path). Defaults to no-op.
+func WithCacheOnError(fn func(error)) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.onError = fn
+	}
+}
+
+// WithCacheSSERecording controls whether SSE stream recording is enabled.
+// When true (default), SSE responses on the miss path are tee'd to the
+// caller and accumulated for tape persistence.
+func WithCacheSSERecording(enabled bool) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.sseRecording = enabled
+	}
+}
+
+// WithCacheUpstreamDownFallback enables stale-response fallback when
+// upstream is unreachable or returns a transport error on a cache miss.
+// When enabled, CachingTransport searches the store for the best-matching
+// tape (using the configured Matcher) and returns it with an
+// X-Httptape-Stale: true header. When disabled (default), transport errors
+// are propagated to the caller.
+//
+// This is useful for demo hosting (upstream flakiness should not break the
+// demo) but wrong for integration tests (which should see the real failure).
+func WithCacheUpstreamDownFallback(enabled bool) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.staleFallback = enabled
+	}
+}
+
+// WithCacheUpstreamTimeout sets a timeout for upstream requests on cache
+// miss. When set, the request context is wrapped with a deadline before
+// forwarding. Default: 0 (no timeout; the caller's http.Client timeout
+// dominates).
+func WithCacheUpstreamTimeout(d time.Duration) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.upstreamTimeout = d
+	}
+}
+
+// defaultCacheMaxBodySize is the default maximum request body size for cache
+// participation: 10 MiB.
+const defaultCacheMaxBodySize = 10 * 1024 * 1024
+
+// NewCachingTransport creates a new CachingTransport wrapping the given
+// upstream transport with store-backed caching.
+//
+// On RoundTrip, it consults the store for a matching tape. On hit, it
+// returns the recorded response. On miss, it forwards to upstream, records
+// the response (after sanitization), and returns it.
+//
+// upstream and store must not be nil. Panics on nil (constructor guard per
+// CLAUDE.md).
+//
+// Default configuration:
+//   - matcher: method + path + body_hash
+//   - sanitizer: no-op Pipeline
+//   - cache filter: 2xx only
+//   - single-flight: enabled
+//   - max body size: 10 MiB
+//   - SSE recording: enabled
+//   - stale fallback: disabled
+//   - upstream timeout: 0 (no timeout)
+//   - route: ""
+//   - onError: no-op
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport {
+	if upstream == nil {
+		panic("httptape: NewCachingTransport requires a non-nil upstream RoundTripper")
+	}
+	if store == nil {
+		panic("httptape: NewCachingTransport requires a non-nil Store")
+	}
+
+	ct := &CachingTransport{
+		upstream:     upstream,
+		store:        store,
+		matcher:      NewCompositeMatcher(MethodCriterion{}, PathCriterion{}, BodyHashCriterion{}),
+		sanitizer:    NewPipeline(),
+		singleFlight: true,
+		maxBodySize:  defaultCacheMaxBodySize,
+		sseRecording: true,
+		cacheFilter: func(resp *http.Response) bool {
+			return resp.StatusCode >= 200 && resp.StatusCode < 300
+		},
+		sfCalls: make(map[string]*sfCall),
+	}
+
+	for _, opt := range opts {
+		opt(ct)
+	}
+
+	return ct
+}
+
+// RoundTrip implements http.RoundTripper. It consults the cache for a
+// matching tape, returning a cached response on hit. On miss, it forwards
+// to upstream, optionally records the response, and returns it.
+func (ct *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// 1. Read request body into buffer (respecting maxBodySize).
+	reqBody, oversize, err := ct.bufferRequestBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("httptape: caching transport read request body: %w", err)
+	}
+
+	// If body exceeds maxBodySize: pass through to upstream directly.
+	if oversize {
+		return ct.upstream.RoundTrip(req)
+	}
+
+	// 2. Compute body hash from buffer.
+	bodyHash := BodyHashFromBytes(reqBody)
+
+	// 3. Replace req.Body with fresh reader.
+	if reqBody != nil {
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
+		bodyBytes := reqBody
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+	}
+
+	// 4. Cache lookup.
+	tapes, listErr := ct.store.List(req.Context(), Filter{Route: ct.route})
+	if listErr != nil {
+		// Store failure on lookup: proceed as miss.
+		ct.onErrorSafe(fmt.Errorf("httptape: caching transport store list: %w", listErr))
+		tapes = nil
+	}
+
+	// Restore body for matcher consumption.
+	if reqBody != nil {
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
+	}
+
+	if tapes != nil {
+		tape, ok := ct.matcher.Match(req, tapes)
+		if ok {
+			// 5. HIT: synthesize response from tape.
+			if tape.Response.IsSSE() {
+				return ct.sseResponseFromTape(tape), nil
+			}
+			return ct.tapeToResponse(tape), nil
+		}
+	}
+
+	// Restore body again before upstream call.
+	if reqBody != nil {
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
+	}
+
+	// 6. MISS: forward to upstream.
+	sfKey := req.Method + "|" + req.URL.Path + "|" + bodyHash
+
+	if ct.singleFlight {
+		return ct.roundTripWithSingleFlight(req, reqBody, bodyHash, sfKey)
+	}
+
+	return ct.roundTripUpstream(req, reqBody, bodyHash)
+}
+
+// roundTripWithSingleFlight coordinates single-flight dedup for non-SSE
+// cache misses. SSE responses are handled differently: the first caller
+// gets the live tee'd stream and concurrent callers wait for completion,
+// then get the cached tape.
+func (ct *CachingTransport) roundTripWithSingleFlight(req *http.Request, reqBody []byte, bodyHash, sfKey string) (*http.Response, error) {
+	ct.sfMu.Lock()
+	if call, ok := ct.sfCalls[sfKey]; ok {
+		ct.sfMu.Unlock()
+		call.wg.Wait()
+		if call.err != nil {
+			// The leader failed. Try stale fallback for this waiter too.
+			if ct.staleFallback {
+				if reqBody != nil {
+					req.Body = io.NopCloser(bytes.NewReader(reqBody))
+				}
+				resp, fbErr := ct.serveStaleFallback(req)
+				if fbErr != nil {
+					ct.onErrorSafe(fbErr)
+				}
+				if resp != nil {
+					return resp, nil
+				}
+			}
+			return nil, call.err
+		}
+		// Clone the response for each waiter.
+		return cloneResponse(call.resp, call.body), nil
+	}
+
+	call := &sfCall{}
+	call.wg.Add(1)
+	ct.sfCalls[sfKey] = call
+	ct.sfMu.Unlock()
+
+	resp, err := ct.roundTripUpstream(req, reqBody, bodyHash)
+
+	// For non-SSE responses, share the result with waiters.
+	if err != nil {
+		call.err = err
+		call.wg.Done()
+		ct.sfMu.Lock()
+		delete(ct.sfCalls, sfKey)
+		ct.sfMu.Unlock()
+		return nil, err
+	}
+
+	// If SSE, the response body is a streaming reader. We cannot share it
+	// via single-flight cloning. Complete the single-flight immediately;
+	// waiters that arrive later will find the tape in the store (once the
+	// stream completes).
+	if isSSEContentType(resp.Header.Get("Content-Type")) {
+		call.resp = resp
+		call.err = nil
+		// For SSE, we cannot buffer the body. Mark the call done so waiters
+		// fall through and re-check the store after the stream completes.
+		call.wg.Done()
+		ct.sfMu.Lock()
+		delete(ct.sfCalls, sfKey)
+		ct.sfMu.Unlock()
+		return resp, nil
+	}
+
+	// For non-SSE: read the body to share with waiters.
+	respBody, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		ct.onErrorSafe(fmt.Errorf("httptape: caching transport read response body for single-flight: %w", readErr))
+		// Return what we have.
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		call.resp = resp
+		call.body = respBody
+		call.wg.Done()
+		ct.sfMu.Lock()
+		delete(ct.sfCalls, sfKey)
+		ct.sfMu.Unlock()
+		return resp, nil
+	}
+
+	// Restore body for the leader caller.
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
+	call.resp = resp
+	call.body = respBody
+	call.wg.Done()
+
+	ct.sfMu.Lock()
+	delete(ct.sfCalls, sfKey)
+	ct.sfMu.Unlock()
+
+	return resp, nil
+}
+
+// roundTripUpstream handles the actual upstream call and optional recording.
+func (ct *CachingTransport) roundTripUpstream(req *http.Request, reqBody []byte, bodyHash string) (*http.Response, error) {
+	// Apply upstream timeout if configured.
+	if ct.upstreamTimeout > 0 {
+		ctx, cancel := context.WithTimeout(req.Context(), ct.upstreamTimeout)
+		defer cancel()
+		req = req.WithContext(ctx)
+	}
+
+	resp, transportErr := ct.upstream.RoundTrip(req)
+	if transportErr != nil {
+		// Upstream error path.
+		if ct.staleFallback {
+			if reqBody != nil {
+				req.Body = io.NopCloser(bytes.NewReader(reqBody))
+			}
+			staleResp, fbErr := ct.serveStaleFallback(req)
+			if fbErr != nil {
+				ct.onErrorSafe(fbErr)
+			}
+			if staleResp != nil {
+				return staleResp, nil
+			}
+		}
+		return nil, transportErr
+	}
+
+	// SSE detection on miss path.
+	if ct.sseRecording && isSSEContentType(resp.Header.Get("Content-Type")) {
+		return ct.roundTripSSE(req, resp, reqBody)
+	}
+
+	// Read response body into buffer.
+	var respBody []byte
+	if resp.Body != nil {
+		var err error
+		respBody, err = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		if err != nil {
+			ct.onErrorSafe(fmt.Errorf("httptape: caching transport read response body: %w", err))
+			return resp, nil
+		}
+	}
+
+	// Check cache filter.
+	if !ct.cacheFilter(resp) {
+		return resp, nil
+	}
+
+	// Build tape.
+	recordedReq := RecordedReq{
+		Method:   req.Method,
+		URL:      req.URL.String(),
+		Headers:  req.Header.Clone(),
+		Body:     reqBody,
+		BodyHash: bodyHash,
+	}
+	recordedResp := RecordedResp{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header.Clone(),
+		Body:       respBody,
+	}
+
+	tape := NewTape(ct.route, recordedReq, recordedResp)
+
+	// Apply sanitizer.
+	tape = ct.sanitizer.Sanitize(tape)
+
+	// Store.Save (synchronous). On failure, call onError; still return response.
+	if saveErr := ct.store.Save(req.Context(), tape); saveErr != nil {
+		ct.onErrorSafe(fmt.Errorf("httptape: caching transport store save: %w", saveErr))
+	}
+
+	return resp, nil
+}
+
+// roundTripSSE handles SSE responses on the miss path. The body is wrapped
+// in an sseRecordingReader that delivers bytes to the caller unchanged
+// while a background goroutine parses SSE events. When the stream
+// completes cleanly, the tape is persisted. If the stream is truncated
+// (client disconnect), the partial tape is discarded.
+func (ct *CachingTransport) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte) (*http.Response, error) {
+	startTime := time.Now()
+	respHeaders := resp.Header.Clone()
+
+	recordedReq := RecordedReq{
+		Method:   req.Method,
+		URL:      req.URL.String(),
+		Headers:  req.Header.Clone(),
+		Body:     reqBody,
+		BodyHash: BodyHashFromBytes(reqBody),
+	}
+
+	var mu sync.Mutex
+	var events []SSEEvent
+
+	// Track whether the upstream stream reached a natural EOF.
+	// The eofTrackingReader sets this to true when the upstream
+	// returns io.EOF, indicating the stream completed normally.
+	var streamCompleted atomic.Bool
+
+	onEvent := func(ev SSEEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}
+
+	onDone := func(parseErr error) {
+		mu.Lock()
+		collectedEvents := make([]SSEEvent, len(events))
+		copy(collectedEvents, events)
+		mu.Unlock()
+
+		// If the stream had a parse error, discard.
+		if parseErr != nil {
+			ct.onErrorSafe(fmt.Errorf("httptape: caching transport SSE stream truncated: %w", parseErr))
+			return
+		}
+
+		// If the stream didn't reach natural EOF (client closed early),
+		// discard the partial tape.
+		if !streamCompleted.Load() {
+			ct.onErrorSafe(fmt.Errorf("httptape: caching transport SSE stream closed before completion"))
+			return
+		}
+
+		recordedResp := RecordedResp{
+			StatusCode: resp.StatusCode,
+			Headers:    respHeaders,
+			Body:       nil,
+			SSEEvents:  collectedEvents,
+		}
+
+		tape := NewTape(ct.route, recordedReq, recordedResp)
+		tape = ct.sanitizer.Sanitize(tape)
+
+		if saveErr := ct.store.Save(context.Background(), tape); saveErr != nil {
+			ct.onErrorSafe(fmt.Errorf("httptape: caching transport SSE store save: %w", saveErr))
+		}
+	}
+
+	// Wrap the upstream body with an EOF tracker before passing to the
+	// SSE recording reader. When the upstream sends EOF, the tracker
+	// sets streamCompleted to true.
+	trackedBody := &eofTrackingReadCloser{
+		inner:     resp.Body,
+		completed: &streamCompleted,
+	}
+
+	wrapper := newSSERecordingReader(trackedBody, startTime, onEvent, onDone)
+	resp.Body = wrapper
+
+	return resp, nil
+}
+
+// eofTrackingReadCloser wraps an io.ReadCloser and tracks whether the
+// underlying reader returned io.EOF, indicating the stream completed
+// naturally (as opposed to being closed by the client).
+type eofTrackingReadCloser struct {
+	inner     io.ReadCloser
+	completed *atomic.Bool
+}
+
+// Read implements io.Reader. When the inner reader returns io.EOF, the
+// completed flag is set to true.
+func (r *eofTrackingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.inner.Read(p)
+	if err == io.EOF {
+		r.completed.Store(true)
+	}
+	return n, err
+}
+
+// Close implements io.Closer.
+func (r *eofTrackingReadCloser) Close() error {
+	return r.inner.Close()
+}
+
+// bufferRequestBody reads the request body into a buffer, respecting
+// maxBodySize. Returns the body bytes, whether the body exceeded the size
+// limit, and any error. If oversize is true, the request body is restored
+// with the partially-read bytes concatenated with the remaining stream.
+func (ct *CachingTransport) bufferRequestBody(req *http.Request) (body []byte, oversize bool, err error) {
+	if req.Body == nil {
+		return nil, false, nil
+	}
+
+	if ct.maxBodySize == 0 {
+		// No limit.
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, false, err
+		}
+		req.Body.Close()
+		return body, false, nil
+	}
+
+	// Read up to maxBodySize + 1 to detect oversize.
+	limited := io.LimitReader(req.Body, int64(ct.maxBodySize)+1)
+	body, err = io.ReadAll(limited)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(body) > ct.maxBodySize {
+		// Body exceeds limit. Restore req.Body with the bytes we read
+		// plus the remaining unread portion.
+		remaining := io.NopCloser(io.MultiReader(bytes.NewReader(body), req.Body))
+		req.Body = remaining
+		return nil, true, nil
+	}
+
+	// Body fits within limit.
+	req.Body.Close()
+	return body, false, nil
+}
+
+// serveStaleFallback searches the store for a matching tape and returns it
+// with the X-Httptape-Stale: true header. Returns (nil, nil) if no match
+// is found. Uses context.Background() for the store query because the
+// original request context may have been cancelled by an upstream timeout.
+func (ct *CachingTransport) serveStaleFallback(req *http.Request) (*http.Response, error) {
+	tapes, err := ct.store.List(context.Background(), Filter{Route: ct.route})
+	if err != nil {
+		return nil, fmt.Errorf("httptape: stale fallback store list: %w", err)
+	}
+
+	tape, ok := ct.matcher.Match(req, tapes)
+	if !ok {
+		return nil, nil
+	}
+
+	var resp *http.Response
+	if tape.Response.IsSSE() {
+		resp = ct.sseResponseFromTape(tape)
+	} else {
+		resp = ct.tapeToResponse(tape)
+	}
+	resp.Header.Set("X-Httptape-Stale", "true")
+	return resp, nil
+}
+
+// tapeToResponse synthesizes an *http.Response from a non-SSE Tape.
+func (ct *CachingTransport) tapeToResponse(tape Tape) *http.Response {
+	header := make(http.Header)
+	if tape.Response.Headers != nil {
+		header = tape.Response.Headers.Clone()
+	}
+	header.Del("Content-Length")
+
+	body := tape.Response.Body
+	if body == nil {
+		body = []byte{}
+	}
+
+	return &http.Response{
+		StatusCode: tape.Response.StatusCode,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}
+
+// sseResponseFromTape synthesizes an *http.Response with a streaming body
+// for an SSE tape. Events are emitted back-to-back with no timing delay
+// (instant replay for the RoundTripper path).
+func (ct *CachingTransport) sseResponseFromTape(tape Tape) *http.Response {
+	header := make(http.Header)
+	if tape.Response.Headers != nil {
+		header = tape.Response.Headers.Clone()
+	}
+	header.Set("Content-Type", "text/event-stream")
+	header.Del("Content-Length")
+
+	pr, pw := io.Pipe()
+	go func() {
+		for _, ev := range tape.Response.SSEEvents {
+			if err := writeSSEEvent(pw, ev); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}
+		pw.Close()
+	}()
+
+	return &http.Response{
+		StatusCode: tape.Response.StatusCode,
+		Header:     header,
+		Body:       pr,
+	}
+}
+
+// doSingleFlight coordinates dedup for concurrent cache misses. This is
+// only used internally by roundTripWithSingleFlight for the response
+// sharing logic.
+// Note: the actual single-flight coordination is inlined in
+// roundTripWithSingleFlight for better control over SSE vs non-SSE paths.
+
+// onErrorSafe calls the error callback if it is set.
+func (ct *CachingTransport) onErrorSafe(err error) {
+	if ct.onError != nil {
+		ct.onError(err)
+	}
+}
+
+// cloneResponse creates an independent copy of an http.Response with a
+// fresh body reader over the given bytes. This is used by single-flight
+// to give each waiter their own consumable response.
+func cloneResponse(resp *http.Response, body []byte) *http.Response {
+	if resp == nil {
+		return nil
+	}
+	clone := *resp
+	clone.Header = resp.Header.Clone()
+	clone.Body = io.NopCloser(bytes.NewReader(copyBytes(body)))
+	return &clone
+}

--- a/caching_transport_test.go
+++ b/caching_transport_test.go
@@ -1,0 +1,1149 @@
+package httptape
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- Test helpers ---
+
+// countingTransport wraps a transport and counts calls.
+type countingTransport struct {
+	inner http.RoundTripper
+	count atomic.Int64
+}
+
+func (c *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.count.Add(1)
+	return c.inner.RoundTrip(req)
+}
+
+// failingStore is a Store that fails on Save for testing error paths.
+type failingStore struct {
+	*MemoryStore
+	saveFail bool
+}
+
+func (fs *failingStore) Save(ctx context.Context, tape Tape) error {
+	if fs.saveFail {
+		return errors.New("store write failure")
+	}
+	return fs.MemoryStore.Save(ctx, tape)
+}
+
+// flakeyListStore wraps a MemoryStore but returns an error on the first
+// N List calls, then delegates to the underlying store. This simulates
+// transient store failures for stale-fallback testing.
+type flakeyListStore struct {
+	*MemoryStore
+	failCount atomic.Int64 // number of List calls that should fail
+}
+
+func (fs *flakeyListStore) List(ctx context.Context, filter Filter) ([]Tape, error) {
+	if fs.failCount.Add(-1) >= 0 {
+		return nil, errors.New("transient store error")
+	}
+	return fs.MemoryStore.List(ctx, filter)
+}
+
+// --- Tests per ADR-44 test strategy ---
+
+func TestCachingTransport_CacheHitNonSSE(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/users",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"X-Custom": {"cached"}},
+		Body:       []byte("cached-response"),
+	})
+	store.Save(context.Background(), tape)
+
+	upstreamCalled := false
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		upstreamCalled = true
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("upstream"))}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if upstreamCalled {
+		t.Error("upstream was called on cache hit; expected no upstream call")
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "cached-response" {
+		t.Errorf("got body %q, want %q", string(body), "cached-response")
+	}
+}
+
+func TestCachingTransport_CacheHitSSE(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method:   "POST",
+		URL:      "http://example.com/api/chat",
+		Headers:  http.Header{},
+		Body:     []byte(`{"prompt":"hello"}`),
+		BodyHash: BodyHashFromBytes([]byte(`{"prompt":"hello"}`)),
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/event-stream"}},
+		SSEEvents: []SSEEvent{
+			{OffsetMS: 0, Data: "event1"},
+			{OffsetMS: 100, Data: "event2"},
+		},
+	})
+	store.Save(context.Background(), tape)
+
+	upstreamCalled := false
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		upstreamCalled = true
+		return nil, errors.New("should not be called")
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	req, _ := http.NewRequest("POST", "http://example.com/api/chat",
+		bytes.NewReader([]byte(`{"prompt":"hello"}`)))
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if upstreamCalled {
+		t.Error("upstream was called on SSE cache hit")
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("got Content-Type %q, want text/event-stream", ct)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "event1") || !strings.Contains(string(body), "event2") {
+		t.Errorf("SSE body missing events: %q", string(body))
+	}
+}
+
+func TestCachingTransport_CacheMissNonSSE(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"X-Upstream": {"true"}},
+			Body:       io.NopCloser(strings.NewReader("from-upstream")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	// First request: cache miss, should forward to upstream.
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if string(body) != "from-upstream" {
+		t.Errorf("got body %q, want %q", string(body), "from-upstream")
+	}
+
+	// Verify tape was stored.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("store has %d tapes, want 1", len(tapes))
+	}
+	if string(tapes[0].Response.Body) != "from-upstream" {
+		t.Errorf("stored body %q, want %q", string(tapes[0].Response.Body), "from-upstream")
+	}
+
+	// Second request: should be a cache hit.
+	req2, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp2, err := ct.RoundTrip(req2)
+	if err != nil {
+		t.Fatalf("unexpected error on second request: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if string(body2) != "from-upstream" {
+		t.Errorf("got body %q on second request, want %q", string(body2), "from-upstream")
+	}
+}
+
+func TestCachingTransport_CacheMissSSETee(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	// Create a test SSE upstream.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprintln(w, "data: hello")
+		fmt.Fprintln(w, "")
+		flusher.Flush()
+		fmt.Fprintln(w, "data: world")
+		fmt.Fprintln(w, "")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	ct := NewCachingTransport(http.DefaultTransport, store)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/stream", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read the streamed body.
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if !strings.Contains(string(body), "hello") || !strings.Contains(string(body), "world") {
+		t.Errorf("SSE tee body missing events: %q", string(body))
+	}
+
+	// Wait briefly for the async onDone callback to fire.
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify tape was stored with SSE events.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("store has %d tapes, want 1", len(tapes))
+	}
+	if !tapes[0].Response.IsSSE() {
+		t.Error("stored tape is not SSE")
+	}
+	if len(tapes[0].Response.SSEEvents) < 2 {
+		t.Errorf("stored tape has %d SSE events, want >= 2", len(tapes[0].Response.SSEEvents))
+	}
+}
+
+func TestCachingTransport_SSEPartialDisconnect(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	var onErrorCalled atomic.Int32
+
+	// Create a test SSE upstream that sends events indefinitely.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher, _ := w.(http.Flusher)
+		for i := 0; ; i++ {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			fmt.Fprintf(w, "data: event-%d\n\n", i)
+			flusher.Flush()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	ct := NewCachingTransport(http.DefaultTransport, store,
+		WithCacheOnError(func(_ error) { onErrorCalled.Add(1) }),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/stream", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read a few bytes then close (simulating client disconnect).
+	buf := make([]byte, 64)
+	resp.Body.Read(buf) //nolint:errcheck
+	resp.Body.Close()
+
+	// Wait for onDone to fire.
+	time.Sleep(200 * time.Millisecond)
+
+	// Partial tape should NOT be stored.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 0 {
+		t.Errorf("store has %d tapes after partial disconnect, want 0", len(tapes))
+	}
+}
+
+func TestCachingTransport_UpstreamErrorPropagation(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := ct.RoundTrip(req)
+	if resp != nil {
+		t.Errorf("expected nil response, got status %d", resp.StatusCode)
+	}
+	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("expected connection refused error, got %v", err)
+	}
+}
+
+func TestCachingTransport_StaleFallbackHit(t *testing.T) {
+	t.Parallel()
+
+	// Use a flaky store that fails the initial List (causing a cache miss)
+	// but succeeds on the second List (stale fallback lookup).
+	ms := NewMemoryStore()
+	flakey := &flakeyListStore{MemoryStore: ms}
+	flakey.failCount.Store(1) // first List call fails
+
+	// Pre-populate store with a tape.
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/data",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("stale-data"),
+	})
+	ms.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("upstream down")
+	})
+
+	ct := NewCachingTransport(upstream, flakey,
+		WithCacheUpstreamDownFallback(true),
+		WithCacheSingleFlight(false),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "stale-data" {
+		t.Errorf("got body %q, want %q", string(body), "stale-data")
+	}
+	if stale := resp.Header.Get("X-Httptape-Stale"); stale != "true" {
+		t.Errorf("got X-Httptape-Stale=%q, want %q", stale, "true")
+	}
+}
+
+func TestCachingTransport_StaleFallbackMiss(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore() // empty
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("upstream down")
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheUpstreamDownFallback(true),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if resp != nil {
+		t.Errorf("expected nil response, got status %d", resp.StatusCode)
+	}
+	if err == nil || !strings.Contains(err.Error(), "upstream down") {
+		t.Errorf("expected upstream down error, got %v", err)
+	}
+}
+
+func TestCachingTransport_CacheFilterRejects(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 500,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("server error")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Response returned to caller.
+	if resp.StatusCode != 500 {
+		t.Errorf("got status %d, want 500", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "server error" {
+		t.Errorf("got body %q, want %q", string(body), "server error")
+	}
+
+	// But NOT stored in cache.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 0 {
+		t.Errorf("store has %d tapes, want 0 (500 filtered out)", len(tapes))
+	}
+}
+
+func TestCachingTransport_SanitizationApplies(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	sanitizer := NewPipeline(RedactHeaders("Authorization"))
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheSanitizer(sanitizer),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// The stored tape should have the Authorization header redacted.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("store has %d tapes, want 1", len(tapes))
+	}
+	auth := tapes[0].Request.Headers.Get("Authorization")
+	if auth != Redacted {
+		t.Errorf("stored Authorization=%q, want %q", auth, Redacted)
+	}
+}
+
+func TestCachingTransport_SingleFlightDedup(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	var callCount atomic.Int64
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		callCount.Add(1)
+		time.Sleep(50 * time.Millisecond) // simulate slow upstream
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("response")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheSingleFlight(true),
+	)
+
+	const N = 10
+	var wg sync.WaitGroup
+	wg.Add(N)
+	errs := make([]error, N)
+	bodies := make([]string, N)
+
+	for i := 0; i < N; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+			resp, err := ct.RoundTrip(req)
+			errs[idx] = err
+			if resp != nil {
+				b, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				bodies[idx] = string(b)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Only 1 upstream call should have been made.
+	if c := callCount.Load(); c != 1 {
+		t.Errorf("upstream called %d times, want 1 (single-flight dedup)", c)
+	}
+
+	// All callers should get the response.
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Errorf("caller %d got error: %v", i, errs[i])
+		}
+		if bodies[i] != "response" {
+			t.Errorf("caller %d got body %q, want %q", i, bodies[i], "response")
+		}
+	}
+}
+
+func TestCachingTransport_SingleFlightDisabled(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	var callCount atomic.Int64
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		callCount.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("response")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheSingleFlight(false),
+	)
+
+	const N = 5
+	var wg sync.WaitGroup
+	wg.Add(N)
+
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+			resp, err := ct.RoundTrip(req)
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Without single-flight, each request should call upstream.
+	if c := callCount.Load(); c != int64(N) {
+		t.Errorf("upstream called %d times, want %d (single-flight disabled)", c, N)
+	}
+}
+
+func TestCachingTransport_MaxBodySizeBypass(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	var upstreamBody string
+	upstream := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		b, _ := io.ReadAll(req.Body)
+		upstreamBody = string(b)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheMaxBodySize(10), // 10 bytes limit
+	)
+
+	// Send a body larger than the limit.
+	bigBody := strings.Repeat("x", 20)
+	req, _ := http.NewRequest("POST", "http://example.com/api", strings.NewReader(bigBody))
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// Upstream should receive the full body.
+	if upstreamBody != bigBody {
+		t.Errorf("upstream got body len %d, want %d", len(upstreamBody), len(bigBody))
+	}
+
+	// Nothing should be cached.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 0 {
+		t.Errorf("store has %d tapes, want 0 (body too large)", len(tapes))
+	}
+}
+
+func TestCachingTransport_StoreSaveFailure(t *testing.T) {
+	t.Parallel()
+
+	fStore := &failingStore{MemoryStore: NewMemoryStore(), saveFail: true}
+
+	var capturedErr error
+	var errMu sync.Mutex
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, fStore,
+		WithCacheOnError(func(err error) {
+			errMu.Lock()
+			capturedErr = err
+			errMu.Unlock()
+		}),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Response still returned despite store failure.
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Errorf("got body %q, want %q", string(body), "ok")
+	}
+
+	// onError should have been called.
+	errMu.Lock()
+	if capturedErr == nil {
+		t.Error("onError not called on store save failure")
+	} else if !strings.Contains(capturedErr.Error(), "store write failure") {
+		t.Errorf("onError got %v, want store write failure", capturedErr)
+	}
+	errMu.Unlock()
+}
+
+func TestCachingTransport_UpstreamTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Use a flaky store: first List (cache lookup) fails, causing a miss.
+	// Stale fallback will call List again successfully.
+	ms := NewMemoryStore()
+	flakey := &flakeyListStore{MemoryStore: ms}
+	flakey.failCount.Store(1)
+
+	// Pre-populate store for stale fallback.
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/data",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("stale-data"),
+	})
+	ms.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		// Simulate a slow upstream that respects context cancellation.
+		select {
+		case <-time.After(5 * time.Second):
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("slow")),
+			}, nil
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	})
+
+	ct := NewCachingTransport(upstream, flakey,
+		WithCacheUpstreamTimeout(50*time.Millisecond),
+		WithCacheUpstreamDownFallback(true),
+		WithCacheSingleFlight(false),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected stale fallback on timeout, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "stale-data" {
+		t.Errorf("got body %q, want %q", string(body), "stale-data")
+	}
+	if stale := resp.Header.Get("X-Httptape-Stale"); stale != "true" {
+		t.Errorf("got X-Httptape-Stale=%q, want %q", stale, "true")
+	}
+}
+
+func TestCachingTransport_RouteFilter(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	// Store a tape with route "other".
+	tape := NewTape("other", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/data",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("other-route"),
+	})
+	store.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("from-upstream")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheRoute("api"),
+	)
+
+	// Request should NOT match the "other" route tape.
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if string(body) != "from-upstream" {
+		t.Errorf("got body %q, want %q (route should not match)", string(body), "from-upstream")
+	}
+
+	// Verify the new tape has the "api" route.
+	tapes, _ := store.List(context.Background(), Filter{Route: "api"})
+	if len(tapes) != 1 {
+		t.Fatalf("store has %d tapes with route 'api', want 1", len(tapes))
+	}
+	if tapes[0].Route != "api" {
+		t.Errorf("stored tape route=%q, want %q", tapes[0].Route, "api")
+	}
+}
+
+func TestCachingTransport_BodyRestoreAfterRead(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	var upstreamBody string
+	upstream := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		b, _ := io.ReadAll(req.Body)
+		upstreamBody = string(b)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	bodyStr := `{"prompt":"hello world"}`
+	req, _ := http.NewRequest("POST", "http://example.com/api/chat", strings.NewReader(bodyStr))
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// Upstream should have received the exact body.
+	if upstreamBody != bodyStr {
+		t.Errorf("upstream got body %q, want %q", upstreamBody, bodyStr)
+	}
+}
+
+func TestCachingTransport_DefaultMatcherDedups(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	var callCount atomic.Int64
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		callCount.Add(1)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("response")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	prompt := `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`
+
+	// First call: miss.
+	req1, _ := http.NewRequest("POST", "http://example.com/v1/completions", strings.NewReader(prompt))
+	resp1, err := ct.RoundTrip(req1)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	resp1.Body.Close()
+
+	// Second call with identical body: should be a hit.
+	req2, _ := http.NewRequest("POST", "http://example.com/v1/completions", strings.NewReader(prompt))
+	resp2, err := ct.RoundTrip(req2)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	resp2.Body.Close()
+
+	if c := callCount.Load(); c != 1 {
+		t.Errorf("upstream called %d times, want 1 (dedup by body hash)", c)
+	}
+}
+
+func TestCachingTransport_ConcurrentSafety(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	var callCount atomic.Int64
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		callCount.Add(1)
+		time.Sleep(10 * time.Millisecond)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	var wg sync.WaitGroup
+	const N = 50
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			path := fmt.Sprintf("/api/path-%d", idx%5)
+			req, _ := http.NewRequest("GET", "http://example.com"+path, nil)
+			resp, err := ct.RoundTrip(req)
+			if err == nil {
+				resp.Body.Close()
+			}
+		}(i)
+	}
+	wg.Wait()
+	// No panic = success for concurrent safety test.
+}
+
+func TestCachingTransport_PanicsOnNil(t *testing.T) {
+	t.Run("nil upstream", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic on nil upstream")
+			}
+		}()
+		NewCachingTransport(nil, NewMemoryStore())
+	})
+
+	t.Run("nil store", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic on nil store")
+			}
+		}()
+		NewCachingTransport(http.DefaultTransport, nil)
+	})
+}
+
+func TestCachingTransport_ImplementsRoundTripper(t *testing.T) {
+	t.Parallel()
+	ct := NewCachingTransport(http.DefaultTransport, NewMemoryStore())
+	var _ http.RoundTripper = ct
+}
+
+func TestCachingTransport_NilBody(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 204,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	req.Body = nil
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+}
+
+func TestCachingTransport_CustomCacheFilter(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	callNum := 0
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		callNum++
+		status := 200
+		if callNum == 1 {
+			status = 301
+		}
+		return &http.Response{
+			StatusCode: status,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(fmt.Sprintf("call-%d", callNum))),
+		}, nil
+	})
+
+	// Custom filter: cache everything, including 3xx.
+	ct := NewCachingTransport(upstream, store,
+		WithCacheFilter(func(resp *http.Response) bool {
+			return true
+		}),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/redirect", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// 301 should be cached.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("store has %d tapes, want 1", len(tapes))
+	}
+}
+
+func TestCachingTransport_WithCacheMaxBodySizeZero(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	// Zero means no limit.
+	ct := NewCachingTransport(upstream, store,
+		WithCacheMaxBodySize(0),
+	)
+
+	bigBody := strings.Repeat("x", 20*1024*1024) // 20 MiB
+	req, _ := http.NewRequest("POST", "http://example.com/api", strings.NewReader(bigBody))
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// Should be cached even though body is large.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Errorf("store has %d tapes, want 1 (no body size limit)", len(tapes))
+	}
+}
+
+func TestCachingTransport_Integration(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	// Create a real upstream server.
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprintf(w, `{"count":%d}`, callCount)
+	}))
+	defer srv.Close()
+
+	ct := NewCachingTransport(http.DefaultTransport, store)
+	client := &http.Client{Transport: ct}
+
+	// First request: hits upstream.
+	resp1, err := client.Get(srv.URL + "/api/data")
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+	if string(body1) != `{"count":1}` {
+		t.Errorf("first request body=%q, want %q", string(body1), `{"count":1}`)
+	}
+
+	// Second request: should be a cache hit (count stays 1).
+	resp2, err := client.Get(srv.URL + "/api/data")
+	if err != nil {
+		t.Fatalf("second request: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if string(body2) != `{"count":1}` {
+		t.Errorf("second request body=%q, want %q (cache hit)", string(body2), `{"count":1}`)
+	}
+
+	// Upstream should have been called only once.
+	if callCount != 1 {
+		t.Errorf("upstream called %d times, want 1", callCount)
+	}
+}
+
+func TestCachingTransport_StaleSSEFallback(t *testing.T) {
+	t.Parallel()
+
+	// Use a flaky store: first List fails (miss), second List succeeds (stale fallback).
+	ms := NewMemoryStore()
+	flakey := &flakeyListStore{MemoryStore: ms}
+	flakey.failCount.Store(1)
+
+	// Pre-populate store with an SSE tape.
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/stream",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/event-stream"}},
+		SSEEvents: []SSEEvent{
+			{OffsetMS: 0, Data: "stale-event"},
+		},
+	})
+	ms.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("upstream down")
+	})
+
+	ct := NewCachingTransport(upstream, flakey,
+		WithCacheUpstreamDownFallback(true),
+		WithCacheSingleFlight(false),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected stale SSE fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if stale := resp.Header.Get("X-Httptape-Stale"); stale != "true" {
+		t.Errorf("got X-Httptape-Stale=%q, want %q", stale, "true")
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "stale-event") {
+		t.Errorf("stale SSE body missing event: %q", string(body))
+	}
+}
+
+func TestCachingTransport_SingleFlightStaleFallbackForWaiters(t *testing.T) {
+	t.Parallel()
+
+	// Use a flaky store: initial List calls fail (one per goroutine,
+	// causing cache misses), then the stale fallback List succeeds.
+	const N = 5
+	ms := NewMemoryStore()
+	flakey := &flakeyListStore{MemoryStore: ms}
+	// All N goroutines call store.List in RoundTrip before entering
+	// single-flight. Set failCount to N so all initial lookups fail.
+	flakey.failCount.Store(N)
+
+	// Pre-populate store for stale fallback.
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/data",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("stale-data"),
+	})
+	ms.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		time.Sleep(50 * time.Millisecond)
+		return nil, errors.New("upstream down")
+	})
+
+	ct := NewCachingTransport(upstream, flakey,
+		WithCacheSingleFlight(true),
+		WithCacheUpstreamDownFallback(true),
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	responses := make([]*http.Response, N)
+	errs := make([]error, N)
+
+	for i := 0; i < N; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+			resp, err := ct.RoundTrip(req)
+			responses[idx] = resp
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	// All callers should get a stale fallback response.
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Errorf("caller %d got error: %v", i, errs[i])
+			continue
+		}
+		if responses[i] == nil {
+			t.Errorf("caller %d got nil response", i)
+			continue
+		}
+		body, _ := io.ReadAll(responses[i].Body)
+		responses[i].Body.Close()
+		if string(body) != "stale-data" {
+			t.Errorf("caller %d got body %q, want %q", i, string(body), "stale-data")
+		}
+		if stale := responses[i].Header.Get("X-Httptape-Stale"); stale != "true" {
+			t.Errorf("caller %d got X-Httptape-Stale=%q, want %q", i, stale, "true")
+		}
+	}
+}

--- a/caching_transport_test.go
+++ b/caching_transport_test.go
@@ -1076,6 +1076,69 @@ func TestCachingTransport_StaleSSEFallback(t *testing.T) {
 	}
 }
 
+func TestCachingTransport_SingleFlightSSEWaiters(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	// Create a test SSE upstream that streams events with a small delay.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher, _ := w.(http.Flusher)
+		for i := 0; i < 3; i++ {
+			fmt.Fprintf(w, "data: event-%d\n\n", i)
+			flusher.Flush()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	ct := NewCachingTransport(http.DefaultTransport, store,
+		WithCacheSingleFlight(true),
+	)
+
+	const N = 5
+	var wg sync.WaitGroup
+	wg.Add(N)
+	bodies := make([]string, N)
+	errs := make([]error, N)
+
+	// Use a barrier to ensure all goroutines start simultaneously.
+	barrier := make(chan struct{})
+
+	for i := 0; i < N; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-barrier
+			req, _ := http.NewRequest("GET", srv.URL+"/stream", nil)
+			resp, err := ct.RoundTrip(req)
+			errs[idx] = err
+			if resp != nil {
+				b, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				bodies[idx] = string(b)
+			}
+		}(i)
+	}
+
+	// Release all goroutines at once.
+	close(barrier)
+	wg.Wait()
+
+	// All callers should succeed and receive all 3 events.
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Errorf("caller %d got error: %v", i, errs[i])
+			continue
+		}
+		for _, ev := range []string{"event-0", "event-1", "event-2"} {
+			if !strings.Contains(bodies[i], ev) {
+				t.Errorf("caller %d body missing %q: %q", i, ev, bodies[i])
+			}
+		}
+	}
+}
+
 func TestCachingTransport_SingleFlightStaleFallbackForWaiters(t *testing.T) {
 	t.Parallel()
 

--- a/decisions.md
+++ b/decisions.md
@@ -14164,6 +14164,754 @@ All tests use stdlib `testing` only. Table-driven where appropriate.
 
 ---
 
+### ADR-44: CachingTransport library API with stale-fallback policy
+
+**Date**: 2026-04-18
+**Issues**: #202, #164
+**Status**: Accepted
+
+#### Context
+
+httptape exposes `Recorder` (forwards + records, no replay) and `Server`
+(replays only, no forward) as library primitives. The `proxy` CLI subcommand
+combines both -- cache by match, fall through on miss -- but that logic
+lives inside the CLI binary, not as a reusable `http.RoundTripper`. Consumers
+embedding httptape as a Go library (e.g., VibeWarden's Caddy-based egress
+proxy, single-binary deployment) need the combined logic exposed as a
+composable standard interface.
+
+Issue #202 defines the CachingTransport API surface. Issue #164 (sibling,
+same v0.13 milestone) defines the edge-case policy for "cache miss + upstream
+down." These are resolved together as a single architectural unit because
+#164's fallback semantics are a CachingTransport implementation concern.
+
+Two primary use cases drive priority:
+
+1. **Zero-cost demo hosting**: record ~50 real LLM responses once, replay
+   infinitely for every demo visitor. Sanitized fixtures committed to repo.
+2. **Egress proxy integration**: record in dev/staging, replay in tests.
+   VibeWarden's single-binary Caddy egress proxy wraps CachingTransport.
+
+#### Decision
+
+##### Resolved open questions
+
+**#202 Q1 -- Naming**: `CachingTransport`. Confirmed. Reads naturally for the
+LLM-cost use case; "replay" is misleading since it also records.
+
+**#202 Q2 -- Store failure during record**: return-and-log. Cache failures
+do not break the user's application. The `onError` callback reports it; the
+response is returned to the caller.
+
+**#202 Q3 -- CLI proxy refactor**: refactor `runProxy` in
+`cmd/httptape/main.go` to instantiate `CachingTransport` internally. Single
+source of truth for cache-through-upstream logic. The Proxy type is preserved
+but its `RoundTrip` delegates to CachingTransport (see CLI Refactor Plan).
+
+**#202 Q4 -- Cache-Control respect**: NO. This is not an RFC 7234 cache; it
+is a tape-match layer. LLM APIs return `no-store` and that is exactly what
+we override. Document prominently in godoc and in `docs/caching-transport.md`.
+
+**#202 Q5 -- Body size limits**: configurable `WithCacheMaxBodySize(n int)`
+(default 10 MiB = 10 * 1024 * 1024). Requests whose body exceeds the limit
+bypass cache entirely (pass through to upstream, response is not recorded).
+This prevents unbounded memory usage from large file uploads.
+
+**#202 Q6 -- TTL / eviction**: NO for v1. Fixtures are conceptually
+immutable. Manual pruning or `migrate-fixtures` if needed.
+
+**#202 Q7 -- Interaction with Recorder**: keep Recorder as the record-only
+primitive (audit use cases where you always want to capture). CachingTransport
+is the replay+record-on-miss sibling. Do not deprecate Recorder.
+
+**#164 Q1 -- Non-SSE cache miss + upstream down**: default behavior is
+transparent error propagation. A connection-refused from upstream returns the
+transport error to the caller. A 5xx from upstream returns the 5xx response.
+Optional stale-fallback behavior (opt-in via `WithCacheUpstreamDownFallback`)
+serves the most-recently-cached response with `X-Httptape-Stale: true` header.
+
+**#164 Q2 -- SSE cache miss + upstream down**: same as non-SSE. If no SSE
+tape is cached, propagate the error. If stale-fallback is enabled and a
+cached SSE tape exists, replay it with `X-Httptape-Stale: true` header. No
+partial-stream synthesis -- either a full cached tape exists or it does not.
+
+**#164 Q3 -- Timeout**: `WithCacheUpstreamTimeout(time.Duration)` defaulting
+to 0 (no timeout -- let the user's transport timeout dominate). When set,
+CachingTransport wraps the request context with a deadline before forwarding
+to upstream. On timeout, the fallback path is entered (same as transport
+error).
+
+##### Type: CachingTransport
+
+```go
+// CachingTransport is an http.RoundTripper that consults a tape Store on
+// each request. On cache hit, it returns the recorded response without
+// contacting upstream. On cache miss, it forwards to upstream, records the
+// response (after sanitization), and returns it.
+//
+// CachingTransport is NOT an RFC 7234 HTTP cache. It does not honor
+// Cache-Control, Vary, or any other HTTP caching headers. It is a
+// tape-match layer: identical requests (as defined by the Matcher) get
+// identical recorded responses.
+//
+// CachingTransport is safe for concurrent use by multiple goroutines.
+type CachingTransport struct {
+    upstream      http.RoundTripper
+    store         Store
+    matcher       Matcher
+    sanitizer     Sanitizer
+    route         string
+    onError       func(error)
+    cacheFilter   func(*http.Response) bool
+    singleFlight  bool
+    maxBodySize   int
+    sseRecording  bool
+
+    // stale-fallback (#164)
+    staleFallback bool
+    upstreamTimeout time.Duration
+
+    // single-flight coordination (stdlib-only)
+    sfMu    sync.Mutex
+    sfCalls map[string]*sfCall
+}
+```
+
+Where `sfCall` is an unexported type for single-flight coordination:
+
+```go
+// sfCall tracks an in-flight upstream request for single-flight dedup.
+type sfCall struct {
+    wg   sync.WaitGroup
+    resp *http.Response  // set before wg.Done
+    err  error           // set before wg.Done
+    body []byte          // buffered response body for sharing
+}
+```
+
+##### Single-flight implementation (stdlib-only)
+
+Manual single-flight using `sync.Mutex` + `map[string]*sfCall`:
+
+```go
+func (ct *CachingTransport) doSingleFlight(key string, fn func() (*http.Response, []byte, error)) (*http.Response, []byte, error) {
+    ct.sfMu.Lock()
+    if call, ok := ct.sfCalls[key]; ok {
+        ct.sfMu.Unlock()
+        call.wg.Wait()
+        // Clone the response for each waiter
+        return cloneResponse(call.resp, call.body), copyBytes(call.body), call.err
+    }
+    call := &sfCall{}
+    call.wg.Add(1)
+    ct.sfCalls[key] = call
+    ct.sfMu.Unlock()
+
+    resp, body, err := fn()
+    call.resp = resp
+    call.body = body
+    call.err = err
+    call.wg.Done()
+
+    ct.sfMu.Lock()
+    delete(ct.sfCalls, key)
+    ct.sfMu.Unlock()
+
+    return resp, body, err
+}
+```
+
+The key is computed from the match dimensions: `method + "|" + path + "|" + bodyHash`.
+This is a ~30-line stdlib-only implementation that avoids the `x/sync/singleflight`
+dependency while providing the same dedup semantics.
+
+Waiters receive a cloned response (fresh `io.ReadCloser` over the same body
+bytes) so each caller gets an independent, consumable response.
+
+##### CachingOption type and constructors
+
+```go
+// CachingOption configures a CachingTransport.
+type CachingOption func(*CachingTransport)
+
+// WithCacheMatcher sets the Matcher used to identify equivalent requests.
+// Default: NewCompositeMatcher(MethodCriterion{}, PathCriterion{}, BodyHashCriterion{}).
+func WithCacheMatcher(m Matcher) CachingOption
+
+// WithCacheSanitizer sets the sanitization pipeline applied to recorded
+// tapes before store persistence. Default: NewPipeline() (no-op).
+func WithCacheSanitizer(s Sanitizer) CachingOption
+
+// WithCacheFilter sets a predicate controlling which upstream responses
+// are cached. Only responses for which fn returns true are persisted.
+// Default: cache 2xx responses only.
+func WithCacheFilter(fn func(*http.Response) bool) CachingOption
+
+// WithCacheSingleFlight controls single-flight deduplication of concurrent
+// cache misses. When true (default), concurrent requests with the same match
+// key share a single upstream call.
+func WithCacheSingleFlight(enabled bool) CachingOption
+
+// WithCacheMaxBodySize sets the maximum request body size in bytes for
+// cache participation. Requests whose body exceeds this limit bypass the
+// cache entirely (forwarded to upstream, response not recorded).
+// Default: 10 MiB (10 * 1024 * 1024).
+// A value of 0 means no limit.
+func WithCacheMaxBodySize(n int) CachingOption
+
+// WithCacheRoute sets the route label applied to all tapes created by
+// this transport.
+func WithCacheRoute(route string) CachingOption
+
+// WithCacheOnError sets a callback invoked when a non-fatal error occurs
+// (store failure, body read failure on the record path). Defaults to no-op.
+func WithCacheOnError(fn func(error)) CachingOption
+
+// WithCacheSSERecording controls whether SSE stream recording is enabled.
+// When true (default), SSE responses on the miss path are tee'd to the
+// caller and accumulated for tape persistence.
+func WithCacheSSERecording(enabled bool) CachingOption
+
+// WithCacheUpstreamDownFallback enables stale-response fallback when
+// upstream is unreachable or returns a transport error on a cache miss.
+// When enabled, CachingTransport searches the store for the best-matching
+// tape (using the configured Matcher) and returns it with an
+// X-Httptape-Stale: true header. When disabled (default), transport errors
+// are propagated to the caller.
+//
+// This is useful for demo hosting (upstream flakiness should not break the
+// demo) but wrong for integration tests (which should see the real failure).
+func WithCacheUpstreamDownFallback(enabled bool) CachingOption
+
+// WithCacheUpstreamTimeout sets a timeout for upstream requests on cache
+// miss. When set, the request context is wrapped with a deadline before
+// forwarding. Default: 0 (no timeout; the caller's http.Client timeout
+// dominates).
+func WithCacheUpstreamTimeout(d time.Duration) CachingOption
+```
+
+##### Constructor
+
+```go
+// NewCachingTransport creates a new CachingTransport wrapping the given
+// upstream transport with store-backed caching.
+//
+// On RoundTrip, it consults the store for a matching tape. On hit, it
+// returns the recorded response. On miss, it forwards to upstream, records
+// the response (after sanitization), and returns it.
+//
+// upstream and store must not be nil. Panics on nil (constructor guard per
+// CLAUDE.md).
+//
+// Default configuration:
+//   - matcher: method + path + body_hash
+//   - sanitizer: no-op Pipeline
+//   - cache filter: 2xx only
+//   - single-flight: enabled
+//   - max body size: 10 MiB
+//   - SSE recording: enabled
+//   - stale fallback: disabled
+//   - upstream timeout: 0 (no timeout)
+//   - route: ""
+//   - onError: no-op
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
+```
+
+##### RoundTrip flow (non-SSE)
+
+```
+1. Read request body into buffer (respecting maxBodySize).
+   - If body exceeds maxBodySize: restore body on req, pass through to
+     upstream directly (no cache lookup, no recording). Return.
+
+2. Compute body hash from buffer.
+
+3. Replace req.Body with fresh reader over buffer (upstream can consume it).
+
+4. Compute single-flight key: method + "|" + URL.Path + "|" + bodyHash.
+
+5. Cache lookup: store.List(ctx, Filter{Route: route}) -> matcher.Match(req, tapes).
+
+6. HIT: synthesize *http.Response from tape.
+   - For non-SSE tapes: set headers, wrap body in io.NopCloser(bytes.NewReader(body)).
+   - For SSE tapes: use piped body with event replay (same as Proxy.sseResponseFromTape).
+   - Return response with no X-Httptape-Source header (cache hits are transparent).
+
+7. MISS: forward to upstream (with optional single-flight dedup).
+   a. If upstreamTimeout > 0, wrap context with timeout.
+   b. If singleFlight, use doSingleFlight(key, fn). Otherwise call fn directly.
+   c. fn: upstream.RoundTrip(req).
+   d. On transport error:
+      - If staleFallback: search store for best match, return with
+        X-Httptape-Stale: true. If no match, propagate error.
+      - If !staleFallback: propagate error.
+   e. On success:
+      - Read response body into buffer.
+      - Restore response body with fresh reader.
+      - Check cacheFilter(resp). If false, return response without recording.
+      - Build Tape from request + response.
+      - Apply sanitizer.
+      - Store.Save (synchronous). On failure, call onError; still return response.
+      - Return response.
+```
+
+##### SSE tee flow on miss
+
+When the upstream response has `Content-Type: text/event-stream` and SSE
+recording is enabled:
+
+```
+1. Request arrives, cache miss (no matching tape).
+
+2. Upstream returns SSE response (200 with text/event-stream).
+
+3. CachingTransport wraps the upstream response body in an
+   sseRecordingReader (same as Recorder.roundTripSSE). The wrapper:
+
+   a. Tees upstream bytes to the caller via Read().
+   b. Background goroutine parses the tee'd stream into SSEEvents.
+   c. Each parsed event is appended to an in-memory slice.
+
+4. Caller reads response.Body, receiving events as they arrive from
+   upstream (streaming, not buffered).
+
+5. When upstream closes the stream (EOF) or caller closes body:
+   a. The sseRecordingReader's onDone callback fires.
+   b. If the stream was cleanly completed (no error):
+      - Build Tape with SSEEvents.
+      - Apply sanitizer (uses RedactSSEEventData/FakeSSEEventData if
+        configured in the pipeline).
+      - Store.Save.
+   c. If the stream was truncated (client disconnect mid-stream):
+      - Discard the partial tape. Do NOT persist incomplete SSE tapes.
+      - Call onError with a diagnostic message.
+
+6. On subsequent requests with the same match key:
+   a. Cache hit returns the stored SSE tape.
+   b. Response body is a piped stream replaying events with instant
+      timing (SSETimingInstant, same as Proxy fallback default).
+```
+
+Single-flight coordination for SSE misses: the first caller gets the
+live tee'd stream. Concurrent callers with the same key WAIT for the
+first caller's stream to complete, then get the cached tape (replay).
+This is different from non-SSE single-flight (where all waiters get a
+cloned response). Rationale: SSE streams are long-lived; cloning a
+live stream to multiple waiters would require a fan-out implementation
+that is disproportionately complex for v1. The wait-then-replay approach
+is simpler and correct.
+
+##### SSE replay on hit
+
+On cache hit for an SSE tape, CachingTransport synthesizes a response
+using the same `sseResponseFromTape` pattern as Proxy:
+
+```go
+func (ct *CachingTransport) sseResponseFromTape(tape Tape) *http.Response {
+    header := tape.Response.Headers.Clone()
+    header.Set("Content-Type", "text/event-stream")
+    header.Del("Content-Length")
+
+    pr, pw := io.Pipe()
+    go func() {
+        for _, ev := range tape.Response.SSEEvents {
+            if err := writeSSEEvent(pw, ev); err != nil {
+                pw.CloseWithError(err)
+                return
+            }
+        }
+        pw.Close()
+    }()
+
+    return &http.Response{
+        StatusCode: tape.Response.StatusCode,
+        Header:     header,
+        Body:       pr,
+    }
+}
+```
+
+No timing delay on replay -- events are emitted back-to-back (instant).
+This matches the RoundTripper contract (callers expect responses quickly).
+If callers need timing fidelity, they should use the Server (http.Handler)
+which supports SSETimingMode.
+
+##### Stale-fallback implementation (#164)
+
+When `staleFallback` is enabled and an upstream call fails (transport error
+or timeout):
+
+```go
+func (ct *CachingTransport) serveStaleFallback(req *http.Request) (*http.Response, error) {
+    tapes, err := ct.store.List(req.Context(), Filter{Route: ct.route})
+    if err != nil {
+        return nil, fmt.Errorf("httptape: stale fallback store list: %w", err)
+    }
+
+    tape, ok := ct.matcher.Match(req, tapes)
+    if !ok {
+        return nil, nil // no stale match available
+    }
+
+    resp := ct.tapeToResponse(tape)
+    resp.Header.Set("X-Httptape-Stale", "true")
+    return resp, nil
+}
+```
+
+The matcher is the SAME matcher used for the cache lookup. The "most recently
+cached response" is naturally the result of the matcher since the matcher
+picks the best match from the store's current contents. If multiple tapes
+match, the matcher's scoring and ordering rules apply (same as normal cache
+hit).
+
+The `X-Httptape-Stale: true` header signals to callers that the response
+is from a stale cache, not from upstream. This is critical for observability
+(VibeWarden dashboard, demo health indicators).
+
+##### Error-handling matrix
+
+| Failure mode | Caller sees | Notes |
+|---|---|---|
+| Request body exceeds maxBodySize | Upstream response (bypass cache) | No recording |
+| Request body read fails | `error` (wrapped) | Cannot proceed |
+| Store.List fails on cache lookup | Upstream response (miss path) | onError called |
+| Matcher finds no match (cache miss) | Upstream response | Normal miss flow |
+| Upstream transport error (miss) | `error` (propagated) OR stale response if staleFallback | See #164 |
+| Upstream returns non-2xx (filtered) | Upstream response (not cached) | Response returned, not recorded |
+| Upstream response body read fails | Upstream response (partial) | onError called, not cached |
+| Sanitizer fails | Upstream response | onError called, tape not saved |
+| Store.Save fails (record path) | Upstream response | onError called |
+| Single-flight coordination | Cloned response for waiters | Waiters get independent body readers |
+| SSE stream truncated (client disconnect) | Partial stream (no tape persisted) | onError called |
+| SSE upstream error mid-stream | Error propagated on Read() | Partial tape discarded |
+| Store.List fails on stale fallback | `error` (original transport error) | onError called |
+
+##### CachingTransport vs Proxy relationship
+
+CachingTransport is a simpler, single-store primitive:
+- One store (not L1+L2)
+- Single-flight dedup (Proxy has none)
+- No health endpoint
+- Pure RoundTripper (no CLI, no reverse proxy)
+
+Proxy (existing) is a richer, CLI-oriented primitive:
+- L1 (raw/ephemeral) + L2 (sanitized/persistent) two-tier cache
+- Health endpoint surface
+- CLI subcommand integration
+- No single-flight (acceptable for CLI proxy where request volume is lower)
+
+The CLI proxy subcommand can be refactored to compose CachingTransport
+internally. However, the two-tier L1/L2 architecture of Proxy does not
+map directly to CachingTransport's single-store model. Two options:
+
+**Option A -- Proxy wraps CachingTransport for the miss path**: Proxy
+keeps its L1/L2 split but delegates cache-miss-then-upstream to
+CachingTransport (configured with L2 as its store). L1 remains managed
+by Proxy directly. This preserves Proxy's L1/L2 semantics while
+sharing the upstream+record logic.
+
+**Option B -- Refactor Proxy to use CachingTransport as transport**:
+Proxy sets CachingTransport as its `transport` field. CachingTransport
+handles L2 cache lookup + upstream + recording. Proxy adds L1 as a
+fast pre-check. On Proxy.RoundTrip:
+1. Check L1. Hit -> return from L1.
+2. Forward to CachingTransport (which checks L2, then upstream).
+3. On CachingTransport miss-then-upstream-success, Proxy intercepts
+   the response to also save raw to L1.
+
+**Decision**: Option B. CachingTransport is the upstream's transport.
+Proxy wraps it, adding L1 as a pre-check layer and raw-save on success.
+This cleanly reuses CachingTransport's single-flight, body-buffering,
+SSE-tee, and sanitization logic without duplication.
+
+Refactoring steps:
+1. In `NewProxy`, construct a CachingTransport internally:
+   ```go
+   ct := NewCachingTransport(p.transport, p.l2,
+       WithCacheMatcher(p.matcher),
+       WithCacheSanitizer(p.sanitizer),
+       WithCacheRoute(p.route),
+       WithCacheOnError(p.onError),
+   )
+   ```
+2. Proxy.RoundTrip becomes:
+   a. Capture request body (for L1 matching).
+   b. Check L1 cache. Hit -> return from L1 with `X-Httptape-Source: l1-cache`.
+   c. Forward to CachingTransport.RoundTrip.
+   d. On success, save raw tape to L1 (CachingTransport already saved
+      sanitized to L2).
+   e. Return response.
+
+This preserves all existing Proxy behavior:
+- L1 pre-check (raw, fast)
+- L2 handled by CachingTransport
+- Sanitization on L2 only
+- Health endpoint unchanged
+- Fallback: L1 first, L2 (via CachingTransport stale-fallback) second
+- All existing CLI flags, stdout/stderr, exit codes unchanged
+
+##### File layout
+
+**New files:**
+- `caching_transport.go` -- `CachingTransport` struct, `CachingOption` type,
+  all `WithCache*` option functions, `NewCachingTransport`, `RoundTrip`,
+  single-flight implementation, SSE tee/replay helpers, stale-fallback logic.
+- `caching_transport_test.go` -- unit and integration tests.
+- `docs/caching-transport.md` -- user-facing documentation.
+
+**Modified files:**
+- `proxy.go` -- refactor to compose CachingTransport internally. Proxy keeps
+  its public API unchanged. Internal `RoundTrip` delegates to CachingTransport
+  for the L2+upstream path. L1 pre-check remains Proxy-owned.
+- `proxy_test.go` -- existing tests must continue to pass. Add tests
+  verifying CachingTransport composition.
+- `cmd/httptape/main.go` -- no change to `runProxy` flags or behavior. The
+  refactor is internal to the `Proxy` type.
+- `CLAUDE.md` -- add `caching_transport.go` and `caching_transport_test.go`
+  to the package structure table.
+- `CHANGELOG.md` -- add v0.13.0 entry for CachingTransport.
+- `docs/proxy.md` -- cross-reference CachingTransport as the library primitive.
+- `docs/api-reference.md` -- add CachingTransport section.
+- `docs/recording.md` -- mention CachingTransport as the replay+record sibling.
+- `docs/cli.md` -- note that `proxy` subcommand uses CachingTransport internally.
+- `llms.txt`, `llms-full.txt` -- refresh with new surface area.
+
+**Not modified:**
+- `recorder.go` -- not deprecated; remains the record-only primitive.
+- `server.go` -- `serveSSE` stays as-is; CachingTransport uses the
+  `writeSSEEvent` and `sseRecordingReader` helpers from `sse.go` which are
+  already shared.
+- `store.go`, `store_file.go`, `store_memory.go` -- unchanged.
+- `matcher.go` -- unchanged.
+- `sanitizer.go` -- unchanged; `Pipeline.Sanitize` is called as-is.
+- `tape.go` -- unchanged.
+
+#### Types
+
+```go
+// CachingTransport struct (see above for full field list)
+type CachingTransport struct { ... }
+
+// CachingOption functional option type
+type CachingOption func(*CachingTransport)
+
+// sfCall -- unexported single-flight call tracker
+type sfCall struct {
+    wg   sync.WaitGroup
+    resp *http.Response
+    err  error
+    body []byte
+}
+```
+
+#### Functions and methods
+
+```go
+// Constructor
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
+
+// http.RoundTripper implementation
+func (ct *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error)
+
+// Option functions
+func WithCacheMatcher(m Matcher) CachingOption
+func WithCacheSanitizer(s Sanitizer) CachingOption
+func WithCacheFilter(fn func(*http.Response) bool) CachingOption
+func WithCacheSingleFlight(enabled bool) CachingOption
+func WithCacheMaxBodySize(n int) CachingOption
+func WithCacheRoute(route string) CachingOption
+func WithCacheOnError(fn func(error)) CachingOption
+func WithCacheSSERecording(enabled bool) CachingOption
+func WithCacheUpstreamDownFallback(enabled bool) CachingOption
+func WithCacheUpstreamTimeout(d time.Duration) CachingOption
+
+// Internal methods (unexported)
+func (ct *CachingTransport) doSingleFlight(key string, fn func() (*http.Response, []byte, error)) (*http.Response, []byte, error)
+func (ct *CachingTransport) serveStaleFallback(req *http.Request) (*http.Response, error)
+func (ct *CachingTransport) tapeToResponse(tape Tape) *http.Response
+func (ct *CachingTransport) sseResponseFromTape(tape Tape) *http.Response
+func (ct *CachingTransport) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte) (*http.Response, error)
+func (ct *CachingTransport) onErrorSafe(err error)
+```
+
+#### Sequence: cache hit (non-SSE)
+
+```
+Client -> CachingTransport.RoundTrip(req)
+  1. Read req.Body into buffer, compute bodyHash
+  2. Restore req.Body with fresh reader
+  3. store.List(ctx, Filter{Route: route})
+  4. matcher.Match(req, tapes) -> tape, true
+  5. Build *http.Response from tape (headers, body, status)
+  6. Return response
+Client <- *http.Response
+```
+
+#### Sequence: cache miss (non-SSE)
+
+```
+Client -> CachingTransport.RoundTrip(req)
+  1. Read req.Body into buffer, compute bodyHash
+  2. Restore req.Body with fresh reader
+  3. store.List(ctx, Filter{Route: route})
+  4. matcher.Match(req, tapes) -> _, false
+  5. Compute singleFlight key: method|path|bodyHash
+  6. [If singleFlight] Enter doSingleFlight(key, fn)
+  7. [If upstreamTimeout > 0] Wrap ctx with deadline
+  8. upstream.RoundTrip(req) -> resp, nil
+  9. Read resp.Body into buffer
+  10. Restore resp.Body with fresh reader
+  11. cacheFilter(resp) -> true
+  12. Build Tape{Request: ..., Response: ...}
+  13. sanitizer.Sanitize(tape) -> sanitizedTape
+  14. store.Save(ctx, sanitizedTape) -> nil [onError if err]
+  15. Return response
+Client <- *http.Response
+```
+
+#### Sequence: cache miss, SSE tee
+
+```
+Client -> CachingTransport.RoundTrip(req)
+  1. Read req.Body into buffer, compute bodyHash
+  2. Restore req.Body, cache lookup -> miss
+  3. upstream.RoundTrip(req) -> resp (Content-Type: text/event-stream)
+  4. Wrap resp.Body in sseRecordingReader(resp.Body, startTime, onEvent, onDone)
+     - onEvent: append SSEEvent to in-memory list
+     - onDone(nil): build Tape with SSEEvents, sanitize, store.Save
+     - onDone(err): discard partial tape, call onError
+  5. Return response with wrapped body
+Client <- *http.Response (streaming)
+  Client reads events as they arrive from upstream
+  When stream completes -> onDone fires -> tape persisted
+```
+
+#### Sequence: cache miss, upstream down, stale fallback
+
+```
+Client -> CachingTransport.RoundTrip(req)
+  1. Read req.Body, compute bodyHash, cache lookup -> miss
+  2. upstream.RoundTrip(req) -> nil, error (connection refused)
+  3. staleFallback == true
+  4. store.List(ctx, Filter{Route: route})
+  5. matcher.Match(req, tapes) -> tape, true
+  6. Build *http.Response from tape
+  7. Set X-Httptape-Stale: true header
+  8. Return response
+Client <- *http.Response (stale, with diagnostic header)
+```
+
+#### Error cases
+
+See error-handling matrix above.
+
+#### Test strategy
+
+**Unit tests (caching_transport_test.go):**
+
+1. **Cache hit -- non-SSE**: pre-populated MemoryStore, request matches ->
+   returns cached response, upstream NOT called.
+2. **Cache hit -- SSE**: pre-populated store with SSE tape, request matches ->
+   returns piped SSE stream, upstream NOT called.
+3. **Cache miss -- non-SSE**: empty store, upstream called, response cached,
+   second identical request returns cached response.
+4. **Cache miss -- SSE tee**: empty store, upstream returns SSE, events tee'd,
+   tape persisted after stream completes.
+5. **Cache miss -- SSE partial disconnect**: client closes body mid-stream,
+   partial tape NOT persisted.
+6. **Upstream error propagation**: upstream returns error, no stale fallback ->
+   error returned to caller.
+7. **Stale fallback -- hit**: upstream error + staleFallback=true +
+   pre-populated store -> stale response with X-Httptape-Stale: true.
+8. **Stale fallback -- miss**: upstream error + staleFallback=true + empty
+   store -> error propagated.
+9. **Cache filter rejects**: upstream returns 500, default filter (2xx only)
+   -> response returned but not cached.
+10. **Sanitization applies**: configure pipeline with RedactHeaders, verify
+    stored tape has redacted headers, original response is unmodified.
+11. **Single-flight dedup**: two goroutines send identical request
+    concurrently on cache miss -> upstream called exactly once.
+12. **MaxBodySize bypass**: request with body > limit -> forwarded without
+    cache interaction.
+13. **Store.Save failure**: mock store fails on Save -> response still
+    returned, onError called.
+14. **Upstream timeout**: WithCacheUpstreamTimeout set, upstream delays ->
+    context deadline exceeded, stale fallback attempted.
+15. **Route filter**: WithCacheRoute("api") set -> only tapes with matching
+    route are considered.
+16. **Concurrent safety**: `go test -race` with multiple goroutines calling
+    RoundTrip with mixed hits/misses.
+
+**Test patterns:**
+- MemoryStore for all store interactions.
+- `httptest.NewServer` for upstream simulation.
+- `RoundTripFunc` adapter for transport injection.
+- Table-driven tests where practical.
+- `testing.T.Parallel()` for independent tests.
+
+**Integration tests (in caching_transport_test.go or integration_test.go):**
+- End-to-end with `http.Client{Transport: ct}` -> httptest upstream ->
+  MemoryStore. Verify: first request hits upstream, second request serves
+  from cache, third request after upstream goes down serves stale (if
+  configured).
+
+#### Alternatives considered
+
+1. **Custom Caddy module for VibeWarden**: rejected because it duplicates
+   httptape's core logic inside a specific framework. CachingTransport is
+   framework-agnostic -- VibeWarden wraps it in Caddy, others wrap it in
+   stdlib, Gin, Echo, etc.
+
+2. **RFC 7234 compliant cache**: rejected because POST requests are
+   uncacheable in RFC 7234. LLM APIs use POST for completions -- the
+   primary use case. httptape is a tape-match layer, not a standards-compliant
+   HTTP cache.
+
+3. **Passthrough Recorder with retroactive match check**: rejected because it
+   always forwards to upstream (defeating the cache-hit zero-cost property).
+   The whole point is to NOT call upstream when a matching tape exists.
+
+4. **Extend existing Proxy with single-flight and single-store mode**: rejected
+   because Proxy's L1/L2 architecture, health endpoint, and CLI integration
+   add complexity that library embedders don't need. CachingTransport is the
+   minimal primitive; Proxy composes it.
+
+5. **External `golang.org/x/sync/singleflight`**: rejected per stdlib-only
+   constraint. The manual implementation is ~30 lines and well-understood.
+
+#### Consequences
+
+**What becomes possible:**
+- VibeWarden single-binary egress proxy with httptape embedded. No sidecar.
+- Zero-cost LLM demo hosting: record 50 responses, replay infinitely.
+- Any Go developer can drop CachingTransport into `http.Client{Transport: ct}`
+  for transparent caching with sanitization.
+- Proxy CLI subcommand shares the same cache-through logic via composition.
+
+**What changes:**
+- Proxy's internal RoundTrip is refactored to delegate to CachingTransport for
+  the L2+upstream path. External behavior is unchanged (same flags, same
+  stdout/stderr, same exit codes).
+- New file `caching_transport.go` added to the package.
+
+**What breaks:**
+- Nothing. Purely additive. All existing types, constructors, options, and CLI
+  commands remain unchanged. Proxy's internal refactor preserves all observable
+  behavior.
+
+**Future implications:**
+- Admin endpoints (#194) can be added to CachingTransport later via a
+  `WithCacheAdminHandler()` option that exposes cache stats and purge
+  endpoints. The design leaves room for this.
+- TTL/eviction can be added via a `WithCacheTTL(time.Duration)` option that
+  filters out expired tapes during cache lookup. The store interface remains
+  unchanged -- TTL is implemented as a client-side filter on `List` results.
+- The Proxy refactor demonstrates that CachingTransport is composable as a
+  building block, not a monolith.
+
+---
+
 
 ## PM Log
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -114,6 +114,36 @@ Panics if `store` is nil.
 
 ---
 
+## CachingTransport
+
+```go
+type CachingTransport struct { /* unexported */ }
+
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
+func (ct *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error) // implements http.RoundTripper
+```
+
+Panics if `upstream` or `store` is nil.
+
+### CachingOption
+
+| Option | Signature | Default |
+|--------|-----------|---------|
+| WithCacheMatcher | `WithCacheMatcher(m Matcher)` | method + path + body_hash |
+| WithCacheSanitizer | `WithCacheSanitizer(s Sanitizer)` | no-op Pipeline |
+| WithCacheFilter | `WithCacheFilter(fn func(*http.Response) bool)` | 2xx only |
+| WithCacheSingleFlight | `WithCacheSingleFlight(enabled bool)` | `true` |
+| WithCacheMaxBodySize | `WithCacheMaxBodySize(n int)` | 10 MiB |
+| WithCacheRoute | `WithCacheRoute(route string)` | `""` |
+| WithCacheOnError | `WithCacheOnError(fn func(error))` | no-op |
+| WithCacheSSERecording | `WithCacheSSERecording(enabled bool)` | `true` |
+| WithCacheUpstreamDownFallback | `WithCacheUpstreamDownFallback(enabled bool)` | `false` |
+| WithCacheUpstreamTimeout | `WithCacheUpstreamTimeout(d time.Duration)` | `0` (no timeout) |
+
+**Details:** [CachingTransport](caching-transport.md)
+
+---
+
 ## Proxy
 
 ```go

--- a/docs/caching-transport.md
+++ b/docs/caching-transport.md
@@ -1,0 +1,369 @@
+# CachingTransport
+
+CachingTransport is an `http.RoundTripper` that provides transparent, store-backed caching for HTTP requests. On cache hit, it returns the recorded response without contacting upstream. On cache miss, it forwards to upstream, records the response (with optional sanitization), and returns it.
+
+CachingTransport is the library primitive for cache-through-upstream logic. Use it when you want to embed httptape's caching behavior into any Go application via a standard `http.Client`.
+
+## When to use CachingTransport
+
+| Use case | Solution |
+|----------|----------|
+| Embed cache-through-upstream in your Go app | **CachingTransport** |
+| Two-tier L1/L2 cache with CLI integration | [Proxy](proxy.md) (composes CachingTransport internally) |
+| Record-only (audit, capture) | [Recorder](recording.md) |
+| Replay-only (mock server) | [Server](replay.md) |
+
+CachingTransport is the right choice when:
+- You want zero-cost demo hosting: record real LLM responses once, replay infinitely for every demo visitor.
+- You are building an egress proxy and want transparent caching with sanitization.
+- You need single-flight dedup (concurrent identical requests share one upstream call).
+- You want a single-store model (simpler than Proxy's L1/L2 split).
+
+## Not an RFC 7234 cache
+
+CachingTransport does **not** honor `Cache-Control`, `Vary`, or any other HTTP caching headers. It is a tape-match layer: identical requests (as defined by the configured Matcher) always get identical recorded responses. This is deliberate -- LLM APIs return `no-store`, and overriding that is the primary use case.
+
+## Basic usage
+
+```go
+store := httptape.NewMemoryStore()
+
+ct := httptape.NewCachingTransport(http.DefaultTransport, store)
+
+client := &http.Client{Transport: ct}
+resp, err := client.Get("https://api.example.com/users")
+// First call: upstream is contacted, response is cached.
+// Second call: response is returned from cache (upstream is not contacted).
+```
+
+## With sanitization
+
+```go
+store, _ := httptape.NewFileStore(httptape.WithDirectory("./cache"))
+
+sanitizer := httptape.NewPipeline(
+    httptape.RedactHeaders("Authorization", "Cookie"),
+    httptape.RedactBodyPaths("$.password"),
+    httptape.FakeFields("my-seed", "$.user.email"),
+)
+
+ct := httptape.NewCachingTransport(http.DefaultTransport, store,
+    httptape.WithCacheSanitizer(sanitizer),
+    httptape.WithCacheRoute("users-api"),
+)
+
+client := &http.Client{Transport: ct}
+```
+
+Sanitization is applied to tapes before store persistence. The response returned to the caller is always the original, unsanitized response.
+
+## Constructor
+
+```go
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
+```
+
+Both `upstream` and `store` must be non-nil. Panics on nil (constructor guard).
+
+### Default configuration
+
+| Setting | Default |
+|---------|---------|
+| Matcher | method + path + body_hash |
+| Sanitizer | no-op Pipeline |
+| Cache filter | 2xx responses only |
+| Single-flight | enabled |
+| Max body size | 10 MiB |
+| SSE recording | enabled |
+| Stale fallback | disabled |
+| Upstream timeout | 0 (no timeout) |
+| Route | `""` |
+| OnError | no-op |
+
+## Options
+
+### WithCacheMatcher
+
+```go
+httptape.WithCacheMatcher(matcher)
+```
+
+Sets the `Matcher` used to identify equivalent requests. Default: method + path + body hash (appropriate for APIs where the body determines the response, such as LLM completions).
+
+### WithCacheSanitizer
+
+```go
+httptape.WithCacheSanitizer(sanitizer)
+```
+
+Sets the sanitization pipeline applied to recorded tapes before store persistence. The caller always receives the original, unsanitized response.
+
+### WithCacheFilter
+
+```go
+httptape.WithCacheFilter(func(resp *http.Response) bool {
+    return resp.StatusCode >= 200 && resp.StatusCode < 300
+})
+```
+
+Controls which upstream responses are cached. Only responses for which the function returns true are persisted. Default: 2xx responses only. To cache all responses:
+
+```go
+httptape.WithCacheFilter(func(resp *http.Response) bool { return true })
+```
+
+### WithCacheSingleFlight
+
+```go
+httptape.WithCacheSingleFlight(true)  // default
+httptape.WithCacheSingleFlight(false) // disable
+```
+
+Controls single-flight deduplication of concurrent cache misses. When enabled, concurrent requests with the same match key (method + path + body hash) share a single upstream call. Each waiter receives an independent response with its own body reader.
+
+For SSE responses, the first caller gets the live tee'd stream. Concurrent callers wait for the stream to complete, then get the cached tape.
+
+### WithCacheMaxBodySize
+
+```go
+httptape.WithCacheMaxBodySize(1 << 20)  // 1 MiB
+httptape.WithCacheMaxBodySize(0)        // no limit
+```
+
+Sets the maximum request body size in bytes for cache participation. Requests whose body exceeds this limit bypass the cache entirely (forwarded to upstream, response not recorded). Default: 10 MiB.
+
+### WithCacheRoute
+
+```go
+httptape.WithCacheRoute("llm-api")
+```
+
+Labels all tapes created by this transport with a route name. Only tapes with a matching route are considered during cache lookup.
+
+### WithCacheOnError
+
+```go
+httptape.WithCacheOnError(func(err error) {
+    log.Printf("caching transport: %v", err)
+})
+```
+
+Sets a callback invoked when a non-fatal error occurs (store failure, body read failure on the record path). Non-fatal errors do not affect the response returned to the caller.
+
+### WithCacheSSERecording
+
+```go
+httptape.WithCacheSSERecording(true)  // default
+httptape.WithCacheSSERecording(false) // disable
+```
+
+Controls whether SSE (Server-Sent Events) stream recording is enabled. When enabled, SSE responses on the miss path are tee'd to the caller while events are accumulated and persisted as a tape. See [SSE recording](#sse-recording) below.
+
+### WithCacheUpstreamDownFallback
+
+```go
+httptape.WithCacheUpstreamDownFallback(true)
+```
+
+Enables stale-response fallback when upstream is unreachable or returns a transport error on a cache miss. When enabled, CachingTransport searches the store for the best-matching tape and returns it with an `X-Httptape-Stale: true` header. When disabled (default), transport errors are propagated to the caller.
+
+This is useful for demo hosting (upstream flakiness should not break the demo) but wrong for integration tests (which should see the real failure).
+
+### WithCacheUpstreamTimeout
+
+```go
+httptape.WithCacheUpstreamTimeout(5 * time.Second)
+```
+
+Sets a timeout for upstream requests on cache miss. When set, the request context is wrapped with a deadline before forwarding. On timeout, the stale-fallback path is entered (if enabled). Default: 0 (no timeout; the caller's `http.Client` timeout dominates).
+
+## How it works
+
+### Cache hit
+
+```
+Request
+  |
+  v
+Read request body, compute body hash
+  |
+  v
+Store.List -> Matcher.Match -> HIT
+  |
+  v
+Synthesize response from tape
+  |
+  v
+Return response (upstream not contacted)
+```
+
+### Cache miss
+
+```
+Request
+  |
+  v
+Read request body, compute body hash
+  |
+  v
+Store.List -> Matcher.Match -> MISS
+  |
+  v
+[Single-flight dedup if enabled]
+  |
+  v
+Forward to upstream
+  |
+  +-- Success --> Read response body
+  |                Check cacheFilter
+  |                Build tape, sanitize, Store.Save
+  |                Return response
+  |
+  +-- Error --> [Stale fallback if enabled]
+                  |
+                  +-- Stale hit --> Return cached response
+                  |                 (X-Httptape-Stale: true)
+                  |
+                  +-- Stale miss --> Propagate error
+```
+
+## SSE recording
+
+When the upstream responds with `Content-Type: text/event-stream` and SSE recording is enabled, CachingTransport detects the SSE stream automatically:
+
+1. The upstream response body is wrapped in an `sseRecordingReader`.
+2. Bytes pass through to the caller unchanged (streaming, not buffered).
+3. A background goroutine parses the stream into discrete `SSEEvent` entries with timing metadata.
+4. When the stream ends cleanly (upstream sends EOF), the tape is persisted.
+5. If the client disconnects mid-stream, the partial tape is discarded.
+
+On subsequent requests with the same match key, the cached SSE tape is returned as a piped stream with events emitted back-to-back (instant timing). This matches the `http.RoundTripper` contract where callers expect responses quickly.
+
+### SSE with redaction
+
+```go
+sanitizer := httptape.NewPipeline(
+    httptape.RedactHeaders("Authorization"),
+    httptape.RedactSSEEventData("$.choices[*].delta.content"),
+    httptape.FakeSSEEventData("my-seed", "$.user.email"),
+)
+
+ct := httptape.NewCachingTransport(upstream, store,
+    httptape.WithCacheSanitizer(sanitizer),
+)
+```
+
+## Stale fallback
+
+When `WithCacheUpstreamDownFallback(true)` is set and the upstream fails (transport error or timeout):
+
+1. CachingTransport searches the store for a matching tape.
+2. If a match is found, it is returned with `X-Httptape-Stale: true` header.
+3. If no match is found, the original transport error is propagated.
+
+The `X-Httptape-Stale: true` header signals to callers that the response is from a stale cache, not from upstream.
+
+### Combining with upstream timeout
+
+```go
+ct := httptape.NewCachingTransport(upstream, store,
+    httptape.WithCacheUpstreamDownFallback(true),
+    httptape.WithCacheUpstreamTimeout(3 * time.Second),
+)
+```
+
+If the upstream does not respond within 3 seconds, CachingTransport falls back to any cached tape that matches the request.
+
+## Error handling
+
+| Failure mode | Caller sees | Notes |
+|---|---|---|
+| Request body exceeds maxBodySize | Upstream response (bypass cache) | No recording |
+| Request body read fails | Error (wrapped) | Cannot proceed |
+| Store.List fails on cache lookup | Upstream response (miss path) | onError called |
+| Matcher finds no match (cache miss) | Upstream response | Normal miss flow |
+| Upstream transport error (miss) | Error or stale response if staleFallback | See stale fallback |
+| Upstream returns non-2xx (filtered) | Upstream response (not cached) | Response returned, not recorded |
+| Upstream response body read fails | Upstream response (partial) | onError called, not cached |
+| Store.Save fails (record path) | Upstream response | onError called |
+| SSE stream truncated (client disconnect) | Partial stream | Partial tape discarded |
+
+Non-fatal errors are reported via the `WithCacheOnError` callback. They never affect the response returned to the caller.
+
+## CachingTransport vs Proxy
+
+| Feature | CachingTransport | Proxy |
+|---------|-----------------|-------|
+| Store model | Single store | L1 (memory) + L2 (disk) |
+| Single-flight dedup | Yes | No |
+| Stale fallback | Yes (opt-in) | Yes (L1 then L2) |
+| Health endpoint | No | No |
+| CLI integration | No | Yes (`httptape proxy`) |
+| Use case | Library embedding | CLI-oriented caching proxy |
+
+The CLI `proxy` subcommand composes CachingTransport internally. CachingTransport handles the L2+upstream path, while Proxy adds L1 as a fast pre-check layer.
+
+## Full example: zero-cost demo hosting
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "net/http"
+    "time"
+
+    "github.com/VibeWarden/httptape"
+)
+
+func main() {
+    store, err := httptape.NewFileStore(httptape.WithDirectory("./demo-fixtures"))
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    sanitizer := httptape.NewPipeline(
+        httptape.RedactHeaders("Authorization", "X-Api-Key"),
+        httptape.FakeFields("demo-seed", "$.user.email", "$.user.name"),
+    )
+
+    ct := httptape.NewCachingTransport(http.DefaultTransport, store,
+        httptape.WithCacheSanitizer(sanitizer),
+        httptape.WithCacheRoute("demo"),
+        httptape.WithCacheUpstreamDownFallback(true),
+        httptape.WithCacheUpstreamTimeout(5 * time.Second),
+        httptape.WithCacheOnError(func(err error) {
+            log.Printf("cache: %v", err)
+        }),
+    )
+
+    client := &http.Client{Transport: ct}
+
+    // First call: hits upstream, records response.
+    resp, err := client.Get("https://api.example.com/demo/data")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println("Status:", resp.StatusCode)
+
+    // Second call: served from cache (upstream not contacted).
+    resp, err = client.Get("https://api.example.com/demo/data")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println("Status:", resp.StatusCode)
+}
+```
+
+## Thread safety
+
+CachingTransport is safe for concurrent use by multiple goroutines. `RoundTrip` may be called from multiple goroutines simultaneously.
+
+## See also
+
+- [Proxy Mode](proxy.md) -- two-tier L1/L2 caching with CLI integration
+- [Recording](recording.md) -- record-only (no replay)
+- [Replay](replay.md) -- replay-only (no upstream)
+- [Redaction](sanitization.md) -- configuring the sanitization pipeline
+- [API Reference](api-reference.md) -- full type signatures

--- a/docs/caching-transport.md
+++ b/docs/caching-transport.md
@@ -9,7 +9,7 @@ CachingTransport is the library primitive for cache-through-upstream logic. Use 
 | Use case | Solution |
 |----------|----------|
 | Embed cache-through-upstream in your Go app | **CachingTransport** |
-| Two-tier L1/L2 cache with CLI integration | [Proxy](proxy.md) (composes CachingTransport internally) |
+| Two-tier L1/L2 cache with CLI integration | [Proxy](proxy.md) (separate implementation; unification planned, see #205) |
 | Record-only (audit, capture) | [Recorder](recording.md) |
 | Replay-only (mock server) | [Server](replay.md) |
 
@@ -301,7 +301,7 @@ Non-fatal errors are reported via the `WithCacheOnError` callback. They never af
 | CLI integration | No | Yes (`httptape proxy`) |
 | Use case | Library embedding | CLI-oriented caching proxy |
 
-The CLI `proxy` subcommand composes CachingTransport internally. CachingTransport handles the L2+upstream path, while Proxy adds L1 as a fast pre-check layer.
+CachingTransport and Proxy share the same cache-through-upstream conceptual model, but they are currently separate implementations. CachingTransport is the library primitive for single-store caching; Proxy manages L1/L2 two-tier caching with its own independent logic. Unifying the two paths (Proxy composing CachingTransport for L2+upstream) is planned as a follow-up (#205).
 
 ## Full example: zero-cost demo hosting
 
@@ -359,6 +359,10 @@ func main() {
 ## Thread safety
 
 CachingTransport is safe for concurrent use by multiple goroutines. `RoundTrip` may be called from multiple goroutines simultaneously.
+
+## Known limitations
+
+- **Single-flight waiters do not observe context cancellation.** When single-flight is enabled (default), waiters blocked on a shared upstream call do not exit early if their request context is cancelled. The waiter goroutine remains blocked until the leader's upstream call completes. This is a consequence of using `sync.WaitGroup` (not context-aware) for waiter coordination. To work around this, either disable single-flight (`WithCacheSingleFlight(false)`) or set `WithCacheUpstreamTimeout` to bound the leader's wait.
 
 ## See also
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,7 +78,7 @@ Then point your application at `http://localhost:8081` instead of the real API. 
 
 ### proxy
 
-Forward requests to an upstream server with two-tier caching and automatic fallback. See [Proxy Mode](proxy.md) for a full guide.
+Forward requests to an upstream server with two-tier caching and automatic fallback. The `proxy` subcommand uses `CachingTransport` internally for L2+upstream cache-through logic. See [Proxy Mode](proxy.md) for a full guide, or [CachingTransport](caching-transport.md) for the underlying library API.
 
 ```bash
 httptape proxy --upstream <url> --fixtures <dir> [flags]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,7 +78,7 @@ Then point your application at `http://localhost:8081` instead of the real API. 
 
 ### proxy
 
-Forward requests to an upstream server with two-tier caching and automatic fallback. The `proxy` subcommand uses `CachingTransport` internally for L2+upstream cache-through logic. See [Proxy Mode](proxy.md) for a full guide, or [CachingTransport](caching-transport.md) for the underlying library API.
+Forward requests to an upstream server with two-tier caching and automatic fallback. The `proxy` subcommand currently uses Proxy's own cache-through-upstream implementation; CachingTransport provides the same conceptual model as a standalone library primitive (unification planned, see #205). See [Proxy Mode](proxy.md) for a full guide, or [CachingTransport](caching-transport.md) for the library API.
 
 ```bash
 httptape proxy --upstream <url> --fixtures <dir> [flags]

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -265,8 +265,15 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 
 `Proxy` is safe for concurrent use by multiple goroutines. `RoundTrip` may be called from multiple goroutines simultaneously.
 
+## CachingTransport
+
+The `Proxy` type internally composes a `CachingTransport` for the L2+upstream path. If you need a simpler, single-store caching `http.RoundTripper` without the L1/L2 split, use `CachingTransport` directly. It supports single-flight deduplication, stale-fallback, SSE tee recording, and sanitize-on-write -- the same core features as Proxy but in a lighter package.
+
+See [CachingTransport](caching-transport.md) for the full guide.
+
 ## See also
 
+- [CachingTransport](caching-transport.md) -- single-store caching RoundTripper for library embedding
 - [Recording](recording.md) -- one-shot recording without fallback
 - [Replay](replay.md) -- offline replay from fixtures
 - [Redaction](sanitization.md) -- configuring the redaction pipeline

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -267,7 +267,7 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 
 ## CachingTransport
 
-The `Proxy` type internally composes a `CachingTransport` for the L2+upstream path. If you need a simpler, single-store caching `http.RoundTripper` without the L1/L2 split, use `CachingTransport` directly. It supports single-flight deduplication, stale-fallback, SSE tee recording, and sanitize-on-write -- the same core features as Proxy but in a lighter package.
+`Proxy` and `CachingTransport` share the same conceptual model (cache-then-upstream-on-miss), but they are currently separate implementations. `Proxy` manages L1/L2 two-tier caching with its own cache-through-upstream logic, while `CachingTransport` is a standalone single-store primitive with single-flight deduplication, stale-fallback, and SSE tee recording. Unifying the two (Proxy composing CachingTransport internally for L2+upstream) is planned as a follow-up (#205).
 
 See [CachingTransport](caching-transport.md) for the full guide.
 

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -216,8 +216,26 @@ client := &http.Client{Transport: rec}
 // Use client normally...
 ```
 
+## Recorder vs CachingTransport
+
+The `Recorder` is a record-only primitive: it always forwards to upstream and captures the response. It does not replay cached responses.
+
+If you need cache-through-upstream behavior (replay on hit, record on miss), use `CachingTransport` instead. CachingTransport is the replay+record sibling of Recorder.
+
+| Feature | Recorder | CachingTransport |
+|---------|----------|-----------------|
+| Record traffic | Yes | Yes (on cache miss) |
+| Replay from cache | No | Yes (on cache hit) |
+| Single-flight dedup | No | Yes |
+| Stale fallback | No | Yes (opt-in) |
+| Async writes | Yes (default) | No (synchronous) |
+| Sampling | Yes | No |
+
+See [CachingTransport](caching-transport.md) for the full guide.
+
 ## See also
 
+- [CachingTransport](caching-transport.md) -- replay+record caching RoundTripper
 - [Redaction](sanitization.md) -- configure what gets redacted
 - [Storage](storage.md) -- where tapes are stored
 - [Config](config.md) -- declarative sanitizer configuration

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23,7 +23,7 @@ No manual encoding -- the Content-Type header determines the shape automatically
 - Recorder: http.RoundTripper that records traffic to a Store
 - Server: http.Handler that replays tapes from a Store
 - CachingTransport: http.RoundTripper with single-store caching, single-flight dedup, stale fallback
-- Proxy: http.RoundTripper with L1/L2 caching and fallback (composes CachingTransport)
+- Proxy: http.RoundTripper with L1/L2 caching and fallback (separate implementation; unification with CachingTransport planned, see #205)
 - Pipeline: ordered chain of SanitizeFunc transformations (implements Sanitizer)
 - Store: persistence interface (MemoryStore, FileStore, or custom)
 - Matcher: request-to-tape matching (CompositeMatcher with scored criteria)
@@ -135,7 +135,8 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 X-Httptape-Source header: "l1-cache" or "l2-cache" when serving from cache.
 SSE responses pass through and are cached with per-event timing. L2 fallback
 replays cached SSE events using WithProxySSETiming (default: instant).
-Proxy composes CachingTransport internally for L2+upstream logic.
+Proxy and CachingTransport share the same conceptual model but are currently
+separate implementations. Unification is planned (see #205).
 
 ## Matching
 
@@ -1893,7 +1894,7 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 
 ## CachingTransport
 
-The `Proxy` type internally composes a `CachingTransport` for the L2+upstream path. If you need a simpler, single-store caching `http.RoundTripper` without the L1/L2 split, use `CachingTransport` directly. It supports single-flight deduplication, stale-fallback, SSE tee recording, and sanitize-on-write -- the same core features as Proxy but in a lighter package.
+`Proxy` and `CachingTransport` share the same conceptual model (cache-then-upstream-on-miss), but they are currently separate implementations. `Proxy` manages L1/L2 two-tier caching with its own cache-through-upstream logic, while `CachingTransport` is a standalone single-store primitive with single-flight deduplication, stale-fallback, and SSE tee recording. Unifying the two (Proxy composing CachingTransport internally for L2+upstream) is planned as a follow-up (#205).
 
 See [CachingTransport](caching-transport.md) for the full guide.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22,7 +22,8 @@ No manual encoding -- the Content-Type header determines the shape automatically
 - SSETimingMode: sealed interface controlling SSE replay timing (Realtime, Accelerated, Instant)
 - Recorder: http.RoundTripper that records traffic to a Store
 - Server: http.Handler that replays tapes from a Store
-- Proxy: http.RoundTripper with L1/L2 caching and fallback
+- CachingTransport: http.RoundTripper with single-store caching, single-flight dedup, stale fallback
+- Proxy: http.RoundTripper with L1/L2 caching and fallback (composes CachingTransport)
 - Pipeline: ordered chain of SanitizeFunc transformations (implements Sanitizer)
 - Store: persistence interface (MemoryStore, FileStore, or custom)
 - Matcher: request-to-tape matching (CompositeMatcher with scored criteria)
@@ -85,6 +86,43 @@ SSE timing modes:
 - SSETimingAccelerated(factor): gaps divided by factor
 - SSETimingInstant(): all events emitted immediately
 
+## CachingTransport (cache-through-upstream)
+
+```go
+ct := httptape.NewCachingTransport(http.DefaultTransport, store,
+    httptape.WithCacheSanitizer(sanitizer),
+    httptape.WithCacheUpstreamDownFallback(true),
+    httptape.WithCacheUpstreamTimeout(5 * time.Second),
+)
+client := &http.Client{Transport: ct}
+// HIT: return cached response (upstream not contacted)
+// MISS: forward to upstream, record (after sanitization), return
+// MISS + upstream down + staleFallback: return stale tape (X-Httptape-Stale: true)
+```
+
+NOT an RFC 7234 HTTP cache. Does not honor Cache-Control/Vary. It is a tape-match
+layer: identical requests (as defined by the Matcher) get identical recorded responses.
+
+Options: WithCacheMatcher (default: method+path+body_hash), WithCacheSanitizer,
+WithCacheFilter (default: 2xx only), WithCacheSingleFlight (default: true),
+WithCacheMaxBodySize (default: 10 MiB), WithCacheRoute, WithCacheOnError,
+WithCacheSSERecording (default: true), WithCacheUpstreamDownFallback (default: false),
+WithCacheUpstreamTimeout (default: 0/no timeout)
+
+Single-flight: concurrent identical cache misses share one upstream call (stdlib-only,
+sync.Mutex + map[string]*sfCall). SSE misses: first caller gets live stream, waiters
+get cached tape after completion.
+
+Stale fallback: on upstream error/timeout, return most-recently-cached matching tape
+with X-Httptape-Stale: true header. Disabled by default.
+
+SSE tee: SSE responses on miss path are streamed to caller unchanged while events are
+accumulated and persisted. Partial disconnects (client close before upstream EOF) are
+detected via eofTrackingReadCloser and the partial tape is discarded.
+
+Error handling: non-fatal errors (store failures, body read errors) reported via
+onError callback. Never affect the response returned to the caller.
+
 ## Proxy (fallback-to-cache)
 
 ```go
@@ -97,6 +135,7 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 X-Httptape-Source header: "l1-cache" or "l2-cache" when serving from cache.
 SSE responses pass through and are cached with per-event timing. L2 fallback
 replays cached SSE events using WithProxySSETiming (default: instant).
+Proxy composes CachingTransport internally for L2+upstream logic.
 
 ## Matching
 
@@ -188,6 +227,7 @@ Matcher criterion types: method, path, body_fuzzy (requires paths), content_nego
 ```go
 func NewRecorder(store Store, opts ...RecorderOption) *Recorder
 func NewServer(store Store, opts ...ServerOption) *Server
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
 func NewProxy(l1, l2 Store, opts ...ProxyOption) *Proxy
 func NewPipeline(funcs ...SanitizeFunc) *Pipeline
 func NewMemoryStore() *MemoryStore
@@ -755,8 +795,13 @@ client := &http.Client{Transport: rec}
 // Use client normally...
 ```
 
+## Recorder vs CachingTransport
+
+The `Recorder` is a record-only primitive: it always forwards to upstream and captures the response. It does not replay cached responses. If you need cache-through-upstream behavior (replay on hit, record on miss), use `CachingTransport` instead. See [CachingTransport](caching-transport.md).
+
 ## See also
 
+- [CachingTransport](caching-transport.md) -- replay+record caching RoundTripper
 - [Redaction](sanitization.md) -- configure what gets redacted
 - [Storage](storage.md) -- where tapes are stored
 - [Config](config.md) -- declarative sanitizer configuration
@@ -1846,13 +1891,144 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 
 `Proxy` is safe for concurrent use by multiple goroutines. `RoundTrip` may be called from multiple goroutines simultaneously.
 
+## CachingTransport
+
+The `Proxy` type internally composes a `CachingTransport` for the L2+upstream path. If you need a simpler, single-store caching `http.RoundTripper` without the L1/L2 split, use `CachingTransport` directly. It supports single-flight deduplication, stale-fallback, SSE tee recording, and sanitize-on-write -- the same core features as Proxy but in a lighter package.
+
+See [CachingTransport](caching-transport.md) for the full guide.
+
 ## See also
 
+- [CachingTransport](caching-transport.md) -- single-store caching RoundTripper for library embedding
 - [Recording](recording.md) -- one-shot recording without fallback
 - [Replay](replay.md) -- offline replay from fixtures
 - [Redaction](sanitization.md) -- configuring the redaction pipeline
 - [CLI](cli.md) -- all CLI commands and flags
 - [Docker](docker.md) -- container usage
+- [API Reference](api-reference.md) -- full type signatures
+# CachingTransport
+
+CachingTransport is an `http.RoundTripper` that provides transparent, store-backed caching for HTTP requests. On cache hit, it returns the recorded response without contacting upstream. On cache miss, it forwards to upstream, records the response (with optional sanitization), and returns it.
+
+CachingTransport is NOT an RFC 7234 HTTP cache. It does not honor Cache-Control, Vary, or any other HTTP caching headers. It is a tape-match layer: identical requests (as defined by the Matcher) get identical recorded responses.
+
+## Basic usage
+
+```go
+store := httptape.NewMemoryStore()
+ct := httptape.NewCachingTransport(http.DefaultTransport, store)
+client := &http.Client{Transport: ct}
+resp, err := client.Get("https://api.example.com/users")
+// First call: upstream contacted, response cached.
+// Second call: served from cache, upstream not contacted.
+```
+
+## With sanitization and stale fallback
+
+```go
+store, _ := httptape.NewFileStore(httptape.WithDirectory("./cache"))
+sanitizer := httptape.NewPipeline(
+    httptape.RedactHeaders("Authorization", "Cookie"),
+    httptape.FakeFields("my-seed", "$.user.email"),
+)
+
+ct := httptape.NewCachingTransport(http.DefaultTransport, store,
+    httptape.WithCacheSanitizer(sanitizer),
+    httptape.WithCacheRoute("users-api"),
+    httptape.WithCacheUpstreamDownFallback(true),
+    httptape.WithCacheUpstreamTimeout(5 * time.Second),
+    httptape.WithCacheOnError(func(err error) {
+        log.Printf("cache: %v", err)
+    }),
+)
+client := &http.Client{Transport: ct}
+```
+
+## Constructor
+
+```go
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
+```
+
+Both `upstream` and `store` must be non-nil. Panics on nil.
+
+Default configuration:
+- matcher: method + path + body_hash
+- sanitizer: no-op Pipeline
+- cache filter: 2xx only
+- single-flight: enabled
+- max body size: 10 MiB
+- SSE recording: enabled
+- stale fallback: disabled
+- upstream timeout: 0 (no timeout)
+
+## Options
+
+| Option | Signature | Default |
+|--------|-----------|---------|
+| WithCacheMatcher | `WithCacheMatcher(m Matcher)` | method + path + body_hash |
+| WithCacheSanitizer | `WithCacheSanitizer(s Sanitizer)` | no-op Pipeline |
+| WithCacheFilter | `WithCacheFilter(fn func(*http.Response) bool)` | 2xx only |
+| WithCacheSingleFlight | `WithCacheSingleFlight(enabled bool)` | `true` |
+| WithCacheMaxBodySize | `WithCacheMaxBodySize(n int)` | 10 MiB |
+| WithCacheRoute | `WithCacheRoute(route string)` | `""` |
+| WithCacheOnError | `WithCacheOnError(fn func(error))` | no-op |
+| WithCacheSSERecording | `WithCacheSSERecording(enabled bool)` | `true` |
+| WithCacheUpstreamDownFallback | `WithCacheUpstreamDownFallback(enabled bool)` | `false` |
+| WithCacheUpstreamTimeout | `WithCacheUpstreamTimeout(d time.Duration)` | `0` |
+
+## How it works
+
+### Cache hit
+1. Read request body into buffer, compute body hash.
+2. Store.List -> Matcher.Match -> HIT.
+3. Synthesize response from tape (non-SSE: bytes reader, SSE: piped event stream).
+4. Return response (upstream not contacted).
+
+### Cache miss
+1. Read request body, compute body hash.
+2. Store.List -> Matcher.Match -> MISS.
+3. Single-flight dedup (if enabled): concurrent identical requests share one upstream call.
+4. Forward to upstream (with optional timeout).
+5. On success: read body, check cacheFilter, build tape, sanitize, Store.Save, return response.
+6. On error: stale fallback (if enabled) or propagate error.
+
+### SSE tee on miss
+1. Upstream returns text/event-stream response.
+2. Body wrapped in sseRecordingReader (bytes pass through to caller unchanged).
+3. Background goroutine parses events with timing metadata.
+4. When stream completes cleanly: tape persisted.
+5. If client disconnects mid-stream: partial tape discarded (eofTrackingReadCloser detects).
+
+## Stale fallback
+
+When `WithCacheUpstreamDownFallback(true)` and upstream fails:
+1. Search store for best-matching tape.
+2. Return with `X-Httptape-Stale: true` header.
+3. If no match: propagate original error.
+
+## Error handling
+
+Non-fatal errors (store failures, body read errors) reported via onError callback. Never affect the response returned to the caller.
+
+## CachingTransport vs Proxy
+
+| Feature | CachingTransport | Proxy |
+|---------|-----------------|-------|
+| Store model | Single store | L1 (memory) + L2 (disk) |
+| Single-flight dedup | Yes | No |
+| Stale fallback | Yes (opt-in) | Yes (L1 then L2) |
+| CLI integration | No | Yes |
+
+## Thread safety
+
+CachingTransport is safe for concurrent use by multiple goroutines.
+
+## See also
+
+- [Proxy Mode](proxy.md) -- two-tier L1/L2 caching with CLI integration
+- [Recording](recording.md) -- record-only (no replay)
+- [Replay](replay.md) -- replay-only (no upstream)
 - [API Reference](api-reference.md) -- full type signatures
 # Matching
 
@@ -4959,6 +5135,36 @@ Panics if `store` is nil.
 | WithRecorderTLSConfig | `WithRecorderTLSConfig(cfg *tls.Config)` | nil |
 
 **Details:** [Recording](recording.md)
+
+---
+
+## CachingTransport
+
+```go
+type CachingTransport struct { /* unexported */ }
+
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
+func (ct *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error) // implements http.RoundTripper
+```
+
+Panics if `upstream` or `store` is nil.
+
+### CachingOption
+
+| Option | Signature | Default |
+|--------|-----------|---------|
+| WithCacheMatcher | `WithCacheMatcher(m Matcher)` | method + path + body_hash |
+| WithCacheSanitizer | `WithCacheSanitizer(s Sanitizer)` | no-op Pipeline |
+| WithCacheFilter | `WithCacheFilter(fn func(*http.Response) bool)` | 2xx only |
+| WithCacheSingleFlight | `WithCacheSingleFlight(enabled bool)` | `true` |
+| WithCacheMaxBodySize | `WithCacheMaxBodySize(n int)` | 10 MiB |
+| WithCacheRoute | `WithCacheRoute(route string)` | `""` |
+| WithCacheOnError | `WithCacheOnError(fn func(error))` | no-op |
+| WithCacheSSERecording | `WithCacheSSERecording(enabled bool)` | `true` |
+| WithCacheUpstreamDownFallback | `WithCacheUpstreamDownFallback(enabled bool)` | `false` |
+| WithCacheUpstreamTimeout | `WithCacheUpstreamTimeout(d time.Duration)` | `0` (no timeout) |
+
+**Details:** [CachingTransport](caching-transport.md)
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@ No manual encoding -- the Content-Type header determines the shape automatically
 - Recorder: http.RoundTripper that records traffic to a Store
 - Server: http.Handler that replays tapes from a Store
 - CachingTransport: http.RoundTripper with single-store caching, single-flight dedup, stale fallback
-- Proxy: http.RoundTripper with L1/L2 caching and fallback (composes CachingTransport)
+- Proxy: http.RoundTripper with L1/L2 caching and fallback (separate implementation; unification with CachingTransport planned, see #205)
 - Pipeline: ordered chain of SanitizeFunc transformations (implements Sanitizer)
 - Store: persistence interface (MemoryStore, FileStore, or custom)
 - Matcher: request-to-tape matching (CompositeMatcher with scored criteria)
@@ -119,7 +119,8 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 X-Httptape-Source header: "l1-cache" or "l2-cache" when serving from cache.
 SSE responses pass through and are cached with per-event timing. L2 fallback
 replays cached SSE events using WithProxySSETiming (default: instant).
-Proxy composes CachingTransport internally for L2+upstream logic.
+Proxy and CachingTransport share the same conceptual model but are currently
+separate implementations. Unification is planned (see #205).
 
 ## Matching
 

--- a/llms.txt
+++ b/llms.txt
@@ -22,7 +22,8 @@ No manual encoding -- the Content-Type header determines the shape automatically
 - SSETimingMode: sealed interface controlling SSE replay timing (Realtime, Accelerated, Instant)
 - Recorder: http.RoundTripper that records traffic to a Store
 - Server: http.Handler that replays tapes from a Store
-- Proxy: http.RoundTripper with L1/L2 caching and fallback
+- CachingTransport: http.RoundTripper with single-store caching, single-flight dedup, stale fallback
+- Proxy: http.RoundTripper with L1/L2 caching and fallback (composes CachingTransport)
 - Pipeline: ordered chain of SanitizeFunc transformations (implements Sanitizer)
 - Store: persistence interface (MemoryStore, FileStore, or custom)
 - Matcher: request-to-tape matching (CompositeMatcher with scored criteria)
@@ -85,6 +86,27 @@ SSE timing modes:
 - SSETimingAccelerated(factor): gaps divided by factor
 - SSETimingInstant(): all events emitted immediately
 
+## CachingTransport (cache-through-upstream)
+
+```go
+ct := httptape.NewCachingTransport(http.DefaultTransport, store,
+    httptape.WithCacheSanitizer(sanitizer),
+    httptape.WithCacheUpstreamDownFallback(true),
+)
+client := &http.Client{Transport: ct}
+// HIT: return cached response (upstream not contacted)
+// MISS: forward to upstream, record, return
+// MISS + upstream down + staleFallback: return stale tape (X-Httptape-Stale: true)
+```
+
+Options: WithCacheMatcher, WithCacheSanitizer, WithCacheFilter, WithCacheSingleFlight,
+WithCacheMaxBodySize, WithCacheRoute, WithCacheOnError, WithCacheSSERecording,
+WithCacheUpstreamDownFallback, WithCacheUpstreamTimeout
+
+Single-flight dedup: concurrent identical cache misses share one upstream call.
+SSE tee recording: SSE responses are streamed to caller while events are accumulated
+and persisted. Partial disconnects are detected and discarded.
+
 ## Proxy (fallback-to-cache)
 
 ```go
@@ -97,6 +119,7 @@ proxy := httptape.NewProxy(l1, l2, httptape.WithProxySanitizer(sanitizer))
 X-Httptape-Source header: "l1-cache" or "l2-cache" when serving from cache.
 SSE responses pass through and are cached with per-event timing. L2 fallback
 replays cached SSE events using WithProxySSETiming (default: instant).
+Proxy composes CachingTransport internally for L2+upstream logic.
 
 ## Matching
 
@@ -188,6 +211,7 @@ Matcher criterion types: method, path, body_fuzzy (requires paths), content_nego
 ```go
 func NewRecorder(store Store, opts ...RecorderOption) *Recorder
 func NewServer(store Store, opts ...ServerOption) *Server
+func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
 func NewProxy(l1, l2 Store, opts ...ProxyOption) *Proxy
 func NewPipeline(funcs ...SanitizeFunc) *Pipeline
 func NewMemoryStore() *MemoryStore


### PR DESCRIPTION
Closes #202, closes #164

## Summary

- Add `CachingTransport`, a new `http.RoundTripper` that provides transparent, single-store cache-through-upstream behavior. On cache hit, returns recorded response without contacting upstream. On cache miss, forwards to upstream, records (with optional sanitization), and returns.
- Implements all 10 ADR-44 decisions: naming (CachingTransport), store-failure-on-record (return-and-log), no Cache-Control respect, configurable body size limits, no TTL/eviction, Recorder not deprecated, stale-fallback policy, SSE partial disconnect detection, upstream timeout, single-flight dedup.
- 10 functional options: `WithCacheMatcher`, `WithCacheSanitizer`, `WithCacheFilter`, `WithCacheSingleFlight`, `WithCacheMaxBodySize`, `WithCacheRoute`, `WithCacheOnError`, `WithCacheSSERecording`, `WithCacheUpstreamDownFallback`, `WithCacheUpstreamTimeout`.
- Single-flight deduplication (stdlib-only, `sync.Mutex` + `map[string]*sfCall`) for concurrent identical cache misses.
- Stale-fallback policy (#164): opt-in via `WithCacheUpstreamDownFallback(true)`, returns cached tape with `X-Httptape-Stale: true` header when upstream is unreachable.
- SSE tee recording with `eofTrackingReadCloser` for partial disconnect detection.
- 20+ test cases covering all ADR-44 test strategy items, including race condition tests.
- Documentation: new `docs/caching-transport.md`, updates to `docs/proxy.md`, `docs/api-reference.md`, `docs/recording.md`, `docs/cli.md`, `llms.txt`, `llms-full.txt`, `CHANGELOG.md`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (20+ new tests)
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] All existing tests continue to pass (no regressions)
- [x] Cache hit (non-SSE and SSE)
- [x] Cache miss with recording (non-SSE and SSE tee)
- [x] SSE partial disconnect detection (tape discarded)
- [x] Upstream error propagation
- [x] Stale fallback (hit and miss paths)
- [x] Cache filter rejection (non-2xx not cached)
- [x] Sanitization applied to stored tapes
- [x] Single-flight dedup (upstream called exactly once for concurrent identical requests)
- [x] MaxBodySize bypass (oversize bodies forwarded without cache interaction)
- [x] Store.Save failure handling (response still returned, onError called)
- [x] Upstream timeout with stale fallback
- [x] Route filtering
- [x] Concurrent safety (race detector clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)