### PR TITLE
chore(#222): minor test cleanup

### DIFF
--- a/caching_transport_test.go
+++ b/caching_transport_test.go
@@ -862,24 +862,22 @@ func TestCachingTransport_ConcurrentSafety(t *testing.T) {
 	// No panic = success for concurrent safety test.
 }
 
-func TestCachingTransport_PanicsOnNil(t *testing.T) {
-	t.Run("nil upstream", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("expected panic on nil upstream")
-			}
-		}()
-		NewCachingTransport(nil, NewMemoryStore())
-	})
+func TestCachingTransport_PanicsOnNilUpstream(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil upstream")
+		}
+	}()
+	NewCachingTransport(nil, NewMemoryStore())
+}
 
-	t.Run("nil store", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("expected panic on nil store")
-			}
-		}()
-		NewCachingTransport(http.DefaultTransport, nil)
-	})
+func TestCachingTransport_PanicsOnNilStore(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil store")
+		}
+	}()
+	NewCachingTransport(http.DefaultTransport, nil)
 }
 
 func TestCachingTransport_ImplementsRoundTripper(t *testing.T) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -445,24 +445,22 @@ func TestProxy_RequestBodyPreservedForMatching(t *testing.T) {
 	}
 }
 
-func TestProxy_PanicsOnNilStores(t *testing.T) {
-	t.Run("nil l1", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("expected panic on nil L1 store")
-			}
-		}()
-		NewProxy(nil, NewMemoryStore())
-	})
+func TestProxy_PanicsOnNilL1Store(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil L1 store")
+		}
+	}()
+	NewProxy(nil, NewMemoryStore())
+}
 
-	t.Run("nil l2", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("expected panic on nil L2 store")
-			}
-		}()
-		NewProxy(NewMemoryStore(), nil)
-	})
+func TestProxy_PanicsOnNilL2Store(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil L2 store")
+		}
+	}()
+	NewProxy(NewMemoryStore(), nil)
 }
 
 func TestProxy_OnErrorCallback(t *testing.T) {

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -487,7 +487,7 @@ func TestRecorder_RoundTrip_WithSanitizer(t *testing.T) {
 
 // --- Error handling tests ---
 
-func TestRecorder_RoundTrip_SyncMode_StoreError_DoesNotAffectCaller(t *testing.T) {
+func TestRecorder_RoundTrip_SyncMode_StoreErrorIsolatedFromCaller(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("all good"))

--- a/sanitizer_test.go
+++ b/sanitizer_test.go
@@ -226,7 +226,7 @@ func TestRedactHeaders_PreservesOtherHeaders(t *testing.T) {
 	}
 }
 
-func TestRedactHeaders_DoesNotMutateOriginal(t *testing.T) {
+func TestRedactHeaders_LeavesOriginalTapeUnchanged(t *testing.T) {
 	reqHeaders := http.Header{"Authorization": {"Bearer original"}}
 	respHeaders := http.Header{"Set-Cookie": {"session=original"}}
 	tape := makeTapeWithHeaders(reqHeaders, respHeaders)
@@ -592,7 +592,7 @@ func TestRedactBodyPaths_BothRequestAndResponse(t *testing.T) {
 	}
 }
 
-func TestRedactBodyPaths_DoesNotMutateOriginal(t *testing.T) {
+func TestRedactBodyPaths_LeavesOriginalTapeUnchanged(t *testing.T) {
 	body := []byte(`{"a":"b"}`)
 	original := make([]byte, len(body))
 	copy(original, body)
@@ -1194,7 +1194,7 @@ func TestFakeFields_BothRequestAndResponse(t *testing.T) {
 	}
 }
 
-func TestFakeFields_DoesNotMutateOriginal(t *testing.T) {
+func TestFakeFields_LeavesOriginalTapeUnchanged(t *testing.T) {
 	body := []byte(`{"name":"Alice"}`)
 	original := make([]byte, len(body))
 	copy(original, body)

--- a/server_test.go
+++ b/server_test.go
@@ -1338,7 +1338,7 @@ func TestServer_Templating_BodyField(t *testing.T) {
 	}
 }
 
-func TestServer_Templating_DoesNotModifyStoredFixture(t *testing.T) {
+func TestServer_Templating_LeavesStoredFixtureUnchanged(t *testing.T) {
 	store := NewMemoryStore()
 	tape := storeTape(t, store, "GET", "/immutable", 200,
 		`{{request.method}}`, nil)


### PR DESCRIPTION
Closes #222

## Summary

- **5 test renames** -- reframe from implementation-contract ("DoesNotMutate") to behavior-describing ("LeavesOriginalTapeUnchanged" / "StoreErrorIsolatedFromCaller"):
  - `TestRedactHeaders_DoesNotMutateOriginal` -> `TestRedactHeaders_LeavesOriginalTapeUnchanged`
  - `TestRedactBodyPaths_DoesNotMutateOriginal` -> `TestRedactBodyPaths_LeavesOriginalTapeUnchanged`
  - `TestFakeFields_DoesNotMutateOriginal` -> `TestFakeFields_LeavesOriginalTapeUnchanged`
  - `TestRecorder_RoundTrip_SyncMode_StoreError_DoesNotAffectCaller` -> `TestRecorder_RoundTrip_SyncMode_StoreErrorIsolatedFromCaller`
  - `TestServer_Templating_DoesNotModifyStoredFixture` -> `TestServer_Templating_LeavesStoredFixtureUnchanged`

- **2 t.Run flattens** -- single-child `t.Run` blocks with no shared setup split into top-level test functions:
  - `TestCachingTransport_PanicsOnNil` (2 sub-tests) -> `TestCachingTransport_PanicsOnNilUpstream` + `TestCachingTransport_PanicsOnNilStore`
  - `TestProxy_PanicsOnNilStores` (2 sub-tests) -> `TestProxy_PanicsOnNilL1Store` + `TestProxy_PanicsOnNilL2Store`

## Test plan

- [x] `go build ./...` -- clean
- [x] `go vet ./...` -- clean
- [x] `go test ./...` -- all pass

No behavior changes, only renames and structural flattens.

Generated with [Claude Code](https://claude.com/claude-code)