### PR TITLE
docs(#217): harden sanitization documentation

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -217,6 +217,12 @@ func writeBundle(ctx context.Context, w io.Writer, tapes []Tape, cfg exportConfi
 // The entire bundle is validated before any fixtures are persisted. If the
 // manifest is missing, malformed, or any fixture fails JSON unmarshalling,
 // ImportBundle returns an error and the store is not modified.
+//
+// ImportBundle does not re-sanitize imported tapes. Bundles produced by
+// ExportBundle contain already-sanitized data, so re-sanitization would
+// corrupt deterministically faked values. If you import a bundle from an
+// untrusted or hand-edited source, validate its contents externally before
+// import -- ImportBundle stores tapes exactly as they appear in the bundle.
 func ImportBundle(ctx context.Context, s Store, r io.Reader) error {
 	gr, err := gzip.NewReader(r)
 	if err != nil {

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -132,6 +132,12 @@ The entire bundle is validated before any fixtures are persisted:
 
 If validation fails, the store is not modified.
 
+### Sanitization policy
+
+ImportBundle does not re-sanitize imported tapes. Bundles produced by ExportBundle contain already-sanitized data (sanitization happens at recording time, before tapes reach the store). Re-sanitization on import would corrupt deterministically faked values by double-faking them.
+
+If you import a bundle from an untrusted or hand-edited source, validate its contents externally before import. ImportBundle stores tapes exactly as they appear in the bundle.
+
 ### Size limits
 
 Individual tar entries are limited to 50 MB to prevent zip-bomb-style attacks.

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -44,6 +44,8 @@ Forward to upstream
 - Lost when the process exits
 - Checked first during fallback (lowest latency, best data quality)
 
+**L1 must be an ephemeral, in-memory store.** Because L1 holds unsanitized data (raw secrets, PII), using a persistent store for L1 would bypass httptape's sanitize-on-write guarantee. Always use `NewMemoryStore()` for L1.
+
 ### L2: Disk cache (redacted)
 
 - Backed by a `FileStore`

--- a/docs/sanitization.md
+++ b/docs/sanitization.md
@@ -140,7 +140,7 @@ httptape.FakeFields("my-project-seed",
 
 The first argument is a project-level seed used as the HMAC key. Different seeds produce different fakes. The same seed and input always produce the same output.
 
-Choose a seed that is unique to your project. It does not need to be secret -- it is used for determinism, not security.
+The seed must be non-empty and unique to your project. Treat it as a moderately sensitive value: anyone who knows the seed can predict the fake output for any input. Do not use an empty string, a default placeholder, or a seed shared across unrelated projects. Store it alongside other project configuration (e.g. environment variables), not in public source code.
 
 ### Faking strategies
 

--- a/faker.go
+++ b/faker.go
@@ -383,8 +383,9 @@ func (f AddressFaker) Fake(seed string, original any) any {
 // request and response bodies with deterministic fakes using explicitly
 // assigned Faker implementations per path.
 //
-// The seed is a project-level secret used as the HMAC key. The fields map
-// associates JSONPath-like paths with specific Faker implementations.
+// The seed is a project-level HMAC key. The fields map associates
+// JSONPath-like paths with specific Faker implementations. See FakeFields
+// for seed sensitivity guidance.
 //
 // This gives callers explicit control over the faking strategy for each
 // field, unlike FakeFields which auto-detects the strategy from the value.

--- a/proxy.go
+++ b/proxy.go
@@ -24,6 +24,9 @@ import (
 // L1 must be an ephemeral, in-memory store (typically *MemoryStore). Because
 // L1 holds unsanitized data, using a persistent store for L1 would bypass
 // the sanitize-on-write guarantee and persist raw secrets and PII to disk.
+// This constraint is documented rather than enforced at runtime: a type check
+// against *MemoryStore would not catch custom ephemeral Store implementations,
+// and would false-positive on wrappers embedding *MemoryStore.
 //
 // On success:
 //   - Raw (unsanitized) tape saved to L1 via l1RecordingTransport

--- a/proxy.go
+++ b/proxy.go
@@ -21,6 +21,10 @@ import (
 // responses on the miss path, saving raw (unsanitized) tapes to L1
 // before CachingTransport sanitizes and saves to L2.
 //
+// L1 must be an ephemeral, in-memory store (typically *MemoryStore). Because
+// L1 holds unsanitized data, using a persistent store for L1 would bypass
+// the sanitize-on-write guarantee and persist raw secrets and PII to disk.
+//
 // On success:
 //   - Raw (unsanitized) tape saved to L1 via l1RecordingTransport
 //   - Sanitized tape saved to L2 via CachingTransport
@@ -442,6 +446,9 @@ func WithProxyUpstreamURL(url string) ProxyOption {
 //   - matcher: DefaultMatcher()
 //   - isFallback: transport errors only (not 5xx)
 //   - route: ""
+//
+// L1 must be an ephemeral store (typically NewMemoryStore()) because it holds
+// unsanitized data. See the Proxy type documentation for details.
 //
 // Both l1 and l2 must be non-nil. Panics on nil stores (constructor guard
 // convention per CLAUDE.md).

--- a/sanitizer.go
+++ b/sanitizer.go
@@ -339,9 +339,16 @@ func redactValue(v any) any {
 // request and response bodies with deterministic fakes derived from
 // HMAC-SHA256.
 //
-// The seed is a project-level secret used as the HMAC key. The same seed
-// and input value always produce the same fake output, preserving
-// cross-fixture consistency. Different seeds produce different fakes.
+// The seed is a project-level HMAC key. The same seed and input value
+// always produce the same fake output, preserving cross-fixture
+// consistency. Different seeds produce different fakes.
+//
+// The seed must be non-empty and unique to your project. Treat it as a
+// moderately sensitive value: anyone who knows the seed can predict the
+// fake output for any input. Do not use an empty string, a default
+// placeholder, or a seed shared across unrelated projects. Store it
+// alongside other project configuration (e.g. environment variables),
+// not in public source code.
 //
 // Paths use the same JSONPath-like syntax as RedactBodyPaths:
 //   - $.field             -- top-level field


### PR DESCRIPTION
## Summary

Documentation hardening for sanitization, driven by the 2026-04-25 sanitization boundary audit (no code defects found — these are documentation gaps that could let embedders weaken the boundary by misuse).

Eight edits across seven files:

- **(a) FakeFields seed guidance**
  - `sanitizer.go` — godoc on `FakeFields` now warns the seed must be non-empty, project-specific, and treated as moderately sensitive (anyone with it can predict fakes)
  - `faker.go` — godoc on `FakeFieldsWith` aligned and cross-references `FakeFields`
  - `docs/sanitization.md` — corrects the previously misleading "It does not need to be secret" line
- **(b) ImportBundle re-sanitization policy**
  - `bundle.go` — godoc explains bundles are assumed already-sanitized; importing untrusted/hand-edited bundles is unsafe
  - `docs/import-export.md` — new "Sanitization policy" subsection
- **(c) Proxy L1 ephemeral-store constraint**
  - `proxy.go` — `Proxy` and `NewProxy` godoc explain L1 must be in-memory because it holds unsanitized data; persistent L1 would bypass the sanitize-on-write guarantee
  - `docs/proxy.md` — bold callout in the L1 section
  - Inline rationale comment explaining why the constraint is documentation-only (no runtime guard)

Closes #217.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)