### PR TITLE
chore(#218): defensively validate tar entry names

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -242,6 +243,10 @@ func ImportBundle(ctx context.Context, s Store, r io.Reader) error {
 			return fmt.Errorf("httptape: import: %w", err)
 		}
 
+		if err := validateEntryName(hdr.Name); err != nil {
+			return err
+		}
+
 		lr := io.LimitReader(tr, maxEntrySize)
 
 		switch {
@@ -290,6 +295,36 @@ func ImportBundle(ctx context.Context, s Store, r io.Reader) error {
 // isFixtureEntry reports whether the tar entry name matches the fixture pattern.
 func isFixtureEntry(name string) bool {
 	return strings.HasPrefix(name, "fixtures/") && strings.HasSuffix(name, ".json")
+}
+
+// validateEntryName checks that a tar entry name does not contain path-traversal
+// patterns. This is defense in depth: ImportBundle deserializes entries into
+// in-memory Tape objects (not to the filesystem), and Store.Save implementations
+// have their own path validation. However, since bundle parsing sits at the trust
+// boundary for untrusted input, we reject suspicious names early to prevent any
+// future code path from being exploitable.
+func validateEntryName(name string) error {
+	// Reject absolute paths (leading /).
+	if strings.HasPrefix(name, "/") {
+		return fmt.Errorf("httptape: import: tar entry %q has absolute path", name)
+	}
+
+	// Reject backslashes (Windows-style separators have no place in tar archives).
+	if strings.ContainsRune(name, '\\') {
+		return fmt.Errorf("httptape: import: tar entry %q contains backslash", name)
+	}
+
+	// Reject path-traversal: clean the path and check for ".." components.
+	// We use path.Clean (not filepath.Clean) because tar paths use forward
+	// slashes regardless of OS.
+	cleaned := path.Clean(name)
+	for _, segment := range strings.Split(cleaned, "/") {
+		if segment == ".." {
+			return fmt.Errorf("httptape: import: tar entry %q contains path traversal", name)
+		}
+	}
+
+	return nil
 }
 
 // validateFixture checks that a tape has the minimum required fields for

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -1159,6 +1159,148 @@ func TestImportBundle_UnknownEntriesSkipped(t *testing.T) {
 	}
 }
 
+func TestImportBundle_RejectsPathTraversalInTarEntryNames(t *testing.T) {
+	tape := makeBundleTape("tape-1", "api", "GET", "http://test/1")
+	tapeJSON, _ := json.Marshal(tape)
+
+	manifest := Manifest{
+		ExportedAt:   time.Now().UTC(),
+		FixtureCount: 1,
+		Routes:       []string{"api"},
+	}
+	manifestJSON, _ := json.Marshal(manifest)
+
+	tests := []struct {
+		name      string
+		entryName string
+		wantErr   string
+	}{
+		{
+			name:      "dot-dot traversal escaping fixtures directory",
+			entryName: "fixtures/../../../etc/passwd.json",
+			wantErr:   "path traversal",
+		},
+		{
+			name:      "dot-dot at start of path",
+			entryName: "../secrets.json",
+			wantErr:   "path traversal",
+		},
+		{
+			name:      "dot-dot in middle of path",
+			entryName: "fixtures/sub/../../../etc/shadow.json",
+			wantErr:   "path traversal",
+		},
+		{
+			name:      "absolute path",
+			entryName: "/etc/passwd",
+			wantErr:   "absolute path",
+		},
+		{
+			name:      "backslash in entry name",
+			entryName: "fixtures\\tape-1.json",
+			wantErr:   "backslash",
+		},
+		{
+			name:      "backslash with traversal",
+			entryName: "fixtures\\..\\..\\etc\\passwd.json",
+			wantErr:   "backslash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := buildTestBundleOrdered(t,
+				[]string{"manifest.json", tt.entryName},
+				[][]byte{manifestJSON, tapeJSON},
+			)
+
+			dstStore := NewMemoryStore()
+			err := ImportBundle(context.Background(), dstStore, bytes.NewReader(bundle))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestImportBundle_AllowsSafeEntryNames(t *testing.T) {
+	// Verify that legitimate entry names with ".." as a substring in filenames
+	// (not as a path component) are accepted. Also verify normal fixture names.
+	tests := []struct {
+		name      string
+		entryName string
+	}{
+		{
+			name:      "normal fixture",
+			entryName: "fixtures/tape-1.json",
+		},
+		{
+			name:      "double-dot in filename is not a path component",
+			entryName: "fixtures/tape..1.json",
+		},
+		{
+			name:      "fixture with dashes and underscores",
+			entryName: "fixtures/my_tape-name.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tape := makeBundleTape("tape-1", "api", "GET", "http://test/1")
+			tapeJSON, _ := json.Marshal(tape)
+
+			manifest := Manifest{
+				ExportedAt:   time.Now().UTC(),
+				FixtureCount: 1,
+				Routes:       []string{"api"},
+			}
+			manifestJSON, _ := json.Marshal(manifest)
+
+			bundle := buildTestBundleOrdered(t,
+				[]string{"manifest.json", tt.entryName},
+				[][]byte{manifestJSON, tapeJSON},
+			)
+
+			dstStore := NewMemoryStore()
+			err := ImportBundle(context.Background(), dstStore, bytes.NewReader(bundle))
+			if err != nil {
+				t.Fatalf("unexpected error for safe entry name %q: %v", tt.entryName, err)
+			}
+		})
+	}
+}
+
+func TestValidateEntryName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid fixture path", "fixtures/tape-1.json", false},
+		{"valid manifest", "manifest.json", false},
+		{"double-dot in filename", "fixtures/tape..1.json", false},
+		{"triple-dot in filename", "fixtures/tape...1.json", false},
+		{"dot-dot path component", "fixtures/../../etc/passwd.json", true},
+		{"bare dot-dot", "..", true},
+		{"dot-dot at start", "../secret.json", true},
+		{"absolute path", "/etc/passwd", true},
+		{"backslash", "fixtures\\tape.json", true},
+		{"mixed slashes", "fixtures/sub\\..\\tape.json", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEntryName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateEntryName(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestExportBundle_EmptyRouteExcluded(t *testing.T) {
 	store := NewMemoryStore()
 	// Tape with empty route should not appear in manifest routes


### PR DESCRIPTION
Closes #218

## Summary

- Add `validateEntryName` in `bundle.go` that rejects tar entry names containing path-traversal patterns (`..` as a path component), absolute paths (leading `/`), or backslashes (Windows-style separators).
- Call `validateEntryName` in `ImportBundle` before processing each tar entry. Malicious entries cause an immediate error return (fail loudly rather than silently skip).
- This is **defense in depth**, not a security patch. `ImportBundle` deserializes entries into in-memory `Tape` objects (not to the filesystem), and `Store.Save` implementations have their own path validation via `validateID`. The new check hardens the trust boundary so that no future code path could be exploitable.
- Uses `path.Clean` (not `filepath.Clean`) for OS-independent tar path normalization, then checks each segment for `..`.

## Test plan

- `TestImportBundle_RejectsPathTraversalInTarEntryNames` -- table-driven test with 6 cases covering `..` traversal, absolute paths, and backslashes; each constructs a tar bundle with the malicious entry and asserts `ImportBundle` returns the expected error.
- `TestImportBundle_AllowsSafeEntryNames` -- verifies that legitimate names (including `tape..1.json` where `..` is a substring, not a path component) are accepted.
- `TestValidateEntryName` -- unit tests for the validation function itself with 10 cases.

```
go test ./... -count=1   # all pass
go vet ./...             # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)