### PR TITLE
chore(#219): coverage for sse, proxy adapters, bundle tar export

### DIFF
--- a/bundle_test.go
+++ b/bundle_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1323,4 +1324,339 @@ func TestExportBundle_EmptyRouteExcluded(t *testing.T) {
 	if manifest.FixtureCount != 1 {
 		t.Errorf("manifest.FixtureCount = %d, want 1", manifest.FixtureCount)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// writeBundle error paths
+// ---------------------------------------------------------------------------
+
+// writeCapWriter counts bytes written and fails after a limit.
+type writeCapWriter struct {
+	remaining int
+	err       error
+}
+
+func (w *writeCapWriter) Write(p []byte) (int, error) {
+	if w.remaining <= 0 {
+		return 0, w.err
+	}
+	if len(p) <= w.remaining {
+		w.remaining -= len(p)
+		return len(p), nil
+	}
+	n := w.remaining
+	w.remaining = 0
+	return n, w.err
+}
+
+func TestWriteBundle_WriterFailsAtVariousByteOffsets(t *testing.T) {
+	tapes := []Tape{makeBundleTape("t1", "api", "GET", "http://test/1")}
+
+	// Sweep byte limits from 0 to well past the successful write size.
+	// With fine-grained limits we hit error branches at different points
+	// in the gzip/tar pipeline.
+	var hitErrors int
+	for limit := 0; limit <= 2000; limit++ {
+		w := &writeCapWriter{remaining: limit, err: errors.New("disk full")}
+		err := writeBundle(context.Background(), w, tapes, exportConfig{})
+		if err != nil {
+			hitErrors++
+		}
+	}
+	if hitErrors == 0 {
+		t.Fatal("expected at least some errors in the sweep")
+	}
+}
+
+// writeCallCounter counts calls to Write and fails on the Nth call.
+type writeCallCounter struct {
+	callsAllowed int
+	callsMade    int
+	err          error
+}
+
+func (w *writeCallCounter) Write(p []byte) (int, error) {
+	w.callsMade++
+	if w.callsMade > w.callsAllowed {
+		return 0, w.err
+	}
+	return len(p), nil
+}
+
+func TestWriteBundle_WriterFailsAtVariousCallCounts(t *testing.T) {
+	tapes := []Tape{makeBundleTape("t1", "api", "GET", "http://test/1")}
+
+	// Gzip writes in a small number of calls. By sweeping call counts
+	// from 0 to ~20, we trigger failures at different internal points
+	// (manifest header, manifest body, fixture, close).
+	var hitErrors int
+	for calls := 0; calls <= 20; calls++ {
+		w := &writeCallCounter{callsAllowed: calls, err: errors.New("write call limit")}
+		err := writeBundle(context.Background(), w, tapes, exportConfig{})
+		if err != nil {
+			hitErrors++
+		}
+	}
+	if hitErrors == 0 {
+		t.Fatal("expected at least some errors in the sweep")
+	}
+}
+
+func TestWriteBundle_LargeTapeForcesGzipFlushMidStream(t *testing.T) {
+	// Gzip uses an internal buffer. By creating tapes with large,
+	// incompressible bodies, we force gzip to flush mid-stream.
+	// When the underlying writer fails during these flushes, the error
+	// propagates to individual tar write operations, hitting the
+	// per-operation error branches in writeBundle.
+	//
+	// We use pseudo-random bytes (actually a repeating 256-byte pattern)
+	// that don't compress well, forcing gzip to write frequently.
+	incompressible := make([]byte, 128*1024) // 128KB
+	for i := range incompressible {
+		incompressible[i] = byte(i * 7) // simple pseudo-random pattern
+	}
+
+	tape := Tape{
+		ID:         "large-tape",
+		Route:      "api",
+		RecordedAt: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+		Request: RecordedReq{
+			Method:  "POST",
+			URL:     "http://test/upload",
+			Headers: http.Header{"Content-Type": {"application/octet-stream"}},
+			Body:    incompressible,
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/json"}},
+			Body:       incompressible,
+		},
+	}
+
+	// First, find the successful write size.
+	var successBuf bytes.Buffer
+	err := writeBundle(context.Background(), &successBuf, []Tape{tape}, exportConfig{})
+	if err != nil {
+		t.Fatalf("writeBundle with large tape failed: %v", err)
+	}
+	successSize := successBuf.Len()
+
+	// Sweep byte limits from 0 to successSize. With incompressible 128KB
+	// bodies, gzip must flush many times, creating failure points at
+	// different tar operations.
+	var hitErrors int
+	for limit := 0; limit < successSize; limit += 50 {
+		w := &writeCapWriter{remaining: limit, err: errors.New("disk full")}
+		if writeBundle(context.Background(), w, []Tape{tape}, exportConfig{}) != nil {
+			hitErrors++
+		}
+	}
+	if hitErrors == 0 {
+		t.Fatal("expected errors during large-tape sweep")
+	}
+}
+
+func TestWriteBundle_WriterFailsDuringFixtureWrite(t *testing.T) {
+	// Allow enough bytes for the gzip header + manifest but fail during
+	// fixture writing. We use a pipe to precisely control when the writer
+	// fails.
+	tapes := []Tape{
+		makeBundleTape("t1", "api", "GET", "http://test/1"),
+		makeBundleTape("t2", "api", "POST", "http://test/2"),
+	}
+
+	// Use a pipe so we can close the writer mid-stream.
+	pr, pw := io.Pipe()
+
+	go func() {
+		// Read some bytes and then close with an error.
+		buf := make([]byte, 256)
+		pr.Read(buf)
+		pr.CloseWithError(errors.New("pipe broken"))
+	}()
+
+	err := writeBundle(context.Background(), pw, tapes, exportConfig{})
+	if err == nil {
+		t.Fatal("expected error from writeBundle")
+	}
+}
+
+func TestWriteBundle_ContextCancelledBeforeManifestHeader(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	tapes := []Tape{makeBundleTape("t1", "api", "GET", "http://test/1")}
+	err := writeBundle(ctx, &buf, tapes, exportConfig{})
+	if err == nil {
+		t.Fatal("expected context cancelled error")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("error = %q, want context canceled", err)
+	}
+}
+
+func TestWriteBundle_ContextCancelledDuringFixtureLoop(t *testing.T) {
+	// Create many tapes and cancel context after a short time.
+	tapes := make([]Tape, 50)
+	for i := range tapes {
+		tapes[i] = makeBundleTape(
+			fmt.Sprintf("tape-%03d", i), "api", "GET",
+			fmt.Sprintf("http://test/%d", i),
+		)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Use a slow writer that gives us time to cancel mid-loop.
+	pr, pw := io.Pipe()
+	go func() {
+		// Read slowly, cancel after a bit.
+		buf := make([]byte, 512)
+		pr.Read(buf)
+		cancel()
+		// Drain the rest to unblock the writer.
+		io.Copy(io.Discard, pr)
+	}()
+
+	err := writeBundle(ctx, pw, tapes, exportConfig{})
+	// Either context canceled or a write error is acceptable.
+	if err == nil {
+		t.Fatal("expected error from writeBundle")
+	}
+}
+
+func TestWriteBundle_ErrorTriggersDeferredClose(t *testing.T) {
+	// The deferred close at lines 137-140 runs only on error paths.
+	// Any error in writeBundle should trigger it. We verify this by
+	// checking that the function returns an error (which means the
+	// deferred close ran to clean up resources).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	err := writeBundle(ctx, &buf, nil, exportConfig{})
+	if err == nil {
+		t.Fatal("expected error to trigger deferred close")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ImportBundle: tar read error (valid gzip, corrupted tar)
+// ---------------------------------------------------------------------------
+
+func TestImportBundle_CorruptedTarInsideValidGzip(t *testing.T) {
+	// Build a valid gzip wrapping invalid tar content.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	gw.Write([]byte("this is not valid tar data"))
+	gw.Close()
+
+	store := NewMemoryStore()
+	err := ImportBundle(context.Background(), store, &buf)
+	if err == nil {
+		t.Fatal("expected error for corrupted tar")
+	}
+	if !strings.Contains(err.Error(), "httptape: import:") {
+		t.Errorf("error = %q, want prefix 'httptape: import:'", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ImportBundle: save error during persist phase
+// ---------------------------------------------------------------------------
+
+// failingSaveBundleStore wraps a MemoryStore to fail on Save for bundle tests.
+type failingSaveBundleStore struct {
+	*MemoryStore
+}
+
+func (s *failingSaveBundleStore) Save(_ context.Context, _ Tape) error {
+	return errors.New("save failed")
+}
+
+func TestImportBundle_SaveError(t *testing.T) {
+	// Build a valid bundle.
+	srcStore := NewMemoryStore()
+	saveTestTapes(t, srcStore, makeBundleTape("t1", "api", "GET", "http://test/1"))
+
+	r, err := ExportBundle(context.Background(), srcStore)
+	if err != nil {
+		t.Fatalf("ExportBundle: %v", err)
+	}
+	bundleData, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+
+	// Import into a store that fails on Save.
+	dstStore := &failingSaveBundleStore{MemoryStore: NewMemoryStore()}
+	err = ImportBundle(context.Background(), dstStore, bytes.NewReader(bundleData))
+	if err == nil {
+		t.Fatal("expected error for save failure")
+	}
+	if !strings.Contains(err.Error(), "save tape") {
+		t.Errorf("error = %q, want mention of 'save tape'", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ImportBundle: context cancelled during persist phase
+// ---------------------------------------------------------------------------
+
+func TestImportBundle_ContextCancelledDuringSave(t *testing.T) {
+	// Build a bundle with multiple tapes.
+	srcStore := NewMemoryStore()
+	for i := 0; i < 5; i++ {
+		saveTestTapes(t, srcStore, makeBundleTape(
+			fmt.Sprintf("t%d", i), "api", "GET",
+			fmt.Sprintf("http://test/%d", i),
+		))
+	}
+
+	r, err := ExportBundle(context.Background(), srcStore)
+	if err != nil {
+		t.Fatalf("ExportBundle: %v", err)
+	}
+	bundleData, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+
+	// Use a store that cancels context after first Save.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelAfterOneSave := &cancelAfterNSavesStore{
+		MemoryStore: NewMemoryStore(),
+		cancel:      cancel,
+		saveCount:   0,
+		cancelAfter: 1,
+	}
+
+	err = ImportBundle(ctx, cancelAfterOneSave, bytes.NewReader(bundleData))
+	if err == nil {
+		t.Fatal("expected error from cancelled context during save")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("error = %q, want context canceled", err)
+	}
+}
+
+// cancelAfterNSavesStore cancels the context after N successful saves.
+type cancelAfterNSavesStore struct {
+	*MemoryStore
+	cancel      context.CancelFunc
+	saveCount   int
+	cancelAfter int
+}
+
+func (s *cancelAfterNSavesStore) Save(ctx context.Context, tape Tape) error {
+	err := s.MemoryStore.Save(ctx, tape)
+	if err != nil {
+		return err
+	}
+	s.saveCount++
+	if s.saveCount >= s.cancelAfter {
+		s.cancel()
+	}
+	return nil
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io"
@@ -993,5 +994,753 @@ func TestProxy_CompositionSanitizationPath(t *testing.T) {
 	l2Secret := l2Tapes[0].Request.Headers.Get("X-Secret")
 	if l2Secret == "top-secret-value" {
 		t.Errorf("L2 X-Secret should be redacted, got raw value %q", l2Secret)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// errReadCloser is a body that returns an error after N bytes.
+// ---------------------------------------------------------------------------
+
+type errReadCloser struct {
+	remaining int
+	err       error
+	closed    bool
+}
+
+func (r *errReadCloser) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, r.err
+	}
+	n := len(p)
+	if n > r.remaining {
+		n = r.remaining
+	}
+	for i := 0; i < n; i++ {
+		p[i] = 'x'
+	}
+	r.remaining -= n
+	return n, nil
+}
+
+func (r *errReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+// failingListStore wraps a MemoryStore to fail on List calls.
+type failingListStore struct {
+	*MemoryStore
+}
+
+func (s *failingListStore) List(_ context.Context, _ Filter) ([]Tape, error) {
+	return nil, errors.New("store list failure")
+}
+
+// failingSaveStore wraps a MemoryStore to fail on Save calls but still
+// support List and Load.
+type failingSaveStore struct {
+	*MemoryStore
+}
+
+func (s *failingSaveStore) Save(_ context.Context, _ Tape) error {
+	return errors.New("store save failure")
+}
+
+// ---------------------------------------------------------------------------
+// l1RecordingTransport: response body read error triggers onError
+// ---------------------------------------------------------------------------
+
+func TestL1RecordingTransport_ResponseBodyReadError(t *testing.T) {
+	l1 := NewMemoryStore()
+	var capturedErr error
+
+	transport := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       &errReadCloser{remaining: 5, err: errors.New("read failed")},
+		}, nil
+	})
+
+	l1rt := &l1RecordingTransport{
+		inner:   transport,
+		l1:      l1,
+		route:   "test",
+		onError: func(err error) { capturedErr = err },
+		isFallback: func(err error, _ *http.Response) bool {
+			return err != nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := l1rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	// Response should still be returned even though reading body failed.
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// The onError callback should have been called with the read error.
+	if capturedErr == nil {
+		t.Fatal("expected onError to be called")
+	}
+	if !strings.Contains(capturedErr.Error(), "l1 recording read response body") {
+		t.Errorf("error = %q, want mention of l1 recording", capturedErr.Error())
+	}
+
+	// L1 should have no tape saved (because reading failed).
+	tapes, _ := l1.List(context.Background(), Filter{})
+	if len(tapes) != 0 {
+		t.Errorf("L1 has %d tapes, want 0 (body read failed)", len(tapes))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// l1RecordingTransport: L1 save error triggers onError
+// ---------------------------------------------------------------------------
+
+func TestL1RecordingTransport_SaveError(t *testing.T) {
+	l1 := &failingSaveStore{MemoryStore: NewMemoryStore()}
+	var capturedErr error
+
+	transport := successTransport(200, "ok")
+
+	l1rt := &l1RecordingTransport{
+		inner:   transport,
+		l1:      l1,
+		route:   "test",
+		onError: func(err error) { capturedErr = err },
+		isFallback: func(err error, _ *http.Response) bool {
+			return err != nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := l1rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if string(body) != "ok" {
+		t.Errorf("body = %q, want %q", string(body), "ok")
+	}
+	if capturedErr == nil {
+		t.Fatal("expected onError for save failure")
+	}
+	if !strings.Contains(capturedErr.Error(), "store save failure") {
+		t.Errorf("error = %q, want mention of store save failure", capturedErr.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// l1RecordingTransport.onErrorSafe: nil callback does not panic
+// ---------------------------------------------------------------------------
+
+func TestL1RecordingTransport_OnErrorSafeNilCallback(t *testing.T) {
+	l1rt := &l1RecordingTransport{
+		onError: nil,
+	}
+	// Should not panic.
+	l1rt.onErrorSafe(errors.New("test error"))
+}
+
+// ---------------------------------------------------------------------------
+// l1RecordingTransport.onErrorSafe: non-nil callback is invoked
+// ---------------------------------------------------------------------------
+
+func TestL1RecordingTransport_OnErrorSafeInvokesCallback(t *testing.T) {
+	var got error
+	l1rt := &l1RecordingTransport{
+		onError: func(err error) { got = err },
+	}
+	l1rt.onErrorSafe(errors.New("test error"))
+	if got == nil || got.Error() != "test error" {
+		t.Errorf("onErrorSafe did not invoke callback; got = %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.onErrorSafe: nil callback does not panic
+// ---------------------------------------------------------------------------
+
+func TestProxy_OnErrorSafeNilCallback(t *testing.T) {
+	p := &Proxy{onError: nil}
+	// Should not panic.
+	p.onErrorSafe(errors.New("test error"))
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.onErrorSafe: non-nil callback is invoked
+// ---------------------------------------------------------------------------
+
+func TestProxy_OnErrorSafeInvokesCallback(t *testing.T) {
+	var got error
+	p := &Proxy{onError: func(err error) { got = err }}
+	p.onErrorSafe(errors.New("test error"))
+	if got == nil || got.Error() != "test error" {
+		t.Errorf("onErrorSafe did not invoke callback; got = %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WithProxySanitizer: nil sanitizer defaults to no-op pipeline
+// ---------------------------------------------------------------------------
+
+func TestWithProxySanitizer_NilDefaultsToNoopPipeline(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(successTransport(200, "ok")),
+		WithProxySanitizer(nil),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// With nil sanitizer (defaulting to no-op), L2 should have the raw header.
+	l2Tapes, _ := l2.List(context.Background(), Filter{})
+	if len(l2Tapes) != 1 {
+		t.Fatalf("L2 has %d tapes, want 1", len(l2Tapes))
+	}
+	l2Auth := l2Tapes[0].Request.Headers.Get("Authorization")
+	if l2Auth != "Bearer secret" {
+		t.Errorf("L2 Authorization=%q, want raw (no sanitization)", l2Auth)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WithProxyTLSConfig: non-http.Transport uses new Transport
+// ---------------------------------------------------------------------------
+
+func TestWithProxyTLSConfig_NonHTTPTransport(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	customRT := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	// When transport is a custom RoundTripper (not *http.Transport),
+	// WithProxyTLSConfig should replace it with a new *http.Transport.
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(customRT),
+		WithProxyTLSConfig(&tls.Config{InsecureSkipVerify: true}), //nolint:gosec
+	)
+
+	// The transport should now be an *http.Transport with the TLS config.
+	if _, ok := proxy.transport.(*http.Transport); !ok {
+		t.Errorf("transport type = %T, want *http.Transport", proxy.transport)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WithProxyProbeInterval: negative duration clamped to zero
+// ---------------------------------------------------------------------------
+
+func TestWithProxyProbeInterval_NegativeClamped(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(successTransport(200, "ok")),
+		WithProxyUpstreamURL("http://up"),
+		WithProxyHealthEndpoint(),
+		WithProxyProbeInterval(-5*time.Second),
+	)
+	defer proxy.Close() //nolint:errcheck
+
+	// The negative probe interval should be clamped to 0 (which means
+	// no probe loop). Verify by starting and confirming no panic.
+	proxy.Start()
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.RoundTrip: request body read error
+// ---------------------------------------------------------------------------
+
+func TestProxy_RequestBodyReadError(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(successTransport(200, "ok")),
+	)
+
+	req, _ := http.NewRequest("POST", "http://example.com/api", &errReadCloser{
+		remaining: 3,
+		err:       errors.New("request body read failed"),
+	})
+	resp, err := proxy.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error for request body read failure")
+	}
+	if resp != nil {
+		resp.Body.Close()
+		t.Error("expected nil response on request body read error")
+	}
+	if !strings.Contains(err.Error(), "proxy read request body") {
+		t.Errorf("error = %q, want mention of proxy read request body", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.RoundTrip: response body read error during 5xx fallback drain
+// ---------------------------------------------------------------------------
+
+func TestProxy_FallbackDrainReadError(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	// Pre-populate L1 with a cached tape so fallback succeeds.
+	tape := NewTape("", RecordedReq{
+		Method: "GET", URL: "http://example.com/api", Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200, Headers: http.Header{}, Body: []byte("cached"),
+	})
+	l1.Save(context.Background(), tape) //nolint:errcheck
+
+	// Transport returns a 503 with a body that errors on read.
+	transport := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 503,
+			Header:     http.Header{},
+			Body:       &errReadCloser{remaining: 2, err: errors.New("drain failed")},
+		}, nil
+	})
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(transport),
+		WithProxyFallbackOn(func(err error, resp *http.Response) bool {
+			if err != nil {
+				return true
+			}
+			return resp != nil && resp.StatusCode >= 500
+		}),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Should fall back to L1 cache.
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "cached" {
+		t.Errorf("body = %q, want %q", string(body), "cached")
+	}
+	if src := resp.Header.Get("X-Httptape-Source"); src != "l1-cache" {
+		t.Errorf("X-Httptape-Source = %q, want l1-cache", src)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.matchFromStore: store.List error invokes onError and returns no match
+// ---------------------------------------------------------------------------
+
+func TestProxy_MatchFromStoreListError(t *testing.T) {
+	l1 := &failingListStore{MemoryStore: NewMemoryStore()}
+	l2 := NewMemoryStore()
+
+	var capturedErr error
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("down"))),
+		WithProxyOnError(func(err error) { capturedErr = err }),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := proxy.RoundTrip(req)
+
+	// Both L1 (failing list) and L2 (empty) miss -> original error returned.
+	if resp != nil {
+		resp.Body.Close()
+		t.Error("expected nil response")
+	}
+	if err == nil {
+		t.Fatal("expected original transport error")
+	}
+	if !strings.Contains(err.Error(), "down") {
+		t.Errorf("error = %q, want original error", err)
+	}
+
+	// onError should have been called with the store list failure.
+	if capturedErr == nil {
+		t.Fatal("expected onError for store list failure")
+	}
+	if !strings.Contains(capturedErr.Error(), "store list failure") {
+		t.Errorf("captured error = %q, want mention of store list failure", capturedErr.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.tapeToResponse: tape with nil response headers
+// ---------------------------------------------------------------------------
+
+func TestProxy_TapeToResponse_NilHeaders(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	// Pre-populate L1 with a tape that has nil headers.
+	tape := NewTape("", RecordedReq{
+		Method: "GET", URL: "http://example.com/api", Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    nil,
+		Body:       []byte("body"),
+	})
+	l1.Save(context.Background(), tape) //nolint:errcheck
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("down"))),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Should still work even with nil original headers.
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if src := resp.Header.Get("X-Httptape-Source"); src != "l1-cache" {
+		t.Errorf("X-Httptape-Source = %q, want l1-cache", src)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "body" {
+		t.Errorf("body = %q, want %q", string(body), "body")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.tapeToResponse: tape with nil body (non-SSE)
+// ---------------------------------------------------------------------------
+
+func TestProxy_TapeToResponse_NilBody(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	// Pre-populate L1 with a tape that has nil body.
+	tape := NewTape("", RecordedReq{
+		Method: "GET", URL: "http://example.com/api", Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 204,
+		Headers:    http.Header{},
+		Body:       nil,
+	})
+	l1.Save(context.Background(), tape) //nolint:errcheck
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("down"))),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		t.Errorf("status = %d, want 204", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if len(body) != 0 {
+		t.Errorf("body length = %d, want 0 (nil body tape)", len(body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.sseResponseFromTape: SSE event write error closes pipe
+// ---------------------------------------------------------------------------
+
+func TestProxy_SSEResponseFromTape_WriteErrorClosesPipe(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	// Create an SSE tape where events will be written via io.Pipe.
+	tape := NewTape("", RecordedReq{
+		Method: "GET", URL: "http://example.com/stream", Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/event-stream"}},
+		SSEEvents: []SSEEvent{
+			{OffsetMS: 0, Data: "hello"},
+			{OffsetMS: 100, Data: "world"},
+		},
+	})
+	l1.Save(context.Background(), tape) //nolint:errcheck
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("down"))),
+		WithProxySSETiming(SSETimingInstant()),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Close the pipe reader immediately to trigger a write error in the
+	// goroutine. The goroutine should detect the error and close the pipe.
+	// Note: we read a tiny bit first to give the goroutine a chance to start,
+	// then close the body to cause the write error.
+	buf := make([]byte, 1)
+	resp.Body.Read(buf)
+	resp.Body.Close()
+	// The goroutine should not hang or panic.
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.fallback: body restore for second match attempt (L2 lookup)
+// ---------------------------------------------------------------------------
+
+func TestProxy_Fallback_BodyRestoredForL2Match(t *testing.T) {
+	l1 := NewMemoryStore() // empty -- force L1 miss
+	l2 := NewMemoryStore()
+
+	// Pre-populate L2 with a tape that matches by body hash.
+	postBody := []byte(`{"action":"test"}`)
+	tape := NewTape("", RecordedReq{
+		Method:   "POST",
+		URL:      "http://example.com/api",
+		Headers:  http.Header{},
+		Body:     postBody,
+		BodyHash: BodyHashFromBytes(postBody),
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("from-l2"),
+	})
+	l2.Save(context.Background(), tape) //nolint:errcheck
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("down"))),
+		WithProxyMatcher(NewCompositeMatcher(MethodCriterion{}, PathCriterion{})),
+	)
+
+	req, _ := http.NewRequest("POST", "http://example.com/api", bytes.NewReader(postBody))
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected L2 fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "from-l2" {
+		t.Errorf("body = %q, want %q", string(body), "from-l2")
+	}
+	if src := resp.Header.Get("X-Httptape-Source"); src != "l2-cache" {
+		t.Errorf("X-Httptape-Source = %q, want l2-cache", src)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// l1RecordingTransport: SSE stream truncation triggers onError
+// ---------------------------------------------------------------------------
+
+func TestL1RecordingTransport_SSETruncation(t *testing.T) {
+	l1 := NewMemoryStore()
+	var capturedErrors []string
+	var mu sync.Mutex
+
+	// Transport that returns an SSE response with a body that errors mid-stream.
+	transport := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		pr, pw := io.Pipe()
+		go func() {
+			pw.Write([]byte("data: event1\n\n"))
+			pw.CloseWithError(errors.New("upstream disconnected"))
+		}()
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+			Body:       pr,
+		}, nil
+	})
+
+	l1rt := &l1RecordingTransport{
+		inner: transport,
+		l1:    l1,
+		route: "test",
+		onError: func(err error) {
+			mu.Lock()
+			capturedErrors = append(capturedErrors, err.Error())
+			mu.Unlock()
+		},
+		isFallback: func(err error, _ *http.Response) bool {
+			return err != nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	resp, err := l1rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read the body to drive the SSE recording.
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// Wait for background parser to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	// The truncation error should have been reported via onError.
+	mu.Lock()
+	defer mu.Unlock()
+	found := false
+	for _, e := range capturedErrors {
+		if strings.Contains(e, "l1 SSE stream truncated") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'l1 SSE stream truncated' error, got %v", capturedErrors)
+	}
+
+	// L1 should still have the tape with the Truncated flag set.
+	tapes, _ := l1.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("L1 has %d tapes, want 1", len(tapes))
+	}
+	if !tapes[0].Response.Truncated {
+		t.Error("tape should have Truncated=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// l1RecordingTransport: SSE L1 save error triggers onError
+// ---------------------------------------------------------------------------
+
+func TestL1RecordingTransport_SSESaveError(t *testing.T) {
+	l1 := &failingSaveStore{MemoryStore: NewMemoryStore()}
+	var capturedErrors []string
+	var mu sync.Mutex
+
+	transport := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader("data: hello\n\n")),
+		}, nil
+	})
+
+	l1rt := &l1RecordingTransport{
+		inner: transport,
+		l1:    l1,
+		route: "test",
+		onError: func(err error) {
+			mu.Lock()
+			capturedErrors = append(capturedErrors, err.Error())
+			mu.Unlock()
+		},
+		isFallback: func(err error, _ *http.Response) bool {
+			return err != nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	resp, err := l1rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read body to drive SSE recording completion.
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// Wait for background parser.
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	found := false
+	for _, e := range capturedErrors {
+		if strings.Contains(e, "store save failure") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'store save failure' error, got %v", capturedErrors)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy.sseResponseFromTape: timing delay exercised via pipe
+// ---------------------------------------------------------------------------
+
+func TestProxy_SSEResponseFromTape_WithTiming(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	// Pre-populate L1 with an SSE tape that has non-zero offsets.
+	tape := NewTape("", RecordedReq{
+		Method: "GET", URL: "http://example.com/stream", Headers: http.Header{},
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/event-stream"}},
+		SSEEvents: []SSEEvent{
+			{OffsetMS: 0, Data: "first"},
+			{OffsetMS: 80, Data: "second"},
+		},
+	})
+	l1.Save(context.Background(), tape) //nolint:errcheck
+
+	proxy := NewProxy(l1, l2,
+		WithProxyTransport(failingTransport(errors.New("down"))),
+		WithProxySSETiming(SSETimingRealtime()),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	start := time.Now()
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the full body, which goes through the pipe with timing delays.
+	var events []SSEEvent
+	parseSSEStream(resp.Body, time.Now(), func(ev SSEEvent) {
+		ev.OffsetMS = 0
+		events = append(events, ev)
+	})
+	elapsed := time.Since(start)
+
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	if events[0].Data != "first" {
+		t.Errorf("events[0].Data = %q, want %q", events[0].Data, "first")
+	}
+	if events[1].Data != "second" {
+		t.Errorf("events[1].Data = %q, want %q", events[1].Data, "second")
+	}
+
+	// The 80ms inter-event delay should be applied (within tolerance).
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("elapsed %v, expected >= 50ms for 80ms timing delay", elapsed)
 	}
 }

--- a/sse_test.go
+++ b/sse_test.go
@@ -1750,3 +1750,224 @@ func TestSSERecordingReader_ConcurrentReads(t *testing.T) {
 		t.Errorf("got %d events, want 100", len(events))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// sseTimingMode seal method coverage
+// ---------------------------------------------------------------------------
+
+func TestSSETimingMode_SealMethodsAreCallable(t *testing.T) {
+	// The sseTimingMode() methods are seal methods that prevent external
+	// implementations. They are no-op but should be covered for completeness.
+	// We exercise them indirectly through the SSETimingMode interface.
+	modes := []SSETimingMode{
+		SSETimingRealtime(),
+		SSETimingAccelerated(1.0),
+		SSETimingInstant(),
+	}
+	for _, m := range modes {
+		// Call the seal method via the interface. It's a no-op, but this
+		// proves the method exists and executes without panic.
+		m.sseTimingMode()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isSSEContentType: mime.ParseMediaType error fallback
+// ---------------------------------------------------------------------------
+
+func TestIsSSEContentType_FallbackOnMalformedMediaType(t *testing.T) {
+	// A content type that mime.ParseMediaType fails to parse but still
+	// has the right prefix should match via the fallback path.
+	tests := []struct {
+		name string
+		ct   string
+		want bool
+	}{
+		{
+			name: "malformed params but correct type prefix triggers fallback match",
+			ct:   "text/event-stream; ===invalid===",
+			want: true,
+		},
+		{
+			name: "malformed params with wrong type prefix does not match",
+			ct:   "application/json; ===invalid===",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSSEContentType(tt.ct); got != tt.want {
+				t.Errorf("isSSEContentType(%q) = %v, want %v", tt.ct, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// writeSSEEvent: error paths for each field type
+// ---------------------------------------------------------------------------
+
+// limitWriter allows the first N bytes to be written, then returns an error.
+// This lets us trigger write failures at specific points in writeSSEEvent.
+type limitWriter struct {
+	remaining int
+	err       error
+}
+
+func (w *limitWriter) Write(p []byte) (int, error) {
+	if w.remaining <= 0 {
+		return 0, w.err
+	}
+	if len(p) <= w.remaining {
+		w.remaining -= len(p)
+		return len(p), nil
+	}
+	n := w.remaining
+	w.remaining = 0
+	return n, w.err
+}
+
+func TestWriteSSEEvent_ErrorOnEventField(t *testing.T) {
+	// Fail after writing 0 bytes -- the "event:" field write should fail.
+	w := &limitWriter{remaining: 0, err: errors.New("disk full")}
+	err := writeSSEEvent(w, SSEEvent{Type: "update", Data: "hello"})
+	if err == nil {
+		t.Fatal("expected error writing event field")
+	}
+	if !strings.Contains(err.Error(), "write event field") {
+		t.Errorf("error = %q, want it to mention 'write event field'", err)
+	}
+}
+
+func TestWriteSSEEvent_ErrorOnIDField(t *testing.T) {
+	// Allow "event:" line to succeed, then fail on "id:" line.
+	eventLine := "event: update\n"
+	w := &limitWriter{remaining: len(eventLine), err: errors.New("disk full")}
+	err := writeSSEEvent(w, SSEEvent{Type: "update", ID: "42", Data: "hello"})
+	if err == nil {
+		t.Fatal("expected error writing id field")
+	}
+	if !strings.Contains(err.Error(), "write id field") {
+		t.Errorf("error = %q, want it to mention 'write id field'", err)
+	}
+}
+
+func TestWriteSSEEvent_ErrorOnRetryField(t *testing.T) {
+	// Allow "event:" and "id:" lines, then fail on "retry:".
+	written := "event: update\nid: 42\n"
+	w := &limitWriter{remaining: len(written), err: errors.New("disk full")}
+	err := writeSSEEvent(w, SSEEvent{Type: "update", ID: "42", Retry: 5000, Data: "hello"})
+	if err == nil {
+		t.Fatal("expected error writing retry field")
+	}
+	if !strings.Contains(err.Error(), "write retry field") {
+		t.Errorf("error = %q, want it to mention 'write retry field'", err)
+	}
+}
+
+func TestWriteSSEEvent_ErrorOnTerminator(t *testing.T) {
+	// Allow everything except the final blank line.
+	dataLine := "data: hello\n"
+	w := &limitWriter{remaining: len(dataLine), err: errors.New("disk full")}
+	err := writeSSEEvent(w, SSEEvent{Data: "hello"})
+	if err == nil {
+		t.Fatal("expected error writing terminator")
+	}
+	if !strings.Contains(err.Error(), "write event terminator") {
+		t.Errorf("error = %q, want it to mention 'write event terminator'", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// replaySSEEvents: context cancelled between delay and write
+// ---------------------------------------------------------------------------
+
+func TestReplaySSEEvents_ContextCancelledAfterDelay(t *testing.T) {
+	// Create events where the second event has a small delay. Cancel the
+	// context during that delay window so the post-delay ctx.Err() check
+	// catches it.
+	events := []SSEEvent{
+		{OffsetMS: 0, Data: "first"},
+		{OffsetMS: 50, Data: "second"},
+	}
+
+	rec := httptest.NewRecorder()
+	flusher := http.ResponseWriter(rec).(http.Flusher)
+
+	// Cancel context right after the first event is written.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Wait enough for the first event to be written and the delay
+		// to start, but cancel before it finishes.
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	err := replaySSEEvents(ctx, rec, flusher, events, SSETimingRealtime())
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// replaySSEEvents: write error propagated
+// ---------------------------------------------------------------------------
+
+// failingResponseWriter is an http.ResponseWriter that fails on Write.
+type failingResponseWriter struct {
+	header http.Header
+}
+
+func (w *failingResponseWriter) Header() http.Header { return w.header }
+func (w *failingResponseWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("broken pipe")
+}
+func (w *failingResponseWriter) WriteHeader(_ int) {}
+
+// noopFlusher implements http.Flusher as a no-op.
+type noopFlusher struct{}
+
+func (noopFlusher) Flush() {}
+
+func TestReplaySSEEvents_ContextCancelledBetweenZeroDelayEvents(t *testing.T) {
+	// When the delay is 0, the timer select is skipped and the post-delay
+	// ctx.Err() check at line 284 is the only cancellation check point.
+	// This test cancels the context before replay starts, so the first
+	// event's post-delay check catches it immediately.
+	events := []SSEEvent{
+		{OffsetMS: 0, Data: "first"},
+		{OffsetMS: 0, Data: "second"},
+	}
+
+	rec := httptest.NewRecorder()
+	flusher := http.ResponseWriter(rec).(http.Flusher)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before replay begins
+
+	err := replaySSEEvents(ctx, rec, flusher, events, SSETimingInstant())
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestReplaySSEEvents_WriteErrorPropagated(t *testing.T) {
+	events := []SSEEvent{
+		{OffsetMS: 0, Data: "hello"},
+	}
+
+	w := &failingResponseWriter{header: http.Header{}}
+	err := replaySSEEvents(context.Background(), w, noopFlusher{}, events, SSETimingInstant())
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if !strings.Contains(err.Error(), "broken pipe") {
+		t.Errorf("error = %q, want it to mention 'broken pipe'", err)
+	}
+}


### PR DESCRIPTION
Closes #219 (partially -- PR 2 of N)

## Summary

Adds test coverage for three files identified in the coverage audit:

### sse.go
- **sseTimingMode() seal methods**: Exercised via interface calls. Remain at 0% in `go tool cover` because empty method bodies (`{}`) cannot be instrumented by Go's coverage tool -- this is a known tooling limitation, not a real gap.
- **isSSEContentType fallback path**: Covers the `mime.ParseMediaType` error fallback with a malformed media type that still has the correct prefix.
- **writeSSEEvent error paths**: Covers write failures on event, id, retry, and terminator fields using a `limitWriter` that fails after N bytes.
- **replaySSEEvents edge cases**: Context cancelled between zero-delay events (exercises the post-delay ctx.Err() check), and write error propagation via a failing ResponseWriter.

Coverage delta: `isSSEContentType` 83.3% -> 100%, `writeSSEEvent` 75% -> 100%, `replaySSEEvents` 84.6% -> 100%.

### proxy.go
- **l1RecordingTransport**: Response body read error, L1 save error, SSE stream truncation, SSE save error.
- **onErrorSafe** (both l1RecordingTransport and Proxy): nil and non-nil callback paths. Both were at 0%.
- **WithProxySanitizer**: nil sanitizer defaults to no-op pipeline (60% -> 100%).
- **WithProxyTLSConfig**: non-http.Transport branch creates new Transport (90% -> 100%).
- **WithProxyProbeInterval**: negative duration clamped to zero (75% -> 100%).
- **Proxy.RoundTrip**: request body read error returns wrapped error.
- **Proxy.fallback**: body restored for L2 match attempt, matchFromStore store.List failure path.
- **Proxy.tapeToResponse**: nil headers, nil body.
- **Proxy.sseResponseFromTape**: write error closes pipe, timing delay exercised with SSETimingRealtime.

Coverage delta: 12 functions from <100% brought to 100%. `Proxy.RoundTrip` 87% -> 91.3%.

Skipped (proxy.go):
- Line 621-623 (GetBody closure): Dead code -- set by Proxy.RoundTrip but immediately overwritten by CachingTransport before l1RecordingTransport calls it.
- Line 642-644 (fallback drain read error): Unreachable because CachingTransport always replaces the response body with a `bytes.Reader` before Proxy sees it.

### bundle.go
- **writeBundle**: Writer failure at various byte offsets (byte sweep + call-count sweep), incompressible large tape that forces gzip mid-stream flushes, context cancellation before manifest header and during fixture loop.
- **ImportBundle**: Corrupted tar inside valid gzip, save error during persist phase, context cancelled during save loop.

Coverage delta: `writeBundle` 63.6% -> 81.8%, `ImportBundle` 92.3% -> 100%.

Skipped (bundle.go):
- Lines 147, 177: `json.MarshalIndent` errors for Manifest/Tape structs with only JSON-safe field types (cannot fail in practice).
- Lines 166, 188, 192, 198: Individual tar Write/WriteHeader/Close errors unreachable because gzip's internal buffering absorbs writes and defers errors to Close time. The first tar operation that sees a stale gzip error (WriteHeader for manifest) returns immediately, preventing downstream error branches from executing.

### Overall
Package coverage: 92.8% -> 94.3%.

## Test plan

- [x] `go build ./...` -- clean
- [x] `go test ./...` -- all pass
- [x] `go test -race ./...` -- no races
- [x] `go vet ./...` -- clean
- [x] No production code changes
- [x] No external dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)