### PR TITLE
chore(examples): bump httptape image to v0.13.0

### DIFF
--- a/examples/java-spring-boot/docker-compose.yml
+++ b/examples/java-spring-boot/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   httptape:
-    image: ghcr.io/vibewarden/httptape:0.12.0
+    image: ghcr.io/vibewarden/httptape:0.13.0
     command: ["serve", "--fixtures", "/fixtures", "--sse-timing=realtime"]
     volumes:
       # All fixtures must be in a single flat directory for FileStore.

--- a/examples/java-spring-boot/src/test/java/dev/httptape/demo/TestcontainersConfig.java
+++ b/examples/java-spring-boot/src/test/java/dev/httptape/demo/TestcontainersConfig.java
@@ -44,7 +44,7 @@ class TestcontainersConfig {
      */
     @Bean
     GenericContainer<?> httptapeContainer() throws IOException {
-        GenericContainer<?> container = new GenericContainer<>("ghcr.io/vibewarden/httptape:0.12.0")
+        GenericContainer<?> container = new GenericContainer<>("ghcr.io/vibewarden/httptape:0.13.0")
                 .withCommand("serve", "--fixtures", "/fixtures", "--sse-timing=realtime")
                 .withExposedPorts(8081)
                 .waitingFor(Wait.forHttp("/").forStatusCode(404));

--- a/examples/kotlin-ktor-koog/README.md
+++ b/examples/kotlin-ktor-koog/README.md
@@ -37,7 +37,7 @@ This demo exercises the matcher composition stack from #178, #179, and #180:
 
 ## httptape version requirement
 
-This demo requires **httptape v0.12.0** or later. v0.12.0 introduced Content-Type-driven body shape in fixtures (PR [#191](https://github.com/VibeWarden/httptape/pull/191)) and includes `--config` support for declarative matcher composition (first shipped in v0.11.0, PR [#184](https://github.com/VibeWarden/httptape/pull/184)). Earlier releases cannot read the migrated fixture format or the matcher config.
+This demo requires **httptape v0.13.0** or later. v0.13.0 adds `CachingTransport` as a library primitive. v0.12.0 introduced Content-Type-driven body shape in fixtures (PR [#191](https://github.com/VibeWarden/httptape/pull/191)) and includes `--config` support for declarative matcher composition (first shipped in v0.11.0, PR [#184](https://github.com/VibeWarden/httptape/pull/184)). Earlier releases cannot read the migrated fixture format or the matcher config.
 
 ## Prerequisites
 
@@ -114,7 +114,7 @@ IDE users: open [`api.http`](./api.http) -- IntelliJ's HTTP Client and VS Code's
 | Kotest | 6.1.11 (FreeSpec) |
 | Testcontainers | 2.0.4 (single shared container) |
 | Gradle | 9.4.1 (wrapper committed) |
-| httptape | v0.12.0 (ghcr.io/vibewarden/httptape:0.12.0) |
+| httptape | v0.13.0 (ghcr.io/vibewarden/httptape:0.13.0) |
 
 ## Why not...?
 

--- a/examples/kotlin-ktor-koog/docker-compose.yml
+++ b/examples/kotlin-ktor-koog/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   httptape:
-    image: ghcr.io/vibewarden/httptape:0.12.0
+    image: ghcr.io/vibewarden/httptape:0.13.0
     command: ["serve", "--fixtures", "/fixtures", "--config", "/config/httptape.config.json"]
     volumes:
       - ./src/test/resources/fixtures/openai/chat-1.json:/fixtures/chat-1.json:ro

--- a/examples/kotlin-ktor-koog/src/test/kotlin/dev/httptape/demo/HttptapeContainer.kt
+++ b/examples/kotlin-ktor-koog/src/test/kotlin/dev/httptape/demo/HttptapeContainer.kt
@@ -17,7 +17,7 @@ import org.testcontainers.utility.MountableFile
 object HttptapeContainer {
 
     val instance: GenericContainer<*> by lazy {
-        GenericContainer("ghcr.io/vibewarden/httptape:0.12.0")
+        GenericContainer("ghcr.io/vibewarden/httptape:0.13.0")
             .withCommand(
                 "serve",
                 "--fixtures", "/fixtures",

--- a/examples/ts-frontend-first/README.md
+++ b/examples/ts-frontend-first/README.md
@@ -85,11 +85,11 @@ httptape's `RedactSSEEventData` and `FakeSSEEventData` sanitization functions op
 docker compose up
 ```
 
-Pulls `ghcr.io/vibewarden/httptape:0.12.0` (v0.12.0 introduced Content-Type-driven body shape, ContentNegotiationCriterion, and the `migrate-fixtures` CLI subcommand). Also builds the React frontend. No local Go build needed.
+Pulls `ghcr.io/vibewarden/httptape:0.13.0` (v0.13.0 adds CachingTransport; v0.12.0 introduced Content-Type-driven body shape, ContentNegotiationCriterion, and the `migrate-fixtures` CLI subcommand). Also builds the React frontend. No local Go build needed.
 
 Open [http://localhost:3000](http://localhost:3000).
 
-> Pinned to `0.12.0` for reproducibility. To track latest, change the image to `ghcr.io/vibewarden/httptape:latest`.
+> Pinned to `0.13.0` for reproducibility. To track latest, change the image to `ghcr.io/vibewarden/httptape:latest`.
 
 ## Try it
 
@@ -155,6 +155,6 @@ ts-frontend-first/
     toggle-upstream.sh           # one-liner to flip upstream up/down
   .httptape-cache/               # L2 cache — generated, gitignored
     fixtures/                    # populated on first request, used as L2 fallback
-  docker-compose.yml             # 3 services, pinned to httptape v0.12.0 from GHCR
+  docker-compose.yml             # 3 services, pinned to httptape v0.13.0 from GHCR
   Dockerfile                     # multi-stage build for the React frontend
 ```

--- a/examples/ts-frontend-first/docker-compose.yml
+++ b/examples/ts-frontend-first/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   upstream:
-    image: ghcr.io/vibewarden/httptape:0.12.0
+    image: ghcr.io/vibewarden/httptape:0.13.0
     command: ["serve", "--fixtures", "/fixtures"]
     volumes:
       - ./mocks/upstream-fixtures:/fixtures:ro
 
   proxy:
-    image: ghcr.io/vibewarden/httptape:0.12.0
+    image: ghcr.io/vibewarden/httptape:0.13.0
     command:
       - proxy
       - --upstream


### PR DESCRIPTION
## Summary

- Bumps all three demo examples from `ghcr.io/vibewarden/httptape:0.12.0` to `ghcr.io/vibewarden/httptape:0.13.0`
- v0.13.0 is tagged (commit `b8ae671`), multi-arch image is live on GHCR
- No breaking changes -- v0.13.0 adds `CachingTransport` as a library primitive; proxy subcommand behavior is unchanged and demo fixtures still work

### Files changed

- `examples/java-spring-boot/src/test/java/dev/httptape/demo/TestcontainersConfig.java` -- Testcontainers image tag
- `examples/java-spring-boot/docker-compose.yml` -- docker-compose image tag
- `examples/kotlin-ktor-koog/src/test/kotlin/dev/httptape/demo/HttptapeContainer.kt` -- Testcontainers image tag
- `examples/kotlin-ktor-koog/docker-compose.yml` -- docker-compose image tag
- `examples/kotlin-ktor-koog/README.md` -- version requirement text and stack table
- `examples/ts-frontend-first/docker-compose.yml` -- both `upstream` and `proxy` service image tags
- `examples/ts-frontend-first/README.md` -- image references, pin note, and project layout comment

## Test plan

All three demos verified locally:

- [x] **Java Spring Boot**: `./mvnw test` -- 5/5 tests pass (UserServiceIntegrationTest: 3, RecommendationServiceIntegrationTest: 2)
- [x] **Kotlin Ktor+Koog**: `./gradlew test` -- BUILD SUCCESSFUL
- [x] **TS frontend-first**: `docker compose up -d` + `curl -fsS http://localhost:3001/api/profile` and `curl -fsS http://localhost:3001/api/products` both return expected JSON responses
- [x] Go source unchanged: `go build ./...`, `go test ./...`, `go vet ./...` all pass

Follows the same swap pattern as v0.11.0 and v0.12.0 bumps. Autonomous-merge-ok (small mechanical change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)