### PR TITLE
chore(#219): coverage for store_file, health, faker — closes #219

### DIFF
--- a/faker_test.go
+++ b/faker_test.go
@@ -728,3 +728,216 @@ func TestNameFaker(t *testing.T) {
 		t.Error("non-string should pass through")
 	}
 }
+
+// --- Coverage gap tests (issue #219) ---
+
+func TestPhoneFaker_HMACRechain(t *testing.T) {
+	// HMAC-SHA256 produces 32 bytes. A phone number with 33+ digits forces
+	// the re-chain path (hi >= len(h)).
+	f := PhoneFaker{}
+	longPhone := strings.Repeat("1", 40) // 40 digits
+	got := f.Fake("seed", longPhone)
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if len(s) != 40 {
+		t.Errorf("length = %d, want 40", len(s))
+	}
+	for i, c := range s {
+		if c < '0' || c > '9' {
+			t.Errorf("non-digit at %d: %c", i, c)
+		}
+	}
+	// Verify deterministic.
+	got2 := f.Fake("seed", longPhone)
+	if got != got2 {
+		t.Errorf("non-deterministic: %v != %v", got, got2)
+	}
+}
+
+func TestPatternFaker_HMACRechain_Digits(t *testing.T) {
+	// Pattern with 40 '#' placeholders forces re-chain for digit generation.
+	pattern := strings.Repeat("#", 40)
+	f := PatternFaker{Pattern: pattern}
+	got := f.Fake("seed", "input")
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if len(s) != 40 {
+		t.Errorf("length = %d, want 40", len(s))
+	}
+	for i, c := range s {
+		if c < '0' || c > '9' {
+			t.Errorf("non-digit at %d: %c", i, c)
+		}
+	}
+}
+
+func TestPatternFaker_HMACRechain_Letters(t *testing.T) {
+	// Pattern with 40 '?' placeholders forces re-chain for letter generation.
+	pattern := strings.Repeat("?", 40)
+	f := PatternFaker{Pattern: pattern}
+	got := f.Fake("seed", "input")
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if len(s) != 40 {
+		t.Errorf("length = %d, want 40", len(s))
+	}
+	for i, c := range s {
+		if c < 'a' || c > 'z' {
+			t.Errorf("non-letter at %d: %c", i, c)
+		}
+	}
+}
+
+func TestFakeAtPathWith_NonObjectData(t *testing.T) {
+	// When the JSON body is an array at the top level, fakeAtPathWith should
+	// return without error (data is not map[string]any).
+	body := []byte(`[{"email":"a@b.com"},{"email":"c@d.com"}]`)
+	tape := Tape{
+		Request:  RecordedReq{Body: body, Headers: make(map[string][]string)},
+		Response: RecordedResp{Body: body, Headers: make(map[string][]string)},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.email": EmailFaker{},
+	})
+
+	result := fn(tape)
+	// Body should be unchanged since the top-level is an array, not an object.
+	var arr []any
+	if err := json.Unmarshal(result.Request.Body, &arr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// The emails should be untouched (path does not match top-level array).
+	first := arr[0].(map[string]any)
+	if first["email"] != "a@b.com" {
+		t.Errorf("email should be unchanged, got %v", first["email"])
+	}
+}
+
+func TestFakeAtPathWith_MissingKey(t *testing.T) {
+	// When the path targets a key that does not exist in the object,
+	// fakeAtPathWith should silently skip.
+	body := []byte(`{"name":"Alice"}`)
+	tape := Tape{
+		Request:  RecordedReq{Body: body, Headers: make(map[string][]string)},
+		Response: RecordedResp{Body: body, Headers: make(map[string][]string)},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.nonexistent": EmailFaker{},
+	})
+
+	result := fn(tape)
+	var data map[string]any
+	if err := json.Unmarshal(result.Request.Body, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// name should be unchanged.
+	if data["name"] != "Alice" {
+		t.Errorf("name = %v, want Alice", data["name"])
+	}
+}
+
+func TestFakeAtPathWith_WildcardOnNonArray(t *testing.T) {
+	// When a wildcard path targets a field that is not an array,
+	// fakeAtPathWith should silently skip.
+	body := []byte(`{"users":"not-an-array"}`)
+	tape := Tape{
+		Request:  RecordedReq{Body: body, Headers: make(map[string][]string)},
+		Response: RecordedResp{Body: body, Headers: make(map[string][]string)},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.users[*].email": EmailFaker{},
+	})
+
+	result := fn(tape)
+	var data map[string]any
+	if err := json.Unmarshal(result.Request.Body, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if data["users"] != "not-an-array" {
+		t.Errorf("users = %v, want 'not-an-array'", data["users"])
+	}
+}
+
+func TestFakeAtPathWith_WildcardAtLeaf(t *testing.T) {
+	// When a wildcard is the last segment (no deeper path), the array
+	// elements are containers and should be left unchanged.
+	body := []byte(`{"items":[1,2,3]}`)
+	tape := Tape{
+		Request:  RecordedReq{Body: body, Headers: make(map[string][]string)},
+		Response: RecordedResp{Body: body, Headers: make(map[string][]string)},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.items[*]": RedactedFaker{},
+	})
+
+	result := fn(tape)
+	var data map[string]any
+	if err := json.Unmarshal(result.Request.Body, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// items should be unchanged since wildcard at leaf skips containers.
+	items := data["items"].([]any)
+	if len(items) != 3 {
+		t.Errorf("items length = %d, want 3", len(items))
+	}
+	if items[0] != float64(1) {
+		t.Errorf("items[0] = %v, want 1", items[0])
+	}
+}
+
+func TestFakeFieldsWith_InvalidPath(t *testing.T) {
+	// Invalid path (no $. prefix) should be silently ignored.
+	body := []byte(`{"email":"test@test.com"}`)
+	tape := Tape{
+		Request:  RecordedReq{Body: body, Headers: make(map[string][]string)},
+		Response: RecordedResp{Body: body, Headers: make(map[string][]string)},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"email":    EmailFaker{}, // missing $. prefix
+		"$.email":  EmailFaker{}, // valid
+	})
+
+	result := fn(tape)
+	var data map[string]any
+	if err := json.Unmarshal(result.Request.Body, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	email := data["email"].(string)
+	if !strings.HasSuffix(email, "@example.com") {
+		t.Errorf("valid path $.email should have been faked, got %q", email)
+	}
+}
+
+func TestFakeAtPathWith_IntermediateNonObject(t *testing.T) {
+	// Path traversal through a non-object intermediate value should silently skip.
+	body := []byte(`{"user":"just-a-string"}`)
+	tape := Tape{
+		Request:  RecordedReq{Body: body, Headers: make(map[string][]string)},
+		Response: RecordedResp{Body: body, Headers: make(map[string][]string)},
+	}
+
+	fn := FakeFieldsWith("seed", map[string]Faker{
+		"$.user.email": EmailFaker{},
+	})
+
+	result := fn(tape)
+	var data map[string]any
+	if err := json.Unmarshal(result.Request.Body, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// user is a string, not an object - path traversal fails silently.
+	if data["user"] != "just-a-string" {
+		t.Errorf("user = %v, want 'just-a-string'", data["user"])
+	}
+}

--- a/health_test.go
+++ b/health_test.go
@@ -960,3 +960,371 @@ func (c *fakeClock) advance(d time.Duration) {
 	defer c.mu.Unlock()
 	c.now = c.now.Add(d)
 }
+
+// --- Coverage gap tests (issue #219) ---
+
+func TestHealthMonitor_ReportError_NilError(t *testing.T) {
+	var called bool
+	h := NewHealthMonitor("http://x", healthNoopTransport{},
+		WithHealthErrorHandler(func(err error) {
+			called = true
+		}))
+	defer h.Close() //nolint:errcheck
+
+	// Calling reportError with nil should be a no-op.
+	h.reportError(nil)
+	if called {
+		t.Error("reportError(nil) should not invoke the error handler")
+	}
+}
+
+func TestHealthMonitor_ReportError_NoHandler(t *testing.T) {
+	// HealthMonitor without error handler: reportError should not panic.
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	h.reportError(errors.New("test error"))
+	// No panic means success.
+}
+
+func TestHealthMonitor_RunProbeOnce_PanicRecovery(t *testing.T) {
+	// Transport that panics on RoundTrip. The panic-recovery in runProbeOnce
+	// should catch it and report it via the error handler.
+	var capturedErr atomic.Value
+	rt := &recordingTransport{
+		respFn: func(*http.Request) (*http.Response, error) {
+			panic("probe-panic")
+		},
+	}
+
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond),
+		WithHealthErrorHandler(func(err error) {
+			capturedErr.Store(err)
+		}))
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if v := capturedErr.Load(); v != nil {
+			errStr := v.(error).Error()
+			if !strings.Contains(errStr, "panic in probe loop") {
+				t.Errorf("error = %q, want 'panic in probe loop'", errStr)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("panic was not caught by runProbeOnce")
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+func TestHealthMonitor_RunProbeOnce_TransportNilResponse(t *testing.T) {
+	// Transport that returns (nil, nil) — an unusual but valid edge case.
+	// runProbeOnce should handle this gracefully (the nil response guard at L440).
+	rt := &recordingTransport{
+		respFn: func(*http.Request) (*http.Response, error) {
+			return nil, nil
+		},
+	}
+
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond))
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+
+	// Let a few probe cycles run without crashing.
+	time.Sleep(60 * time.Millisecond)
+	if rt.callCount() == 0 {
+		t.Fatal("probe never fired")
+	}
+}
+
+func TestHealthMonitor_RunProbeOnce_ResponseWithBodyOnError(t *testing.T) {
+	// Transport returns (resp with body, error) — the rare partial-read scenario.
+	// runProbeOnce should close the body to avoid leaking connections.
+	var bodyClosed atomic.Int32
+	rt := &recordingTransport{
+		respFn: func(*http.Request) (*http.Response, error) {
+			body := &trackingCloser{closed: &bodyClosed}
+			resp := &http.Response{
+				StatusCode: 200,
+				Body:       body,
+				Header:     http.Header{},
+			}
+			return resp, errors.New("partial read error")
+		},
+	}
+
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond))
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+
+	deadline := time.After(2 * time.Second)
+	for bodyClosed.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("body was never closed on transport error with response")
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+// trackingCloser is an io.ReadCloser that tracks Close calls.
+type trackingCloser struct {
+	closed *atomic.Int32
+}
+
+func (tc *trackingCloser) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (tc *trackingCloser) Close() error {
+	tc.closed.Add(1)
+	return nil
+}
+
+func TestHealthMonitor_RunProbeOnce_5xxNoTransition(t *testing.T) {
+	// Transport returns 500 without X-Httptape-Source header.
+	// classifyProbeResponse returns (_, false), so state stays unchanged.
+	rt := &recordingTransport{
+		respFn: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 500, Body: http.NoBody, Header: http.Header{}}, nil
+		},
+	}
+
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond))
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+
+	time.Sleep(60 * time.Millisecond)
+
+	// State should remain live (no transition from 5xx without header).
+	if got := h.snapshot().State; got != StateLive {
+		t.Errorf("State=%q, want %q (5xx should not cause transition)", got, StateLive)
+	}
+}
+
+func TestHealthMonitor_RunProbeOnce_501PromotesToGET(t *testing.T) {
+	// Test that 501 (Not Implemented) also triggers HEAD-to-GET promotion,
+	// in addition to 405 (tested elsewhere).
+	var seenGet atomic.Int32
+	rt := &recordingTransport{
+		respFn: func(req *http.Request) (*http.Response, error) {
+			if req.Method == http.MethodHead {
+				return &http.Response{StatusCode: 501, Body: http.NoBody, Header: http.Header{}}, nil
+			}
+			seenGet.Add(1)
+			return &http.Response{StatusCode: 200, Body: http.NoBody, Header: http.Header{}}, nil
+		},
+	}
+
+	h := NewHealthMonitor("http://x", rt,
+		WithHealthInterval(15*time.Millisecond))
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+
+	deadline := time.After(2 * time.Second)
+	for seenGet.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("never promoted to GET on 501")
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+func TestHealthMonitor_ServeStream_MonitorCloseMidStream(t *testing.T) {
+	// Test that closing the monitor while a client is connected to the SSE
+	// stream causes the handler to return cleanly (the h.done branch in
+	// serveStream's select).
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+healthStreamPath, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	br := bufio.NewReader(resp.Body)
+	if _, err := readSSEEvent(br, 2*time.Second); err != nil {
+		t.Fatalf("read initial event: %v", err)
+	}
+
+	// Close the monitor while the stream is active. This should trigger the
+	// <-h.done branch in serveStream's select loop.
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Read should terminate (EOF or connection closed).
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, resp.Body)
+		done <- err
+	}()
+	select {
+	case <-done:
+		// clean termination
+	case <-time.After(2 * time.Second):
+		t.Error("stream did not close after monitor shutdown")
+	}
+}
+
+func TestHealthMonitor_ServeStream_SubscriberDroppedByOverflow(t *testing.T) {
+	// When a subscriber's buffer overflows, broadcastLocked drops it by
+	// closing the channel. The serveStream handler should see ok=false on
+	// the next receive and return cleanly.
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+healthStreamPath, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	br := bufio.NewReader(resp.Body)
+	// Read initial event to drain it.
+	if _, err := readSSEEvent(br, 2*time.Second); err != nil {
+		t.Fatalf("read initial: %v", err)
+	}
+
+	// Now flood transitions to overflow the subscriber's buffer (size 8).
+	// The subscriber is NOT being drained, so it will overflow.
+	for i := 0; i < 20; i++ {
+		if i%2 == 0 {
+			h.observe(StateL1Cache)
+		} else {
+			h.observe(StateLive)
+		}
+	}
+
+	// The stream should terminate (channel closed by overflow drop).
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, resp.Body)
+		done <- err
+	}()
+	select {
+	case <-done:
+		// clean termination
+	case <-time.After(2 * time.Second):
+		t.Error("stream did not close after subscriber overflow")
+	}
+}
+
+func TestHealthMonitor_StartWithZeroInterval(t *testing.T) {
+	// When interval is 0, start() enters startOnce.Do but returns early
+	// because interval <= 0. No goroutine should be spawned.
+	baseline := runtime.NumGoroutine()
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	h.start()
+	h.start() // idempotent
+
+	// Goroutine count should not increase.
+	time.Sleep(50 * time.Millisecond)
+	waitForGoroutineCount(t, baseline+2, time.Second) // +2 for test overhead
+}
+
+func TestHealthMonitor_RunProbeOnce_InvalidUpstreamURL(t *testing.T) {
+	// Use an upstream URL that causes http.NewRequestWithContext to fail.
+	// This exercises the request-build error path (L422-425).
+	var capturedErr atomic.Value
+	h := NewHealthMonitor("http://x", healthNoopTransport{},
+		WithHealthInterval(15*time.Millisecond),
+		WithHealthErrorHandler(func(err error) {
+			capturedErr.Store(err)
+		}))
+	defer h.Close() //nolint:errcheck
+
+	// Override the upstreamURL to something that makes NewRequest fail.
+	// The method needs to be invalid. Promote probeMethod to something invalid.
+	h.promoteProbeMethod("BAD\nMETHOD")
+
+	h.start()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if v := capturedErr.Load(); v != nil {
+			errStr := v.(error).Error()
+			if !strings.Contains(errStr, "probe build request") {
+				t.Errorf("error = %q, want 'probe build request'", errStr)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("NewRequest error was not reported")
+		default:
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+}
+
+func TestHealthMonitor_ServeStream_NonFlusher(t *testing.T) {
+	// Test that serveStream returns 500 when the ResponseWriter does not
+	// implement http.Flusher.
+	h := NewHealthMonitor("http://x", healthNoopTransport{})
+	defer h.Close() //nolint:errcheck
+
+	w := &nonFlusherResponseWriter{
+		header: http.Header{},
+	}
+	r := httptest.NewRequest("GET", healthStreamPath, nil)
+
+	h.ServeHTTP(w, r)
+
+	if w.statusCode != http.StatusInternalServerError {
+		t.Errorf("status=%d, want 500", w.statusCode)
+	}
+}
+
+// nonFlusherResponseWriter implements http.ResponseWriter but NOT http.Flusher.
+type nonFlusherResponseWriter struct {
+	header     http.Header
+	statusCode int
+	body       []byte
+}
+
+func (w *nonFlusherResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *nonFlusherResponseWriter) Write(b []byte) (int, error) {
+	w.body = append(w.body, b...)
+	return len(b), nil
+}
+
+func (w *nonFlusherResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}

--- a/store_file_test.go
+++ b/store_file_test.go
@@ -1851,3 +1851,583 @@ func TestFileStore_DefaultDirectory(t *testing.T) {
 		t.Error("default fixtures directory was not created")
 	}
 }
+
+// --- Coverage gap tests (issue #219) ---
+
+func TestSlugifyURL_ParseFallback_WithSchemeAndPath(t *testing.T) {
+	// url.Parse fails on URLs with invalid hosts like "http://[bad".
+	// The fallback code extracts the path manually.
+	got := slugifyURL("http://[bad/api/users")
+	if got != "api-users" {
+		t.Errorf("slugifyURL fallback with scheme = %q, want %q", got, "api-users")
+	}
+}
+
+func TestSlugifyURL_ParseFallback_NoSlash(t *testing.T) {
+	// When the fallback path has no '/', it collapses to empty -> "root".
+	got := slugifyURL("http://[bad")
+	if got != "root" {
+		t.Errorf("slugifyURL fallback no slash = %q, want %q", got, "root")
+	}
+}
+
+func TestSlugifyURL_ParseFallback_WithQuery(t *testing.T) {
+	// The fallback path extraction should strip query strings.
+	got := slugifyURL("http://[bad/api/items?page=2")
+	if got != "api-items" {
+		t.Errorf("slugifyURL fallback with query = %q, want %q", got, "api-items")
+	}
+}
+
+func TestQueryHash_ParseError(t *testing.T) {
+	// queryHash returns "" when url.Parse fails.
+	got := queryHash("http://[bad?key=value")
+	if got != "" {
+		t.Errorf("queryHash with unparseable URL = %q, want empty", got)
+	}
+}
+
+func TestReadableFilenames_EmptySlugFallsBackToID(t *testing.T) {
+	// When the URL path produces an empty slug after slugification and the
+	// resulting filename is empty, ReadableFilenames falls back to tape.ID.
+	strategy := ReadableFilenames()
+	tape := Tape{
+		ID: "fallback-id",
+		Request: RecordedReq{
+			// Empty method and a URL whose path is only special chars.
+			Method: "",
+			URL:    "http://example.com/###",
+		},
+	}
+	got := strategy(tape)
+	// "unknown" + "_" + some slug from "###". But if path is only special chars,
+	// slugifyURL returns "root", so we get "unknown_root".
+	if got == "" {
+		t.Error("ReadableFilenames() produced empty string, should not happen")
+	}
+}
+
+func TestFileStore_Save_TmpWriteError(t *testing.T) {
+	// Simulate a write failure by making the store's directory read-only
+	// after the temp file is created. On macOS/Linux, chmod on dir prevents
+	// creating new files but CreateTemp itself may fail instead.
+	//
+	// The simplest portable test: make the directory read-only so CreateTemp
+	// fails (L272). This is already covered by TestFileStore_Save_ReadOnlyDir.
+	//
+	// Instead, test the rename error path (L288): save to a directory, then
+	// remove it between CreateTemp and Rename by using a custom strategy
+	// that triggers collision resolution failure.
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// Fill the directory with files that have read-only permissions to
+	// provoke filenameAvailableForID read errors (L340).
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(func(tape Tape) string {
+		return "fixed"
+	}))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	// Write a file that is unreadable, matching the collision candidate name.
+	unreadable := filepath.Join(dir, "fixed.json")
+	if err := os.WriteFile(unreadable, []byte(`{"id":"other"}`), 0o000); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(unreadable, 0o644) })
+
+	tape := makeTape("route", "GET", "http://example.com")
+	err = store.Save(ctx, tape)
+	// The file is unreadable, so filenameAvailableForID returns an error,
+	// which propagates through resolveFilename.
+	if err == nil {
+		t.Fatal("Save() with unreadable collision file: error = nil, want error")
+	}
+}
+
+func TestFileStore_FilenameCollision_ReadErrorInLoop(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(func(tape Tape) string {
+		return "collide"
+	}))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	// Save one tape normally to occupy collide.json.
+	tape1 := makeTape("route", "GET", "http://example.com")
+	tape1.ID = "tape-1"
+	if err := store.Save(ctx, tape1); err != nil {
+		t.Fatalf("Save(tape1) error = %v", err)
+	}
+
+	// Make collide_2.json unreadable to trigger the error path inside
+	// the collision resolution loop (L314-316).
+	unreadable := filepath.Join(dir, "collide_2.json")
+	if err := os.WriteFile(unreadable, []byte(`{"id":"other"}`), 0o000); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(unreadable, 0o644) })
+
+	tape2 := makeTape("route", "POST", "http://example.com")
+	tape2.ID = "tape-2"
+	err = store.Save(ctx, tape2)
+	if err == nil {
+		t.Fatal("Save() with unreadable collision suffix file: error = nil, want error")
+	}
+}
+
+func TestFileStore_RemoveOldFile_SkipsCorruptAndUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// Save a tape with UUID strategy under <id>.json.
+	storeUUID, err := NewFileStore(WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	tape := makeTape("route", "GET", "http://example.com/users")
+	if err := storeUUID.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Place a corrupt JSON file and an unreadable JSON file in the directory
+	// to exercise the skip paths in removeOldFile (L364-365, L368-369).
+	// Use "000-" prefix to sort before any UUID so they are visited first.
+	corruptPath := filepath.Join(dir, "000-corrupt.json")
+	if err := os.WriteFile(corruptPath, []byte("{broken"), 0o644); err != nil {
+		t.Fatalf("WriteFile(corrupt) error = %v", err)
+	}
+	unreadablePath := filepath.Join(dir, "000-unreadable.json")
+	if err := os.WriteFile(unreadablePath, []byte(`{"id":"x"}`), 0o000); err != nil {
+		t.Fatalf("WriteFile(unreadable) error = %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(unreadablePath, 0o644) })
+
+	// Re-save the same tape with readable strategy. This triggers removeOldFile
+	// to scan and find the old UUID file, but it must skip the corrupt and
+	// unreadable files along the way.
+	storeReadable, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore(readable) error = %v", err)
+	}
+
+	if err := storeReadable.Save(ctx, tape); err != nil {
+		t.Fatalf("Save(readable) error = %v", err)
+	}
+
+	// The old UUID file should have been removed.
+	uuidPath := filepath.Join(dir, tape.ID+".json")
+	if _, err := os.Stat(uuidPath); !os.IsNotExist(err) {
+		t.Error("old UUID file still exists after re-save with readable strategy")
+	}
+}
+
+func TestFileStore_Load_FastPathDifferentID(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// Save a tape with readable strategy.
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	tape := makeTape("route", "GET", "http://example.com/users")
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Write a file named exactly <id>.json but with a different tape ID inside.
+	// This exercises the fast-path "file exists but has different ID" fallthrough
+	// to scan (L403-408).
+	differentTape := makeTape("other-route", "POST", "http://example.com/other")
+	data, err := json.MarshalIndent(differentTape, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent() error = %v", err)
+	}
+	imposterPath := filepath.Join(dir, tape.ID+".json")
+	if err := os.WriteFile(imposterPath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Load by original tape.ID should fall through to scan and find it.
+	loaded, err := store.Load(ctx, tape.ID)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.ID != tape.ID {
+		t.Errorf("Load().ID = %q, want %q", loaded.ID, tape.ID)
+	}
+}
+
+func TestFileStore_Delete_FastPathCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// Save a tape with readable strategy so the actual file has a readable name.
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	tape := makeTape("route", "GET", "http://example.com/users")
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Place a corrupt JSON file at the fast-path location <id>.json.
+	// This exercises the "file exists but corrupt" fallthrough in Delete (L489-491).
+	fastPath := filepath.Join(dir, tape.ID+".json")
+	if err := os.WriteFile(fastPath, []byte("{corrupt}"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Delete should fall through to scan and still succeed.
+	if err := store.Delete(ctx, tape.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	// Verify the real tape file is gone by listing (List skips corrupt JSON).
+	tapes, listErr := store.List(ctx, Filter{})
+	if listErr != nil {
+		t.Fatalf("List() error = %v", listErr)
+	}
+	for _, tp := range tapes {
+		if tp.ID == tape.ID {
+			t.Error("tape still found in List after Delete")
+		}
+	}
+}
+
+func TestFileStore_Delete_FastPathDifferentID(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	tape := makeTape("route", "GET", "http://example.com/users")
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Place a valid JSON file at the fast-path but with a different ID.
+	differentTape := makeTape("other", "POST", "http://example.com/other")
+	data, _ := json.MarshalIndent(differentTape, "", "  ")
+	fastPath := filepath.Join(dir, tape.ID+".json")
+	if err := os.WriteFile(fastPath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Delete should fall through to scan and find the real file.
+	if err := store.Delete(ctx, tape.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+}
+
+func TestFileStore_Delete_FastPathRemoveError(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// Use UUID strategy so <id>.json is the fast-path file.
+	store, err := NewFileStore(WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	tape := makeTape("route", "GET", "http://example.com")
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Make directory read+execute only (0o555): files can be read but not deleted.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+
+	err = store.Delete(ctx, tape.ID)
+	if err == nil {
+		t.Fatal("Delete() with non-writable dir: error = nil, want error")
+	}
+}
+
+func TestFileStore_Delete_ScanRemoveError(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	tape := makeTape("route", "GET", "http://example.com/users")
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Make the directory read-only to prevent file removal in the scan path.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+
+	err = store.Delete(ctx, tape.ID)
+	if err == nil {
+		t.Fatal("Delete() in read-only dir via scan: error = nil, want error")
+	}
+}
+
+func TestFileStore_List_MidLoopContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	// Save multiple tapes so there are files to iterate.
+	for i := 0; i < 5; i++ {
+		tape := makeTape("route", "GET", "http://example.com")
+		tape.ID = fmt.Sprintf("tape-%d", i)
+		if err := store.Save(ctx, tape); err != nil {
+			t.Fatalf("Save(tape-%d) error = %v", i, err)
+		}
+	}
+
+	// Use a context that is already cancelled. The per-file cancellation check
+	// (L443) fires during iteration.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = store.List(cancelledCtx, Filter{})
+	if err == nil {
+		t.Fatal("List() with cancelled context: error = nil, want error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("List() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestFileStore_ScanForID_ContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// Use readable strategy so Load uses scan path.
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	// Save multiple tapes so the scan iterates.
+	for i := 0; i < 3; i++ {
+		tape := makeTape("route", "GET", "http://example.com/items")
+		tape.ID = fmt.Sprintf("tape-%d", i)
+		if err := store.Save(ctx, tape); err != nil {
+			t.Fatalf("Save(tape-%d) error = %v", i, err)
+		}
+	}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Load triggers scanForID. With cancelled context, the per-file check fires.
+	_, err = store.Load(cancelledCtx, "tape-2")
+	if err == nil {
+		t.Fatal("Load() with cancelled context during scan: error = nil, want error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Load() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestFileStore_ScanForID_SkipsCorruptAfterIDExtraction(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	// Save a valid tape first.
+	tape := makeTape("route", "GET", "http://example.com/users")
+	tape.ID = "target-id"
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// AFTER saving, write a file where extractIDFromJSON succeeds but
+	// json.Unmarshal into a full Tape fails. Place it so it sorts before the
+	// valid file (get_users.json). This exercises the unmarshal-skip path in
+	// scanForID: extractIDFromJSON returns "target-id" (matches), but full
+	// Tape unmarshal fails due to invalid recorded_at format.
+	malformedPath := filepath.Join(dir, "aaa-malformed.json")
+	malformedJSON := `{"id":"target-id","route":"r","recorded_at":"not-valid-time-format"}`
+	if err := os.WriteFile(malformedPath, []byte(malformedJSON), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Load should skip the malformed file and find the valid one.
+	loaded, err := store.Load(ctx, "target-id")
+	if err != nil {
+		t.Fatalf("Load() error = %v, expected success after skipping corrupt file", err)
+	}
+	if loaded.ID != "target-id" {
+		t.Errorf("Load().ID = %q, want %q", loaded.ID, "target-id")
+	}
+}
+
+func TestFileStore_Delete_ScanSkipsCorruptAndUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	tape := makeTape("route", "GET", "http://example.com/users")
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Add corrupt and unreadable JSON files that the Delete scan must skip.
+	corruptPath := filepath.Join(dir, "aaa-corrupt.json")
+	if err := os.WriteFile(corruptPath, []byte("{bad json"), 0o644); err != nil {
+		t.Fatalf("WriteFile(corrupt) error = %v", err)
+	}
+	unreadablePath := filepath.Join(dir, "aaa-unreadable.json")
+	if err := os.WriteFile(unreadablePath, []byte(`{"id":"x"}`), 0o000); err != nil {
+		t.Fatalf("WriteFile(unreadable) error = %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(unreadablePath, 0o644) })
+
+	// Add a non-JSON file and a subdirectory to exercise entry-skip conditions.
+	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("WriteFile(txt) error = %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	// Delete should scan past all non-matching entries and succeed.
+	if err := store.Delete(ctx, tape.ID); err != nil {
+		t.Fatalf("Delete() error = %v, want nil (corrupt files should be skipped)", err)
+	}
+
+	_, err = store.Load(context.Background(), tape.ID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Load() after Delete error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFileStore_List_SkipsUnreadableFiles(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	// Save a valid tape.
+	tape := makeTape("route", "GET", "http://example.com")
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Place an unreadable JSON file in the directory.
+	unreadable := filepath.Join(dir, "unreadable.json")
+	if err := os.WriteFile(unreadable, []byte(`{"id":"x"}`), 0o000); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(unreadable, 0o644) })
+
+	// List should skip the unreadable file and return the valid tape.
+	tapes, err := store.List(ctx, Filter{})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(tapes) != 1 {
+		t.Errorf("List() returned %d tapes, want 1", len(tapes))
+	}
+}
+
+func TestFileStore_Save_CollisionWithCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(func(tape Tape) string {
+		return "fixed"
+	}))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	// Place a corrupt (but readable) JSON file at the candidate path.
+	// filenameAvailableForID reads it, extractIDFromJSON fails, returns (false, nil).
+	// This makes the slot "occupied" so the strategy tries suffixed names.
+	corruptPath := filepath.Join(dir, "fixed.json")
+	if err := os.WriteFile(corruptPath, []byte("{broken json"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	tape := makeTape("route", "GET", "http://example.com")
+	if err := store.Save(ctx, tape); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// The tape should have been written as fixed_2.json since fixed.json was occupied.
+	path := filepath.Join(dir, "fixed_2.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected fixed_2.json to exist: %v", err)
+	}
+}
+
+func TestFileStore_Delete_ScanContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store, err := NewFileStore(WithDirectory(dir), WithFilenameStrategy(ReadableFilenames()))
+	if err != nil {
+		t.Fatalf("NewFileStore() error = %v", err)
+	}
+
+	// Save multiple tapes so there are entries to iterate.
+	for i := 0; i < 3; i++ {
+		tape := makeTape("route", "GET", "http://example.com/items")
+		tape.ID = fmt.Sprintf("tape-%d", i)
+		if err := store.Save(ctx, tape); err != nil {
+			t.Fatalf("Save() error = %v", err)
+		}
+	}
+
+	// Place a valid JSON file at fast-path with a different ID so Delete falls
+	// through to scan, then cancel context.
+	differentTape := makeTape("other", "POST", "http://example.com")
+	data, _ := json.MarshalIndent(differentTape, "", "  ")
+	fastPath := filepath.Join(dir, "tape-2.json")
+	if err := os.WriteFile(fastPath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = store.Delete(cancelledCtx, "tape-2")
+	if err == nil {
+		t.Fatal("Delete() with cancelled context during scan: error = nil, want error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Delete() error = %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
Closes #219

## Summary

Final PR (3 of 3) for the test coverage audit. Covers the remaining three files cited in the audit: `store_file.go`, `health.go`, and `faker.go`.

**Package coverage: 94.2% -> 95.4%**

### store_file.go (19 new tests)
- URL parse fallback in `slugifyURL` (scheme+path, no-slash, query stripping)
- `queryHash` parse error returns ""
- `filenameAvailableForID` corrupt-but-readable collision file
- `resolveFilename` collision loop read error (unreadable suffix file)
- `removeOldFile` skip paths: corrupt JSON, unreadable files (with correct sort ordering)
- `Load` fast-path different-ID fallthrough to scan
- `Delete` fast-path: corrupt file, different-ID, remove-permission-error
- `Delete` scan: skip corrupt/unreadable/non-JSON, remove error
- `List` unreadable file skip, mid-loop context cancel
- `scanForID` context cancel, unmarshal failure after ID extraction
- **Functions -> 100%**: `slugifyURL`, `queryHash`, `filenameAvailableForID`, `resolveFilename`
- **Skipped**: `Save` atomic write error paths (CreateTemp/Write/Close/Rename) — OS fault injection not portable; `removeOldFile`/`scanForID`/`List`/`Delete` ReadDir errors — require directory to vanish mid-operation; `ReadableFilenames` empty-name guard — unreachable since `slugifyURL` always returns at least "root"; `json.MarshalIndent(Tape)` error — unreachable for valid struct types

### health.go (11 new tests)
- `reportError` nil-error and no-handler paths
- `runProbeOnce` panic recovery
- `runProbeOnce` transport returning `(nil, nil)`
- `runProbeOnce` response-with-body on transport error (body leak prevention)
- `runProbeOnce` 5xx-no-transition (classifyProbeResponse returns false)
- `runProbeOnce` 501 HEAD-to-GET promotion
- `runProbeOnce` invalid method causing `NewRequest` failure
- `serveStream` non-flusher ResponseWriter returns 500
- `serveStream` subscriber dropped by buffer overflow
- `serveStream` monitor close mid-stream
- `start()` with zero interval (no goroutine spawned)
- **Functions -> 100%**: `runProbeOnce`, `reportError`, `start`
- **Skipped**: `subscribe` initial seed defensive default — fresh buffer cannot block; `runProbe` interval<=0 guard — redundant, never reached; `runProbe` done re-check — timing-dependent race guard; `serveSnapshot`/`serveStream` JSON encode error — unreachable for HealthSnapshot types; `serveStream` writeSSEEvent error — requires ResponseWriter.Write to fail

### faker.go (9 new tests)
- `PhoneFaker` HMAC re-chain on 40-digit input
- `PatternFaker` HMAC re-chain for `#` (digits) and `?` (letters) with 40 placeholders
- `fakeAtPathWith` non-object top-level data (array)
- `fakeAtPathWith` missing key in object
- `fakeAtPathWith` wildcard on non-array value
- `fakeAtPathWith` wildcard at leaf (container skip)
- `fakeAtPathWith` intermediate non-object path traversal
- `FakeFieldsWith` invalid path silently ignored
- **Functions -> 100%**: `PhoneFaker.Fake`, `PatternFaker.Fake`
- **Skipped**: `fakeBodyFieldsWith` json.Marshal error — unreachable (data from json.Unmarshal); `fakeAtPathWith` empty segments guard — unreachable (parsePath always produces 1+ segments)

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all pass (95.4% coverage)
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean
- [x] No production code changes

After this merges, #219 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)