### PR TITLE
refactor(#215): panic discipline — option panics become constructor errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to httptape are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- **`NewServer` signature change**: `NewServer(store Store, opts ...ServerOption)`
+  now returns `(*Server, error)` instead of `*Server`. The constructor validates
+  option values (e.g., error rate) after all options are applied and returns an
+  error if any are invalid. Nil-store panics are retained (programming error
+  convention). (#215, ADR-46)
+
+- **`NewProxy` signature change**: `NewProxy(l1, l2 Store, opts ...ProxyOption)`
+  now returns `(*Proxy, error)` instead of `*Proxy`. The constructor validates
+  cross-option constraints (e.g., `WithProxyHealthEndpoint` requires
+  `WithProxyUpstreamURL`) and returns an error instead of panicking. Nil-store
+  panics are retained. (#215, ADR-46)
+
+- **`SSETimingAccelerated` signature change**: `SSETimingAccelerated(factor float64)`
+  now returns `(SSETimingMode, error)` instead of `SSETimingMode`. Returns an
+  error when factor is <= 0 instead of panicking. (#215, ADR-46)
+
+### Migration
+
+All three changes are caught by the Go compiler -- no silent breakage. Update
+call sites as follows:
+
+```go
+// Before
+srv := httptape.NewServer(store, opts...)
+
+// After
+srv, err := httptape.NewServer(store, opts...)
+if err != nil {
+    // handle error
+}
+```
+
+The same pattern applies to `NewProxy` and `SSETimingAccelerated`. Behavior on
+success is unchanged.
+
 ## [0.13.1] - 2026-04-18
 
 ### Changed

--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -150,7 +150,13 @@ func parseSSETiming(s string) (httptape.SSETimingMode, error) {
 		if factor <= 0 {
 			return nil, fmt.Errorf("invalid --sse-timing %q: factor must be greater than 0. Valid modes: realtime, instant, accelerated=<factor>", s)
 		}
-		return httptape.SSETimingAccelerated(factor), nil
+		// The CLI pre-validates factor > 0 above, so SSETimingAccelerated
+		// cannot return an error here. Handle it defensively anyway.
+		mode, modeErr := httptape.SSETimingAccelerated(factor)
+		if modeErr != nil {
+			return nil, fmt.Errorf("invalid --sse-timing %q: %w", s, modeErr)
+		}
+		return mode, nil
 	default:
 		return nil, fmt.Errorf("invalid --sse-timing %q: valid modes are realtime, instant, accelerated=<factor>", s)
 	}
@@ -220,7 +226,10 @@ func runServe(args []string) error {
 		serverOpts = append(serverOpts, httptape.WithReplayHeaders(rh[:eqIdx], rh[eqIdx+1:]))
 	}
 
-	server := httptape.NewServer(store, serverOpts...)
+	server, err := httptape.NewServer(store, serverOpts...)
+	if err != nil {
+		return fmt.Errorf("create server: %w", err)
+	}
 
 	addr := fmt.Sprintf(":%d", *port)
 	httpServer := &http.Server{
@@ -481,7 +490,10 @@ func runProxy(args []string) error {
 		return &usageError{fmt.Errorf("--upstream-probe-interval requires --health-endpoint")}
 	}
 
-	tapeProxy := httptape.NewProxy(l1, l2, proxyOpts...)
+	tapeProxy, err := httptape.NewProxy(l1, l2, proxyOpts...)
+	if err != nil {
+		return fmt.Errorf("create proxy: %w", err)
+	}
 
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
@@ -765,10 +777,10 @@ func migrateLegacyFixture(data []byte) ([]byte, error) {
 }
 
 // removeLegacyBodyEncodingAndDecodeBody modifies the raw JSON to:
-// 1. Remove body_encoding fields
-// 2. For base64-encoded bodies with non-JSON Content-Types, decode the body
-//    and replace it with the appropriate representation so the new
-//    UnmarshalJSON interprets it correctly.
+//  1. Remove body_encoding fields
+//  2. For base64-encoded bodies with non-JSON Content-Types, decode the body
+//     and replace it with the appropriate representation so the new
+//     UnmarshalJSON interprets it correctly.
 func removeLegacyBodyEncodingAndDecodeBody(data []byte, reqEncoding, respEncoding string) []byte {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {

--- a/doc.go
+++ b/doc.go
@@ -28,7 +28,10 @@
 // [Server] implements [http.Handler] and replays recorded tapes. It uses a
 // [Matcher] to find the best-matching tape for each incoming request.
 //
-//	srv := httptape.NewServer(store)
+//	srv, err := httptape.NewServer(store)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
 //	ts := httptest.NewServer(srv)
 //	defer ts.Close()
 //

--- a/http2_test.go
+++ b/http2_test.go
@@ -102,7 +102,11 @@ func TestHTTP2Replay(t *testing.T) {
 		t.Fatalf("save tape: %v", err)
 	}
 
-	srv := httptest.NewUnstartedServer(NewServer(store))
+	handler, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewUnstartedServer(handler)
 	srv.EnableHTTP2 = true
 	srv.StartTLS()
 	defer srv.Close()

--- a/integration_test.go
+++ b/integration_test.go
@@ -188,7 +188,10 @@ func TestIntegration_RecordReplay_MemoryStore(t *testing.T) {
 	rec.Close()
 
 	// Create a replay Server from the same store.
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	replayTS := httptest.NewServer(srv)
 	defer replayTS.Close()
 
@@ -227,7 +230,10 @@ func TestIntegration_RecordReplay_FileStore(t *testing.T) {
 	}
 
 	// Create a replay Server from the new store.
-	srv := NewServer(store2)
+	srv, err := NewServer(store2)
+	if err != nil {
+		t.Fatal(err)
+	}
 	replayTS := httptest.NewServer(srv)
 	defer replayTS.Close()
 
@@ -250,7 +256,10 @@ func TestIntegration_RecordReplay_AsyncRecorder(t *testing.T) {
 	// Close flushes the async buffer.
 	rec.Close()
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	replayTS := httptest.NewServer(srv)
 	defer replayTS.Close()
 
@@ -290,7 +299,10 @@ func TestIntegration_RecordReplay_WithSanitization(t *testing.T) {
 	rec.Close()
 
 	// Replay from the store -- the replayed response should be sanitized.
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	replayTS := httptest.NewServer(srv)
 	defer replayTS.Close()
 
@@ -387,7 +399,10 @@ func TestIntegration_RecordReplay_WithFakeFields(t *testing.T) {
 
 	// Replay via a real HTTP client — the Content-Length fix in ServeHTTP
 	// ensures the faked body (different length) is served correctly.
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	replayTS := httptest.NewServer(srv)
 	defer replayTS.Close()
 
@@ -479,11 +494,17 @@ func TestIntegration_BothStores_IdenticalReplay(t *testing.T) {
 	}
 
 	// --- Replay from both stores ---
-	memSrv := NewServer(memStore)
+	memSrv, err := NewServer(memStore)
+	if err != nil {
+		t.Fatal(err)
+	}
 	memReplayTS := httptest.NewServer(memSrv)
 	defer memReplayTS.Close()
 
-	fileSrv := NewServer(fileStore)
+	fileSrv, err := NewServer(fileStore)
+	if err != nil {
+		t.Fatal(err)
+	}
 	fileReplayTS := httptest.NewServer(fileSrv)
 	defer fileReplayTS.Close()
 
@@ -573,7 +594,10 @@ func TestIntegration_RecordReplay_FileStore_Sanitized(t *testing.T) {
 		t.Fatalf("NewFileStore (reload): %v", err)
 	}
 
-	srv := NewServer(store2)
+	srv, err := NewServer(store2)
+	if err != nil {
+		t.Fatal(err)
+	}
 	replayTS := httptest.NewServer(srv)
 	defer replayTS.Close()
 
@@ -628,7 +652,10 @@ func TestIntegration_RecordReplay_PostWithBody(t *testing.T) {
 	}
 
 	// Replay.
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	replayTS := httptest.NewServer(srv)
 	defer replayTS.Close()
 
@@ -693,7 +720,10 @@ func TestIntegration_SSE_RecordReplay_E2E(t *testing.T) {
 	}
 
 	// Replay.
-	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	srv, err := NewServer(store, WithSSETiming(SSETimingInstant()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	replayTS := httptest.NewServer(srv)
 	defer replayTS.Close()
 
@@ -747,7 +777,10 @@ func TestIntegration_SSE_Proxy_E2E(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+	proxy, err := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Passthrough: forward to upstream.
 	req, _ := http.NewRequest("GET", upstream.URL+"/sse", nil)
@@ -778,12 +811,15 @@ func TestIntegration_SSE_Proxy_E2E(t *testing.T) {
 	}
 
 	// L2 fallback: upstream is now "down".
-	proxy2 := NewProxy(l1, l2,
+	proxy2, err := NewProxy(l1, l2,
 		WithProxyTransport(roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
 			return nil, errors.New("down")
 		})),
 		WithProxySSETiming(SSETimingInstant()),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req2, _ := http.NewRequest("GET", upstream.URL+"/sse", nil)
 	resp2, err := proxy2.RoundTrip(req2)
@@ -861,7 +897,10 @@ func TestIntegration_ConfigDrivenMatcher_BodyFuzzy(t *testing.T) {
 	}
 
 	// Start server with the config-driven matcher.
-	srv := NewServer(store, WithMatcher(matcher))
+	srv, err := NewServer(store, WithMatcher(matcher))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -959,7 +998,10 @@ func TestIntegration_ContentNegotiation_MultiCT(t *testing.T) {
 		t.Fatalf("BuildMatcher: %v", err)
 	}
 
-	srv := NewServer(store, WithMatcher(matcher))
+	srv, err := NewServer(store, WithMatcher(matcher))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1779,7 +1779,10 @@ func TestServer_UsesDefaultMatcher(t *testing.T) {
 		t.Fatalf("saving tape: %v", err)
 	}
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/users", nil)
 	srv.ServeHTTP(w, req)

--- a/mock.go
+++ b/mock.go
@@ -155,7 +155,13 @@ func Mock(stubs ...Stub) *MockServer {
 		}
 	}
 
-	handler := NewServer(store)
+	// Mock always constructs a Server with no options, so NewServer cannot
+	// return an error. Panic on failure follows the existing Mock convention
+	// (Mock already panics on Save failure above).
+	handler, err := NewServer(store)
+	if err != nil {
+		panic("httptape: Mock failed to create server: " + err.Error())
+	}
 	ts := httptest.NewServer(handler)
 	return &MockServer{Server: ts}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -455,7 +456,11 @@ func WithProxyUpstreamURL(url string) ProxyOption {
 //
 // Both l1 and l2 must be non-nil. Panics on nil stores (constructor guard
 // convention per CLAUDE.md).
-func NewProxy(l1, l2 Store, opts ...ProxyOption) *Proxy {
+//
+// Returns an error if any cross-option constraints are violated (e.g.,
+// WithProxyHealthEndpoint without WithProxyUpstreamURL). All validation
+// errors are accumulated and returned together.
+func NewProxy(l1, l2 Store, opts ...ProxyOption) (*Proxy, error) {
 	if l1 == nil {
 		panic("httptape: NewProxy requires a non-nil L1 Store")
 	}
@@ -479,14 +484,16 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) *Proxy {
 		opt(p)
 	}
 
-	if p.healthEnabled {
-		// Default the upstream URL to "" when the embedder didn't provide one.
-		// HealthMonitor's constructor guard panics on empty upstream -- give a
-		// clearer message here pointing at the right option.
-		if p.upstreamURLHint == "" {
-			panic("httptape: WithProxyHealthEndpoint requires WithProxyUpstreamURL")
-		}
+	// Validate after all options are applied.
+	var errs []error
+	if p.healthEnabled && p.upstreamURLHint == "" {
+		errs = append(errs, fmt.Errorf("httptape: WithProxyHealthEndpoint requires WithProxyUpstreamURL"))
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
 
+	if p.healthEnabled {
 		// Resolve the error handler precedence: explicit health handler beats
 		// the proxy-wide onError, which beats nothing.
 		var errFn func(error)
@@ -557,7 +564,7 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) *Proxy {
 		WithCacheFilter(cacheFilter),
 	)
 
-	return p
+	return p, nil
 }
 
 // HealthHandler returns the http.Handler that serves /__httptape/health and

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -48,9 +48,12 @@ func TestProxy_SuccessPath(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "hello")),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -107,9 +110,12 @@ func TestProxy_FallbackToL1(t *testing.T) {
 	l1.Save(context.Background(), tape) //nolint:errcheck
 
 	transportErr := errors.New("connection refused")
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(transportErr)),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -148,9 +154,12 @@ func TestProxy_FallbackToL2(t *testing.T) {
 	l2.Save(context.Background(), tape) //nolint:errcheck
 
 	transportErr := errors.New("connection refused")
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(transportErr)),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -176,9 +185,12 @@ func TestProxy_NoCacheError(t *testing.T) {
 	l2 := NewMemoryStore() // empty
 
 	transportErr := errors.New("connection refused")
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(transportErr)),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -200,7 +212,7 @@ func TestProxy_SanitizationOnL2Only(t *testing.T) {
 	// Create a sanitizer that redacts a specific header.
 	sanitizer := NewPipeline(RedactHeaders("Authorization"))
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
@@ -210,6 +222,9 @@ func TestProxy_SanitizationOnL2Only(t *testing.T) {
 		})),
 		WithProxySanitizer(sanitizer),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
 	req.Header.Set("Authorization", "Bearer secret-token")
@@ -266,7 +281,7 @@ func TestProxy_FallbackOn5xx(t *testing.T) {
 		}, nil
 	})
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(transport),
 		WithProxyFallbackOn(func(err error, resp *http.Response) bool {
 			if err != nil {
@@ -275,6 +290,9 @@ func TestProxy_FallbackOn5xx(t *testing.T) {
 			return resp != nil && resp.StatusCode >= 500
 		}),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -330,9 +348,12 @@ func TestProxy_XHttptapeSourceHeader(t *testing.T) {
 				l2.Save(context.Background(), tape) //nolint:errcheck
 			}
 
-			proxy := NewProxy(l1, l2,
+			proxy, err := NewProxy(l1, l2,
 				WithProxyTransport(failingTransport(errors.New("down"))),
 			)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			req, _ := http.NewRequest("GET", "http://example.com/x", nil)
 			resp, err := proxy.RoundTrip(req)
@@ -353,7 +374,10 @@ func TestProxy_Close_NoOp(t *testing.T) {
 	// This test verifies it implements RoundTripper only, not io.Closer.
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
-	proxy := NewProxy(l1, l2, WithProxyTransport(successTransport(200, "ok")))
+	proxy, err := NewProxy(l1, l2, WithProxyTransport(successTransport(200, "ok")))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Verify it implements http.RoundTripper.
 	var _ http.RoundTripper = proxy
@@ -388,7 +412,10 @@ func TestProxy_ConcurrentSafety(t *testing.T) {
 		}, nil
 	})
 
-	proxy := NewProxy(l1, l2, WithProxyTransport(transport))
+	proxy, err := NewProxy(l1, l2, WithProxyTransport(transport))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
@@ -425,10 +452,13 @@ func TestProxy_RequestBodyPreservedForMatching(t *testing.T) {
 	})
 	l1.Save(context.Background(), tape) //nolint:errcheck
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 		WithProxyMatcher(NewCompositeMatcher(MethodCriterion{}, PathCriterion{}, BodyHashCriterion{})),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("POST", "http://example.com/api/items", bytes.NewReader(postBody))
 	resp, err := proxy.RoundTrip(req)
@@ -472,7 +502,7 @@ func TestProxy_OnErrorCallback(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 		WithProxyOnError(func(err error) {
 			mu.Lock()
@@ -480,6 +510,9 @@ func TestProxy_OnErrorCallback(t *testing.T) {
 			mu.Unlock()
 		}),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -509,7 +542,7 @@ func TestProxy_FallbackOn5xx_NoCacheMatch(t *testing.T) {
 		}, nil
 	})
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(transport),
 		WithProxyFallbackOn(func(err error, resp *http.Response) bool {
 			if err != nil {
@@ -518,6 +551,9 @@ func TestProxy_FallbackOn5xx_NoCacheMatch(t *testing.T) {
 			return resp != nil && resp.StatusCode >= 500
 		}),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -547,10 +583,13 @@ func TestProxy_WithProxyRoute(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 		WithProxyRoute("users-api"),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -586,9 +625,12 @@ func TestProxy_HealthDisabledByDefault(t *testing.T) {
 
 	baseline := runtime.NumGoroutine()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if h := proxy.HealthHandler(); h != nil {
 		t.Fatalf("HealthHandler() = %v, want nil with default options", h)
@@ -634,12 +676,15 @@ func TestProxy_HealthHeaderUnchanged(t *testing.T) {
 	})
 	l1.Save(context.Background(), tape) //nolint:errcheck
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 		WithProxyUpstreamURL("http://example.com"),
 		WithProxyHealthEndpoint(),
 		WithProxyProbeInterval(0), // no probe loop in this test
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer proxy.Close() //nolint:errcheck
 
 	req, _ := http.NewRequest("GET", "http://example.com/x", nil)
@@ -658,12 +703,15 @@ func TestProxy_HealthEndpointMounted(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 		WithProxyUpstreamURL("http://upstream.example"),
 		WithProxyHealthEndpoint(),
 		WithProxyProbeInterval(0),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer proxy.Close() //nolint:errcheck
 
 	if proxy.HealthHandler() == nil {
@@ -695,12 +743,15 @@ func TestProxy_StartCloseIdempotent(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 		WithProxyUpstreamURL("http://up"),
 		WithProxyHealthEndpoint(),
 		WithProxyProbeInterval(20*time.Millisecond),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	baseline := runtime.NumGoroutine()
 	proxy.Start()
@@ -733,7 +784,7 @@ func TestProxy_HealthOptionsApplied(t *testing.T) {
 	l2 := NewMemoryStore()
 
 	var captured atomic.Int32
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("boom"))),
 		WithProxyUpstreamURL("http://up"),
 		WithProxyHealthEndpoint(),
@@ -741,6 +792,9 @@ func TestProxy_HealthOptionsApplied(t *testing.T) {
 		WithProxyProbePath("/healthz"),
 		WithProxyHealthErrorHandler(func(error) { captured.Add(1) }),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer proxy.Close() //nolint:errcheck
 
 	if proxy.health == nil || proxy.health.probePath != "/healthz" {
@@ -767,13 +821,16 @@ func TestProxy_HealthErrorHandlerFallsBackToOnError(t *testing.T) {
 	l2 := NewMemoryStore()
 
 	var captured atomic.Int32
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("boom"))),
 		WithProxyUpstreamURL("http://up"),
 		WithProxyOnError(func(error) { captured.Add(1) }),
 		WithProxyHealthEndpoint(),
 		WithProxyProbeInterval(15*time.Millisecond),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer proxy.Close() //nolint:errcheck
 
 	proxy.Start()
@@ -788,17 +845,19 @@ func TestProxy_HealthErrorHandlerFallsBackToOnError(t *testing.T) {
 	}
 }
 
-// TestProxy_HealthPanicsWithoutUpstreamURL confirms the constructor guard
-// fires when WithProxyHealthEndpoint is set without WithProxyUpstreamURL.
-func TestProxy_HealthPanicsWithoutUpstreamURL(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic when health endpoint enabled without upstream URL")
-		}
-	}()
-	NewProxy(NewMemoryStore(), NewMemoryStore(),
+// TestNewProxy_HealthEndpointRequiresUpstreamURL confirms the constructor
+// returns an error when WithProxyHealthEndpoint is set without
+// WithProxyUpstreamURL.
+func TestNewProxy_HealthEndpointRequiresUpstreamURL(t *testing.T) {
+	_, err := NewProxy(NewMemoryStore(), NewMemoryStore(),
 		WithProxyHealthEndpoint(),
 	)
+	if err == nil {
+		t.Fatal("expected error when health endpoint enabled without upstream URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "WithProxyUpstreamURL") {
+		t.Errorf("error = %q, want it to mention WithProxyUpstreamURL", err.Error())
+	}
 }
 
 // TestProxy_HealthIntegration exercises the full path: a transport whose
@@ -834,12 +893,15 @@ func TestProxy_HealthIntegration(t *testing.T) {
 		}, nil
 	})
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(transport),
 		WithProxyUpstreamURL("http://upstream.example"),
 		WithProxyHealthEndpoint(),
 		WithProxyProbeInterval(20*time.Millisecond),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer proxy.Close() //nolint:errcheck
 
 	srv := httptest.NewServer(proxy.HealthHandler())
@@ -913,7 +975,10 @@ func TestProxy_SingleFlightViaComposition(t *testing.T) {
 		}, nil
 	})
 
-	proxy := NewProxy(l1, l2, WithProxyTransport(transport))
+	proxy, err := NewProxy(l1, l2, WithProxyTransport(transport))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	const concurrency = 10
 	var wg sync.WaitGroup
@@ -957,7 +1022,7 @@ func TestProxy_CompositionSanitizationPath(t *testing.T) {
 
 	sanitizer := NewPipeline(RedactHeaders("X-Secret"))
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
@@ -967,6 +1032,9 @@ func TestProxy_CompositionSanitizationPath(t *testing.T) {
 		})),
 		WithProxySanitizer(sanitizer),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
 	req.Header.Set("X-Secret", "top-secret-value")
@@ -1195,10 +1263,13 @@ func TestWithProxySanitizer_NilDefaultsToNoopPipeline(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 		WithProxySanitizer(nil),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer secret")
@@ -1237,10 +1308,13 @@ func TestWithProxyTLSConfig_NonHTTPTransport(t *testing.T) {
 
 	// When transport is a custom RoundTripper (not *http.Transport),
 	// WithProxyTLSConfig should replace it with a new *http.Transport.
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(customRT),
 		WithProxyTLSConfig(&tls.Config{InsecureSkipVerify: true}), //nolint:gosec
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// The transport should now be an *http.Transport with the TLS config.
 	if _, ok := proxy.transport.(*http.Transport); !ok {
@@ -1256,12 +1330,15 @@ func TestWithProxyProbeInterval_NegativeClamped(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 		WithProxyUpstreamURL("http://up"),
 		WithProxyHealthEndpoint(),
 		WithProxyProbeInterval(-5*time.Second),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer proxy.Close() //nolint:errcheck
 
 	// The negative probe interval should be clamped to 0 (which means
@@ -1277,9 +1354,12 @@ func TestProxy_RequestBodyReadError(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("POST", "http://example.com/api", &errReadCloser{
 		remaining: 3,
@@ -1323,7 +1403,7 @@ func TestProxy_FallbackDrainReadError(t *testing.T) {
 		}, nil
 	})
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(transport),
 		WithProxyFallbackOn(func(err error, resp *http.Response) bool {
 			if err != nil {
@@ -1332,6 +1412,9 @@ func TestProxy_FallbackDrainReadError(t *testing.T) {
 			return resp != nil && resp.StatusCode >= 500
 		}),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -1359,10 +1442,13 @@ func TestProxy_MatchFromStoreListError(t *testing.T) {
 	l2 := NewMemoryStore()
 
 	var capturedErr error
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 		WithProxyOnError(func(err error) { capturedErr = err }),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -1406,9 +1492,12 @@ func TestProxy_TapeToResponse_NilHeaders(t *testing.T) {
 	})
 	l1.Save(context.Background(), tape) //nolint:errcheck
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -1448,9 +1537,12 @@ func TestProxy_TapeToResponse_NilBody(t *testing.T) {
 	})
 	l1.Save(context.Background(), tape) //nolint:errcheck
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -1489,10 +1581,13 @@ func TestProxy_SSEResponseFromTape_WriteErrorClosesPipe(t *testing.T) {
 	})
 	l1.Save(context.Background(), tape) //nolint:errcheck
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 		WithProxySSETiming(SSETimingInstant()),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -1534,10 +1629,13 @@ func TestProxy_Fallback_BodyRestoredForL2Match(t *testing.T) {
 	})
 	l2.Save(context.Background(), tape) //nolint:errcheck
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 		WithProxyMatcher(NewCompositeMatcher(MethodCriterion{}, PathCriterion{})),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("POST", "http://example.com/api", bytes.NewReader(postBody))
 	resp, err := proxy.RoundTrip(req)
@@ -1708,10 +1806,13 @@ func TestProxy_SSEResponseFromTape_WithTiming(t *testing.T) {
 	})
 	l1.Save(context.Background(), tape) //nolint:errcheck
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 		WithProxySSETiming(SSETimingRealtime()),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
 	start := time.Now()

--- a/race_test.go
+++ b/race_test.go
@@ -240,7 +240,10 @@ func TestServer_ConcurrentServeHTTP(t *testing.T) {
 		}
 	}
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -342,7 +345,10 @@ func TestServer_ConcurrentSSEReplay(t *testing.T) {
 		}
 	}
 
-	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	srv, err := NewServer(store, WithSSETiming(SSETimingInstant()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 

--- a/server.go
+++ b/server.go
@@ -1,6 +1,8 @@
 package httptape
 
 import (
+	"errors"
+	"fmt"
 	"math/rand"
 	"net/http"
 	"time"
@@ -85,13 +87,10 @@ func WithDelay(d time.Duration) ServerOption {
 // A rate of 0.0 disables error simulation (default). A rate of 1.0
 // causes all requests to fail.
 //
-// Panics if rate is outside [0.0, 1.0]. This is a programming error,
-// following the constructor-guard convention.
+// The rate is validated when NewServer is called. An out-of-range rate
+// causes NewServer to return an error.
 func WithErrorRate(rate float64) ServerOption {
 	return func(s *Server) {
-		if rate < 0 || rate > 1 {
-			panic("httptape: WithErrorRate rate must be between 0.0 and 1.0")
-		}
 		s.errorRate = rate
 	}
 }
@@ -180,7 +179,10 @@ func withRandFloat(fn func() float64) ServerOption {
 //
 // The store must not be nil. Passing a nil store is a programming error and
 // will panic.
-func NewServer(store Store, opts ...ServerOption) *Server {
+//
+// Returns an error if any option values are invalid (e.g., error rate outside
+// [0.0, 1.0]). All validation errors are accumulated and returned together.
+func NewServer(store Store, opts ...ServerOption) (*Server, error) {
 	if store == nil {
 		panic("httptape: NewServer requires a non-nil Store")
 	}
@@ -197,12 +199,21 @@ func NewServer(store Store, opts ...ServerOption) *Server {
 		opt(s)
 	}
 
+	// Validate after all options are applied.
+	var errs []error
+	if s.errorRate < 0 || s.errorRate > 1 {
+		errs = append(errs, fmt.Errorf("httptape: WithErrorRate rate must be between 0.0 and 1.0, got %g", s.errorRate))
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
 	// Default random number generator for error simulation.
 	if s.randFloat == nil {
 		s.randFloat = rand.Float64
 	}
 
-	return s
+	return s, nil
 }
 
 // ServeHTTP handles an incoming HTTP request by finding a matching tape

--- a/server_test.go
+++ b/server_test.go
@@ -35,10 +35,14 @@ func storeTape(t *testing.T, store *MemoryStore, method, path string, status int
 // errListStore is a Store implementation whose List always returns an error.
 type errListStore struct{}
 
-func (f *errListStore) Save(_ context.Context, _ Tape) error            { return errors.New("fail") }
-func (f *errListStore) Load(_ context.Context, _ string) (Tape, error)  { return Tape{}, errors.New("fail") }
-func (f *errListStore) List(_ context.Context, _ Filter) ([]Tape, error) { return nil, errors.New("fail") }
-func (f *errListStore) Delete(_ context.Context, _ string) error        { return errors.New("fail") }
+func (f *errListStore) Save(_ context.Context, _ Tape) error { return errors.New("fail") }
+func (f *errListStore) Load(_ context.Context, _ string) (Tape, error) {
+	return Tape{}, errors.New("fail")
+}
+func (f *errListStore) List(_ context.Context, _ Filter) ([]Tape, error) {
+	return nil, errors.New("fail")
+}
+func (f *errListStore) Delete(_ context.Context, _ string) error { return errors.New("fail") }
 
 func TestServer_BasicReplay(t *testing.T) {
 	store := NewMemoryStore()
@@ -46,7 +50,10 @@ func TestServer_BasicReplay(t *testing.T) {
 		"Content-Type": {"application/json"},
 	})
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/users", nil)
 
@@ -70,7 +77,10 @@ func TestServer_ResponseHeaders(t *testing.T) {
 		"X-Custom":   {"val"},
 	})
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/cookies", nil)
 
@@ -90,7 +100,10 @@ func TestServer_ResponseHeaders(t *testing.T) {
 
 func TestServer_NoMatch_DefaultFallback(t *testing.T) {
 	store := NewMemoryStore()
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/nonexistent", nil)
@@ -107,10 +120,13 @@ func TestServer_NoMatch_DefaultFallback(t *testing.T) {
 
 func TestServer_NoMatch_CustomFallback(t *testing.T) {
 	store := NewMemoryStore()
-	srv := NewServer(store,
+	srv, err := NewServer(store,
 		WithFallbackStatus(http.StatusServiceUnavailable),
 		WithFallbackBody([]byte("custom fallback")),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/missing", nil)
@@ -131,12 +147,15 @@ func TestServer_NoMatch_Callback(t *testing.T) {
 	var capturedPath string
 	var mu sync.Mutex
 
-	srv := NewServer(store, WithOnNoMatch(func(r *http.Request) {
+	srv, err := NewServer(store, WithOnNoMatch(func(r *http.Request) {
 		called.Add(1)
 		mu.Lock()
 		capturedPath = r.URL.Path
 		mu.Unlock()
 	}))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/unmatched", nil)
@@ -171,7 +190,10 @@ func TestNewServer_NilStore_Panics(t *testing.T) {
 }
 
 func TestServer_StoreError(t *testing.T) {
-	srv := NewServer(&errListStore{})
+	srv, err := NewServer(&errListStore{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/anything", nil)
@@ -203,7 +225,10 @@ func TestServer_CustomMatcher(t *testing.T) {
 		return Tape{}, false
 	})
 
-	srv := NewServer(store, WithMatcher(customMatcher))
+	srv, err := NewServer(store, WithMatcher(customMatcher))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Request with matching header.
 	rec := httptest.NewRecorder()
@@ -233,7 +258,10 @@ func TestServer_ExactMatcher_MethodMismatch(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/api/data", 200, "data", nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/data", nil)
 
@@ -248,7 +276,10 @@ func TestServer_ExactMatcher_PathMismatch(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/foo", 200, "foo", nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/bar", nil)
 
@@ -261,7 +292,10 @@ func TestServer_ExactMatcher_PathMismatch(t *testing.T) {
 
 func TestServer_EmptyStore(t *testing.T) {
 	store := NewMemoryStore()
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/anything", nil)
@@ -287,7 +321,10 @@ func TestServer_NilResponseBody(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/empty", nil)
 
@@ -306,7 +343,10 @@ func TestServer_ConcurrentRequests(t *testing.T) {
 	storeTape(t, store, "GET", "/a", 200, "response-a", nil)
 	storeTape(t, store, "GET", "/b", 200, "response-b", nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	const goroutines = 20
 	var wg sync.WaitGroup
@@ -368,7 +408,10 @@ func TestServer_WithHTTPTestServer(t *testing.T) {
 		"Content-Type": {"application/json"},
 	})
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -435,7 +478,10 @@ func BenchmarkServerServeHTTP_ExactMatch(b *testing.B) {
 				b.Fatalf("Save: %v", err)
 			}
 
-			srv := NewServer(store)
+			srv, err := NewServer(store)
+			if err != nil {
+				b.Fatal(err)
+			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -527,7 +573,10 @@ func TestServer_Replay204NoContent(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "DELETE", "/resource/1", 204, "", nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/resource/1", nil)
 
@@ -558,7 +607,10 @@ func TestServer_ReplayBinaryBody(t *testing.T) {
 		t.Fatalf("save tape: %v", err)
 	}
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/image.png", nil)
 
@@ -594,7 +646,10 @@ func TestServer_ReplayTruncatedBody(t *testing.T) {
 		t.Fatalf("save tape: %v", err)
 	}
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/large", nil)
 
@@ -614,7 +669,10 @@ func TestServer_CORS_HeadersPresent(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
 
-	srv := NewServer(store, WithCORS())
+	srv, err := NewServer(store, WithCORS())
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/data", nil)
 
@@ -644,7 +702,10 @@ func TestServer_CORS_Disabled_NoHeaders(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
 
-	srv := NewServer(store) // no WithCORS
+	srv, err := NewServer(store) // no WithCORS
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/data", nil)
 
@@ -657,7 +718,10 @@ func TestServer_CORS_Disabled_NoHeaders(t *testing.T) {
 
 func TestServer_CORS_OptionsPreflight(t *testing.T) {
 	store := NewMemoryStore()
-	srv := NewServer(store, WithCORS())
+	srv, err := NewServer(store, WithCORS())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("OPTIONS", "/api/data", nil)
@@ -677,7 +741,10 @@ func TestServer_CORS_OptionsPreflight(t *testing.T) {
 
 func TestServer_CORS_OptionsWithoutCORS(t *testing.T) {
 	store := NewMemoryStore()
-	srv := NewServer(store) // no WithCORS
+	srv, err := NewServer(store) // no WithCORS
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("OPTIONS", "/api/data", nil)
@@ -695,7 +762,10 @@ func TestServer_CORS_WithVariousMethods(t *testing.T) {
 	storeTape(t, store, "POST", "/api/data", 201, "created", nil)
 	storeTape(t, store, "DELETE", "/api/data", 204, "", nil)
 
-	srv := NewServer(store, WithCORS())
+	srv, err := NewServer(store, WithCORS())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	methods := []struct {
 		method string
@@ -724,7 +794,10 @@ func TestServer_Delay_GlobalDelay(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
 
-	srv := NewServer(store, WithDelay(50*time.Millisecond))
+	srv, err := NewServer(store, WithDelay(50*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/data", nil)
@@ -745,7 +818,10 @@ func TestServer_Delay_ZeroDelay(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
 
-	srv := NewServer(store, WithDelay(0))
+	srv, err := NewServer(store, WithDelay(0))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/data", nil)
@@ -777,7 +853,10 @@ func TestServer_Delay_PerFixtureOverride(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	srv := NewServer(store, WithDelay(1*time.Millisecond)) // global is 1ms
+	srv, err := NewServer(store, WithDelay(1*time.Millisecond)) // global is 1ms
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/slow", nil)
@@ -799,7 +878,10 @@ func TestServer_Delay_ContextCancellation(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
 
-	srv := NewServer(store, WithDelay(5*time.Second)) // very long delay
+	srv, err := NewServer(store, WithDelay(5*time.Second)) // very long delay
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -826,7 +908,10 @@ func TestServer_Delay_ContextCancellation(t *testing.T) {
 func TestServer_Delay_NoDelayOnNoMatch(t *testing.T) {
 	store := NewMemoryStore() // empty store, no tapes
 
-	srv := NewServer(store, WithDelay(5*time.Second))
+	srv, err := NewServer(store, WithDelay(5*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/nonexistent", nil)
@@ -851,7 +936,10 @@ func TestServer_ErrorRate_Zero_NoErrors(t *testing.T) {
 	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
 
 	// randFloat always returns 0.5, but errorRate is 0 so it should never trigger.
-	srv := NewServer(store, withRandFloat(func() float64 { return 0.5 }))
+	srv, err := NewServer(store, withRandFloat(func() float64 { return 0.5 }))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/data", nil)
@@ -867,10 +955,13 @@ func TestServer_ErrorRate_One_AllErrors(t *testing.T) {
 	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
 
 	// randFloat returns 0.5, errorRate is 1.0 so all requests fail.
-	srv := NewServer(store,
+	srv, err := NewServer(store,
 		WithErrorRate(1.0),
 		withRandFloat(func() float64 { return 0.5 }),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/data", nil)
@@ -893,7 +984,7 @@ func TestServer_ErrorRate_Deterministic(t *testing.T) {
 
 	// Error rate 0.5: randFloat < 0.5 -> error, randFloat >= 0.5 -> success.
 	callCount := 0
-	srv := NewServer(store,
+	srv, err := NewServer(store,
 		WithErrorRate(0.5),
 		withRandFloat(func() float64 {
 			callCount++
@@ -903,6 +994,9 @@ func TestServer_ErrorRate_Deterministic(t *testing.T) {
 			return 0.9 // above rate -> success
 		}),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// First request: error.
 	rec1 := httptest.NewRecorder()
@@ -925,11 +1019,14 @@ func TestServer_ErrorRate_WithCORS(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/api/data", 200, "ok", nil)
 
-	srv := NewServer(store,
+	srv, err := NewServer(store,
 		WithCORS(),
 		WithErrorRate(1.0),
 		withRandFloat(func() float64 { return 0.0 }),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/data", nil)
@@ -944,7 +1041,7 @@ func TestServer_ErrorRate_WithCORS(t *testing.T) {
 	}
 }
 
-func TestServer_ErrorRate_InvalidPanics(t *testing.T) {
+func TestNewServer_InvalidErrorRate(t *testing.T) {
 	tests := []struct {
 		name string
 		rate float64
@@ -954,20 +1051,13 @@ func TestServer_ErrorRate_InvalidPanics(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if r == nil {
-					t.Fatal("expected panic, got none")
-				}
-				msg, ok := r.(string)
-				if !ok {
-					t.Fatalf("expected string panic, got %T", r)
-				}
-				if !strings.Contains(msg, "between 0.0 and 1.0") {
-					t.Errorf("panic message = %q, want it to contain 'between 0.0 and 1.0'", msg)
-				}
-			}()
-			WithErrorRate(tt.rate)(&Server{})
+			_, err := NewServer(NewMemoryStore(), WithErrorRate(tt.rate))
+			if err == nil {
+				t.Fatal("expected error for invalid error rate, got nil")
+			}
+			if !strings.Contains(err.Error(), "between 0.0 and 1.0") {
+				t.Errorf("error = %q, want it to contain 'between 0.0 and 1.0'", err.Error())
+			}
 		})
 	}
 }
@@ -991,7 +1081,10 @@ func TestServer_PerFixtureError(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/broken", nil)
 	srv.ServeHTTP(rec, req)
@@ -1024,7 +1117,10 @@ func TestServer_PerFixtureError_DefaultStatus(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/err", nil)
 	srv.ServeHTTP(rec, req)
@@ -1053,7 +1149,10 @@ func TestServer_PerFixtureError_WithCORS(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	srv := NewServer(store, WithCORS())
+	srv, err := NewServer(store, WithCORS())
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/broken", nil)
 	srv.ServeHTTP(rec, req)
@@ -1094,9 +1193,12 @@ func TestServer_ReplayHeaders_Override(t *testing.T) {
 		"Content-Type":  {"application/json"},
 	})
 
-	srv := NewServer(store,
+	srv, err := NewServer(store,
 		WithReplayHeaders("Authorization", "Bearer injected-token"),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/data", nil)
 
@@ -1118,11 +1220,14 @@ func TestServer_ReplayHeaders_Multiple(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/multi", 200, "ok", http.Header{})
 
-	srv := NewServer(store,
+	srv, err := NewServer(store,
 		WithReplayHeaders("X-Request-Id", "req-123"),
 		WithReplayHeaders("X-Trace-Id", "trace-456"),
 		WithReplayHeaders("Cache-Control", "no-store"),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/multi", nil)
 
@@ -1131,7 +1236,7 @@ func TestServer_ReplayHeaders_Multiple(t *testing.T) {
 	tests := map[string]string{
 		"X-Request-Id":  "req-123",
 		"X-Trace-Id":    "trace-456",
-		"Cache-Control":  "no-store",
+		"Cache-Control": "no-store",
 	}
 	for key, want := range tests {
 		if got := rec.Header().Get(key); got != want {
@@ -1146,7 +1251,10 @@ func TestServer_ReplayHeaders_NotSetByDefault(t *testing.T) {
 		"X-Original": {"value"},
 	})
 
-	srv := NewServer(store) // no WithReplayHeaders
+	srv, err := NewServer(store) // no WithReplayHeaders
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/default", nil)
 
@@ -1164,7 +1272,10 @@ func TestServer_Templating_BodySubstitution(t *testing.T) {
 	storeTape(t, store, "POST", "/echo", 200,
 		`{"method":"{{request.method}}","path":"{{request.path}}"}`, nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/echo", nil)
 
@@ -1185,7 +1296,10 @@ func TestServer_Templating_HeaderSubstitution(t *testing.T) {
 		"X-Idempotency-Key": {"{{request.headers.Idempotency-Key}}"},
 	})
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/payments", nil)
 	req.Header.Set("Idempotency-Key", "idem-xyz-456")
@@ -1204,7 +1318,10 @@ func TestServer_Templating_Disabled(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/raw", 200, `{{request.method}}`, nil)
 
-	srv := NewServer(store, WithTemplating(false))
+	srv, err := NewServer(store, WithTemplating(false))
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/raw", nil)
 
@@ -1223,7 +1340,10 @@ func TestServer_Templating_StrictMode_Error(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/strict", 200, `{{request.headers.Missing}}`, nil)
 
-	srv := NewServer(store, WithStrictTemplating(true))
+	srv, err := NewServer(store, WithStrictTemplating(true))
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/strict", nil)
 
@@ -1246,7 +1366,10 @@ func TestServer_Templating_StrictMode_HeaderError(t *testing.T) {
 		"X-Echo": {"{{request.headers.Missing}}"},
 	})
 
-	srv := NewServer(store, WithStrictTemplating(true))
+	srv, err := NewServer(store, WithStrictTemplating(true))
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/strict-hdr", nil)
 
@@ -1265,7 +1388,10 @@ func TestServer_Templating_LenientMode_MissingRef(t *testing.T) {
 	storeTape(t, store, "GET", "/lenient", 200,
 		`key={{request.headers.Missing}}`, nil)
 
-	srv := NewServer(store) // default: lenient
+	srv, err := NewServer(store) // default: lenient
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/lenient", nil)
 
@@ -1283,7 +1409,10 @@ func TestServer_Templating_NoTemplates_FastPath(t *testing.T) {
 	store := NewMemoryStore()
 	storeTape(t, store, "GET", "/plain", 200, `{"static":"response"}`, nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/plain", nil)
 
@@ -1302,7 +1431,10 @@ func TestServer_Templating_QueryParam(t *testing.T) {
 	storeTape(t, store, "GET", "/search", 200,
 		`{"q":"{{request.query.q}}","page":"{{request.query.page}}"}`, nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/search?q=hello&page=3", nil)
 
@@ -1322,7 +1454,10 @@ func TestServer_Templating_BodyField(t *testing.T) {
 	storeTape(t, store, "POST", "/echo-body", 200,
 		`{"echo_email":"{{request.body.user.email}}"}`, nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/echo-body",
 		strings.NewReader(`{"user":{"email":"test@example.com"}}`))
@@ -1343,7 +1478,10 @@ func TestServer_Templating_LeavesStoredFixtureUnchanged(t *testing.T) {
 	tape := storeTape(t, store, "GET", "/immutable", 200,
 		`{{request.method}}`, nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/immutable", nil)
 
@@ -1369,7 +1507,10 @@ func TestServer_Templating_WithCORS(t *testing.T) {
 	storeTape(t, store, "GET", "/cors-template", 200,
 		`{{request.method}}`, nil)
 
-	srv := NewServer(store, WithCORS())
+	srv, err := NewServer(store, WithCORS())
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/cors-template", nil)
 
@@ -1391,7 +1532,10 @@ func TestServer_Templating_EnabledByDefault(t *testing.T) {
 	storeTape(t, store, "GET", "/default-on", 200, `{{request.method}}`, nil)
 
 	// NewServer without any templating options — should be enabled by default.
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/default-on", nil)
 
@@ -1410,7 +1554,10 @@ func TestServer_Templating_NonRequestNamespace_Literal(t *testing.T) {
 	storeTape(t, store, "GET", "/state", 200,
 		`count={{state.counter}}`, nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/state", nil)
 
@@ -1430,7 +1577,10 @@ func TestServer_Templating_URL(t *testing.T) {
 	storeTape(t, store, "GET", "/url-echo", 200,
 		`url={{request.url}}`, nil)
 
-	srv := NewServer(store)
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/url-echo?key=val", nil)
 

--- a/sse.go
+++ b/sse.go
@@ -94,13 +94,13 @@ func SSETimingRealtime() SSETimingMode {
 }
 
 // SSETimingAccelerated returns an SSETimingMode that divides all
-// inter-event gaps by the given factor. Factor must be > 0; panics
-// otherwise (constructor guard).
-func SSETimingAccelerated(factor float64) SSETimingMode {
+// inter-event gaps by the given factor. Factor must be > 0; returns an
+// error otherwise.
+func SSETimingAccelerated(factor float64) (SSETimingMode, error) {
 	if factor <= 0 {
-		panic("httptape: SSETimingAccelerated factor must be > 0")
+		return nil, fmt.Errorf("httptape: SSETimingAccelerated factor must be > 0, got %g", factor)
 	}
-	return sseTimingAccelerated{factor: factor}
+	return sseTimingAccelerated{factor: factor}, nil
 }
 
 // SSETimingInstant returns an SSETimingMode that emits all events

--- a/sse_test.go
+++ b/sse_test.go
@@ -436,7 +436,10 @@ func TestSSETimingAccelerated(t *testing.T) {
 		{OffsetMS: 200},
 		{OffsetMS: 600},
 	}
-	mode := SSETimingAccelerated(2.0)
+	mode, err := SSETimingAccelerated(2.0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if d := mode.delay(events, 0); d != 0 {
 		t.Errorf("delay(0) = %v, want 0", d)
@@ -449,22 +452,24 @@ func TestSSETimingAccelerated(t *testing.T) {
 	}
 }
 
-func TestSSETimingAccelerated_PanicOnZero(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for factor 0")
-		}
-	}()
-	SSETimingAccelerated(0)
+func TestSSETimingAccelerated_ErrorOnZero(t *testing.T) {
+	_, err := SSETimingAccelerated(0)
+	if err == nil {
+		t.Error("expected error for factor 0, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be > 0") {
+		t.Errorf("error = %q, want it to contain 'must be > 0'", err.Error())
+	}
 }
 
-func TestSSETimingAccelerated_PanicOnNegative(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for negative factor")
-		}
-	}()
-	SSETimingAccelerated(-1.0)
+func TestSSETimingAccelerated_ErrorOnNegative(t *testing.T) {
+	_, err := SSETimingAccelerated(-1.0)
+	if err == nil {
+		t.Error("expected error for negative factor, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be > 0") {
+		t.Errorf("error = %q, want it to contain 'must be > 0'", err.Error())
+	}
 }
 
 func TestSSETimingInstant(t *testing.T) {
@@ -737,8 +742,12 @@ func TestReplaySSEEvents_Accelerated(t *testing.T) {
 	rec := httptest.NewRecorder()
 	flusher := http.ResponseWriter(rec).(http.Flusher)
 
+	accelMode, modeErr := SSETimingAccelerated(2.0)
+	if modeErr != nil {
+		t.Fatal(modeErr)
+	}
 	start := time.Now()
-	err := replaySSEEvents(context.Background(), rec, flusher, events, SSETimingAccelerated(2.0))
+	err := replaySSEEvents(context.Background(), rec, flusher, events, accelMode)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("error: %v", err)
@@ -955,7 +964,10 @@ func TestServer_SSEReplay_Instant(t *testing.T) {
 	})
 	store.Save(context.Background(), tape)
 
-	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	srv, err := NewServer(store, WithSSETiming(SSETimingInstant()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -1010,10 +1022,13 @@ func TestServer_SSEReplay_WithHeaders(t *testing.T) {
 	})
 	store.Save(context.Background(), tape)
 
-	srv := NewServer(store,
+	srv, err := NewServer(store,
 		WithSSETiming(SSETimingInstant()),
 		WithReplayHeaders("X-Override", "injected"),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -1056,7 +1071,10 @@ func TestServer_NonSSETapeUnchanged(t *testing.T) {
 	})
 	store.Save(context.Background(), tape)
 
-	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	srv, err := NewServer(store, WithSSETiming(SSETimingInstant()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -1099,7 +1117,10 @@ func TestProxy_SSE_SuccessPath(t *testing.T) {
 
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
-	proxy := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+	proxy, err := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", upstream.URL+"/stream", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -1161,10 +1182,13 @@ func TestProxy_SSE_L2Fallback(t *testing.T) {
 	})
 	l2.Save(context.Background(), tape)
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(failingTransport(errors.New("down"))),
 		WithProxySSETiming(SSETimingInstant()),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
 	resp, err := proxy.RoundTrip(req)
@@ -1347,7 +1371,10 @@ func TestIntegration_SSE_RecordReplay(t *testing.T) {
 	}
 
 	// Replay.
-	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	srv, err := NewServer(store, WithSSETiming(SSETimingInstant()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -1430,7 +1457,10 @@ func TestIntegration_SSE_RecordReplay_WithSanitization(t *testing.T) {
 	}
 
 	// Replay and verify redacted values are served.
-	srv := NewServer(store, WithSSETiming(SSETimingInstant()))
+	srv, err := NewServer(store, WithSSETiming(SSETimingInstant()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -1471,7 +1501,10 @@ func TestIntegration_SSE_ProxyPassthrough(t *testing.T) {
 
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
-	proxy := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+	proxy, err := NewProxy(l1, l2, WithProxyTransport(upstream.Client().Transport))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Use the proxy as an HTTP handler via httptest.
 	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1540,12 +1573,15 @@ func TestHealth_StreamUsesWriteSSEEvent(t *testing.T) {
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
 
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(successTransport(200, "ok")),
 		WithProxyUpstreamURL("http://upstream.example"),
 		WithProxyHealthEndpoint(),
 		WithProxyProbeInterval(0),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer proxy.Close()
 
 	srv := httptest.NewServer(proxy.HealthHandler())
@@ -1685,7 +1721,10 @@ func TestSSETimingAccelerated_NegativeGapClamped(t *testing.T) {
 		{OffsetMS: 200},
 		{OffsetMS: 100},
 	}
-	mode := SSETimingAccelerated(2.0)
+	mode, err := SSETimingAccelerated(2.0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	d := mode.delay(events, 1)
 	if d != 0 {
 		t.Errorf("negative gap should be clamped to 0, got %v", d)
@@ -1701,7 +1740,10 @@ func TestSSETimingAccelerated_FractionalFactor(t *testing.T) {
 		{OffsetMS: 0},
 		{OffsetMS: 100},
 	}
-	mode := SSETimingAccelerated(0.5)
+	mode, err := SSETimingAccelerated(0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
 	d := mode.delay(events, 1)
 	expected := 200 * time.Millisecond
 	if math.Abs(float64(d-expected)) > float64(5*time.Millisecond) {
@@ -1759,9 +1801,13 @@ func TestSSETimingMode_SealMethodsAreCallable(t *testing.T) {
 	// The sseTimingMode() methods are seal methods that prevent external
 	// implementations. They are no-op but should be covered for completeness.
 	// We exercise them indirectly through the SSETimingMode interface.
+	accel, err := SSETimingAccelerated(1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	modes := []SSETimingMode{
 		SSETimingRealtime(),
-		SSETimingAccelerated(1.0),
+		accel,
 		SSETimingInstant(),
 	}
 	for _, m := range modes {

--- a/tls_test.go
+++ b/tls_test.go
@@ -36,12 +36,12 @@ func generateTestCA(t *testing.T) testCert {
 	}
 
 	template := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "Test CA"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(24 * time.Hour),
-		IsCA:         true,
-		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
 	}
 
@@ -328,7 +328,10 @@ func TestProxyTLSIntegration(t *testing.T) {
 
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
-	proxy := NewProxy(l1, l2, WithProxyTLSConfig(tlsCfg))
+	proxy, err := NewProxy(l1, l2, WithProxyTLSConfig(tlsCfg))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	client := &http.Client{Transport: proxy}
 	resp, err := client.Get(ts.URL)
@@ -393,7 +396,10 @@ func TestWithProxyTLSConfig_NilConfig(t *testing.T) {
 	l2 := NewMemoryStore()
 
 	// Should not panic or change transport.
-	proxy := NewProxy(l1, l2, WithProxyTLSConfig(nil))
+	proxy, err := NewProxy(l1, l2, WithProxyTLSConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if proxy.transport != http.DefaultTransport {
 		t.Fatal("expected default transport when TLS config is nil")
 	}
@@ -418,10 +424,13 @@ func TestWithProxyTLSConfig_CustomTransport(t *testing.T) {
 
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
-	proxy := NewProxy(l1, l2,
+	proxy, err := NewProxy(l1, l2,
 		WithProxyTransport(existing),
 		WithProxyTLSConfig(tlsCfg),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	transport, ok := proxy.transport.(*http.Transport)
 	if !ok {
@@ -445,7 +454,10 @@ func TestWithProxyTLSConfig_DoesNotMutateDefaultTransport(t *testing.T) {
 	tlsCfg := &tls.Config{InsecureSkipVerify: true}
 	l1 := NewMemoryStore()
 	l2 := NewMemoryStore()
-	proxy := NewProxy(l1, l2, WithProxyTLSConfig(tlsCfg))
+	proxy, err := NewProxy(l1, l2, WithProxyTLSConfig(tlsCfg))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// The proxy must have a new transport, not the default one.
 	if proxy.transport == http.DefaultTransport {


### PR DESCRIPTION
Closes #215

Implements ADR-46 (`decisions.md`): convert three non-nil-guard panics into constructor error returns.

## Signature changes (breaking)

| Before | After |
|---|---|
| `NewServer(Store, ...ServerOption) *Server` | `NewServer(Store, ...ServerOption) (*Server, error)` |
| `NewProxy(Store, Store, ...ProxyOption) *Proxy` | `NewProxy(Store, Store, ...ProxyOption) (*Proxy, error)` |
| `SSETimingAccelerated(float64) SSETimingMode` | `SSETimingAccelerated(float64) (SSETimingMode, error)` |

**Nil-guard panics are retained** per ADR-46 (programming errors, not runtime config failures).

## Validation pattern

Options set fields without validation. Constructors validate after all options are applied, accumulating errors via `errors.Join`. Error messages use plain `fmt.Errorf` with descriptive context (field name + what was wrong + what's expected).

## Call site migration

- **Tests** (~130 call sites): `srv := NewServer(...)` becomes `srv, err := NewServer(...)` + `if err != nil { t.Fatal(err) }`
- **CLI** (`cmd/httptape/main.go`): three call sites gain `if err != nil { return fmt.Errorf(...) }` blocks. The CLI pre-validates inputs, so these error paths are unreachable in practice.
- **Mock** (`mock.go`): panics on error (follows existing Mock convention — Mock already panics on Save failure).
- **doc.go**: example code updated to show error handling.

## CHANGELOG updated

New `[Unreleased]` section with `### Breaking Changes` documenting all three signature changes and a `### Migration` subsection with before/after code.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` all pass
- [x] `gofmt -l` clean on all modified files
- [x] Panic-expectation tests rewritten as error-expectation tests:
  - `TestNewServer_InvalidErrorRate` (was `TestServer_ErrorRate_InvalidPanics`)
  - `TestSSETimingAccelerated_ErrorOnZero` (was `TestSSETimingAccelerated_PanicOnZero`)
  - `TestSSETimingAccelerated_ErrorOnNegative` (was `TestSSETimingAccelerated_PanicOnNegative`)
  - `TestNewProxy_HealthEndpointRequiresUpstreamURL` (was `TestProxy_HealthPanicsWithoutUpstreamURL`)
- [x] Nil-guard panic tests unchanged: `TestNewServer_NilStore_Panics`, `TestProxy_PanicsOnNilL1Store`, `TestProxy_PanicsOnNilL2Store`

��� Generated with [Claude Code](https://claude.com/claude-code)