### PR TITLE
feat(#199): synthetic responses via exemplar tapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`ResolveTemplateBodySimple`**: backward-compatible wrapper for template
   resolution using only request data. (#196)
 
+- **Synthesis mode**: exemplar tapes with URL patterns and template expressions
+  generate responses for unmatched URLs. Opt-in via `WithSynthesis()` (library)
+  or `--synthesize` (CLI). Exemplar tapes use `"exemplar": true` and
+  `"url_pattern"` fields. Two-phase match: exact tapes first, exemplar fallback
+  second. (#199, ADR-43)
+
+- **Type coercion**: `| int`, `| float`, `| bool` coercion pipes in JSON
+  template expressions convert resolved strings to native JSON types. Only
+  effective in JSON response bodies of exemplar tapes. (#199)
+
+- **`ValidateTape` / `ValidateExemplar`**: structural validation for tapes,
+  including exemplar-specific constraints (url_pattern required, SSE not
+  supported, mutual exclusivity with url). (#199)
+
+- **Startup tape validation**: the CLI `serve` command validates all loaded
+  tapes at startup. Invalid exemplar tapes produce a startup error. (#199)
+
 - **Config support for `path_pattern`**: declarative `"type": "path_pattern"`
   criterion with `"pattern"` field. (#196)
 

--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -251,17 +251,14 @@ func runServe(args []string) error {
 		}
 		logger.Printf("synthesis mode ENABLED -- %d exemplar tape(s) loaded", exemplarCount)
 	} else {
+		exemplarCount := 0
 		for _, t := range allTapes {
 			if t.Exemplar {
-				exemplarCount := 0
-				for _, tt := range allTapes {
-					if tt.Exemplar {
-						exemplarCount++
-					}
-				}
-				logger.Printf("WARNING: %d exemplar tape(s) found but synthesis is disabled (use --synthesize to enable)", exemplarCount)
-				break
+				exemplarCount++
 			}
+		}
+		if exemplarCount > 0 {
+			logger.Printf("WARNING: %d exemplar tape(s) found but synthesis is disabled (use --synthesize to enable)", exemplarCount)
 		}
 	}
 

--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -174,6 +174,7 @@ func runServe(args []string) error {
 	var replayHeaders repeatableFlag
 	fs.Var(&replayHeaders, "replay-header", "Header to inject into responses (Key=Value, repeatable)")
 	sseTiming := fs.String("sse-timing", "", "SSE replay timing mode: realtime, instant, accelerated=<factor>")
+	synthesize := fs.Bool("synthesize", false, "Enable synthesis mode (exemplar tapes generate responses for unmatched URLs)")
 
 	if err := fs.Parse(args); err != nil {
 		return &usageError{err}
@@ -224,6 +225,44 @@ func runServe(args []string) error {
 			return &usageError{fmt.Errorf("invalid --replay-header %q: expected Key=Value", rh)}
 		}
 		serverOpts = append(serverOpts, httptape.WithReplayHeaders(rh[:eqIdx], rh[eqIdx+1:]))
+	}
+	if *synthesize {
+		serverOpts = append(serverOpts, httptape.WithSynthesis())
+	}
+
+	// Startup validation: check all loaded tapes for structural validity.
+	allTapes, err := store.List(context.Background(), httptape.Filter{})
+	if err != nil {
+		return fmt.Errorf("load tapes: %w", err)
+	}
+	for _, t := range allTapes {
+		if err := httptape.ValidateTape(t); err != nil {
+			return fmt.Errorf("invalid tape %s: %w", t.ID, err)
+		}
+	}
+
+	// Synthesis logging.
+	if *synthesize {
+		exemplarCount := 0
+		for _, t := range allTapes {
+			if t.Exemplar {
+				exemplarCount++
+			}
+		}
+		logger.Printf("synthesis mode ENABLED -- %d exemplar tape(s) loaded", exemplarCount)
+	} else {
+		for _, t := range allTapes {
+			if t.Exemplar {
+				exemplarCount := 0
+				for _, tt := range allTapes {
+					if tt.Exemplar {
+						exemplarCount++
+					}
+				}
+				logger.Printf("WARNING: %d exemplar tape(s) found but synthesis is disabled (use --synthesize to enable)", exemplarCount)
+				break
+			}
+		}
 	}
 
 	server, err := httptape.NewServer(store, serverOpts...)

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -923,12 +923,9 @@ func TestServeWithSynthesizeLogging(t *testing.T) {
 func TestServeWithInvalidExemplarTape(t *testing.T) {
 	// Create a fixture with an invalid exemplar tape (Exemplar=true but no URLPattern).
 	dir := t.TempDir()
-	store, err := httptape.NewFileStore(httptape.WithDirectory(dir))
-	if err != nil {
-		t.Fatalf("create store: %v", err)
-	}
 
-	// Write a malformed exemplar tape directly as JSON.
+	// Write a malformed exemplar tape directly as JSON (bypasses Store validation
+	// to test the startup path's own ValidateTape call).
 	tapeJSON := `{
 		"id": "bad-exemplar",
 		"route": "",
@@ -947,7 +944,6 @@ func TestServeWithInvalidExemplarTape(t *testing.T) {
 			"body": null
 		}
 	}`
-	_ = store
 	tapePath := filepath.Join(dir, "bad-exemplar.json")
 	if err := os.WriteFile(tapePath, []byte(tapeJSON), 0644); err != nil {
 		t.Fatalf("write tape: %v", err)

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -879,6 +879,88 @@ func TestMigrateFixtures_AlreadyMigratedTape(t *testing.T) {
 	}
 }
 
+func TestServeWithSynthesize(t *testing.T) {
+	// --synthesize flag should be accepted without error.
+	got := run([]string{"serve", "--fixtures", t.TempDir(), "--synthesize", "-h"})
+	if got != exitOK {
+		t.Errorf("got exit %d, want %d for serve --synthesize -h", got, exitOK)
+	}
+}
+
+func TestServeWithSynthesizeLogging(t *testing.T) {
+	// Create a fixture directory with an exemplar tape.
+	dir := t.TempDir()
+	store, err := httptape.NewFileStore(httptape.WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	exemplar := httptape.Tape{
+		ID:       "exemplar-log-test",
+		Exemplar: true,
+		Request: httptape.RecordedReq{
+			Method:     "GET",
+			URLPattern: "/users/:id",
+		},
+		Response: httptape.RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/json"}},
+			Body:       []byte(`{"id":"{{pathParam.id}}"}`),
+		},
+	}
+	ctx := context.Background()
+	if err := store.Save(ctx, exemplar); err != nil {
+		t.Fatalf("save exemplar: %v", err)
+	}
+
+	// Just verify --synthesize flag is accepted (the -h flag triggers help and exits).
+	got := run([]string{"serve", "--fixtures", dir, "--synthesize", "-h"})
+	if got != exitOK {
+		t.Errorf("got exit %d, want %d", got, exitOK)
+	}
+}
+
+func TestServeWithInvalidExemplarTape(t *testing.T) {
+	// Create a fixture with an invalid exemplar tape (Exemplar=true but no URLPattern).
+	dir := t.TempDir()
+	store, err := httptape.NewFileStore(httptape.WithDirectory(dir))
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	// Write a malformed exemplar tape directly as JSON.
+	tapeJSON := `{
+		"id": "bad-exemplar",
+		"route": "",
+		"recorded_at": "2026-01-01T00:00:00Z",
+		"exemplar": true,
+		"request": {
+			"method": "GET",
+			"url": "",
+			"headers": {},
+			"body": null,
+			"body_hash": ""
+		},
+		"response": {
+			"status_code": 200,
+			"headers": {},
+			"body": null
+		}
+	}`
+	_ = store
+	tapePath := filepath.Join(dir, "bad-exemplar.json")
+	if err := os.WriteFile(tapePath, []byte(tapeJSON), 0644); err != nil {
+		t.Fatalf("write tape: %v", err)
+	}
+
+	// The serve command should fail at startup validation because the tape
+	// has Exemplar=true but no URLPattern.
+	got := run([]string{"serve", "--fixtures", dir})
+	if got != exitRuntime {
+		t.Errorf("got exit %d, want %d (startup validation should reject bad exemplar)", got, exitRuntime)
+	}
+}
+
 func itoa(i int) string {
 	const digits = "0123456789"
 	if i == 0 {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,9 +14,12 @@ type Tape struct {
     Request    RecordedReq    `json:"request"`
     Response   RecordedResp   `json:"response"`
     Metadata   map[string]any `json:"metadata,omitempty"`
+    Exemplar   bool           `json:"exemplar,omitempty"`
 }
 
 func NewTape(route string, req RecordedReq, resp RecordedResp) Tape
+func ValidateTape(t Tape) error
+func ValidateExemplar(t Tape) error
 ```
 
 ### RecordedReq
@@ -25,6 +28,7 @@ func NewTape(route string, req RecordedReq, resp RecordedResp) Tape
 type RecordedReq struct {
     Method           string      `json:"method"`
     URL              string      `json:"url"`
+    URLPattern       string      `json:"url_pattern,omitempty"`
     Headers          http.Header `json:"headers"`
     Body             []byte      `json:"-"`
     BodyHash         string      `json:"body_hash"`
@@ -195,8 +199,9 @@ Returns an error if option values are invalid. Panics if `store` is nil.
 | WithDelay | `WithDelay(d time.Duration)` | `0` |
 | WithErrorRate | `WithErrorRate(rate float64)` | `0.0` |
 | WithReplayHeaders | `WithReplayHeaders(key, value string)` | none |
+| WithSynthesis | `WithSynthesis()` | disabled |
 
-**Details:** [Replay](replay.md)
+**Details:** [Replay](replay.md), [Synthesis](synthesis.md)
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,9 +30,10 @@ httptape serve --fixtures ./fixtures [flags]
 | `--error-rate` | `0` | Fraction of requests that return 500 (0.0-1.0) |
 | `--replay-header` | (none) | Header to inject into responses (`Key=Value`, repeatable) |
 | `--sse-timing` | (none) | SSE replay timing mode: `realtime`, `instant`, `accelerated=<factor>`. When unset, the library default (`realtime`) is used. |
+| `--synthesize` | `false` | Enable synthesis mode. When enabled, exemplar tapes (with `"exemplar": true` and a `url_pattern`) generate responses for unmatched URLs. See [Synthesis](synthesis.md). |
 | `--config` | (none) | Path to httptape config JSON. When the config includes a `matcher` section, the server uses it to build a `CompositeMatcher` instead of the default method + path matcher. Sanitization rules in the config are ignored by `serve`. See [Config](config.md). |
 
-The server uses `DefaultMatcher` (method + path matching) unless a `--config` with a `matcher` section is provided. Fixtures are loaded from the specified directory. The server shuts down gracefully on SIGINT/SIGTERM.
+The server uses `DefaultMatcher` (method + path matching) unless a `--config` with a `matcher` section is provided. Fixtures are loaded from the specified directory. The server shuts down gracefully on SIGINT/SIGTERM. At startup, all loaded tapes are validated; invalid exemplar tapes cause a startup error.
 
 **Example:**
 

--- a/docs/fixtures-authoring.md
+++ b/docs/fixtures-authoring.md
@@ -402,10 +402,76 @@ If your fixtures were recorded with sanitization enabled, the values in headers 
 
 See [Declarative Configuration](config.md) for the config file format and [Sanitization](sanitization.md) for the programmatic API.
 
+## Exemplar tapes (synthesis mode)
+
+Exemplar tapes are hand-authored fixtures that serve as templates for URL
+families. Instead of recording one tape per URL, you author a single exemplar
+with a URL pattern and template expressions in the response body.
+
+### Required fields
+
+- `"exemplar": true` at the tape level.
+- `"url_pattern"` on the request, using colon-prefixed named segments
+  (e.g., `/users/:id`). Mutually exclusive with `"url"`.
+
+### Template expressions in exemplar bodies
+
+JSON response bodies support template expressions at string leaf positions:
+
+```json
+{
+  "id": "{{pathParam.id | int}}",
+  "name": "{{faker.name seed=user-{{pathParam.id}}}}",
+  "active": "{{request.query.active | bool}}"
+}
+```
+
+The `| int`, `| float`, and `| bool` coercion pipes convert the resolved
+string to a native JSON type (number or boolean).
+
+### Validation
+
+Exemplar tapes are validated at load time. Common validation errors:
+
+- `exemplar: true` without `url_pattern` -- error.
+- `url_pattern` without `exemplar: true` -- error.
+- Both `url` and `url_pattern` set -- error.
+- SSE exemplar (has `sse_events`) -- error (not supported).
+
+### Example
+
+```json
+{
+  "id": "products-exemplar",
+  "route": "",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "exemplar": true,
+  "request": {
+    "method": "GET",
+    "url_pattern": "/products/:category/:id",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": { "Content-Type": ["application/json"] },
+    "body": {
+      "id": "{{pathParam.id | int}}",
+      "category": "{{pathParam.category}}",
+      "name": "{{faker.name seed=product-{{pathParam.id}}}}"
+    }
+  }
+}
+```
+
+See [Synthesis Mode](synthesis.md) for the full guide.
+
 ## See also
 
 - [Storage](storage.md) -- FileStore and MemoryStore details
 - [Replay](replay.md) -- how the Server matches and serves fixtures
 - [Matching](matching.md) -- customizing request-to-tape matching
+- [Synthesis](synthesis.md) -- exemplar tapes and URL pattern matching
 - [UI-First Dev](ui-first-dev.md) -- using hand-authored fixtures for frontend development
 - [Config](config.md) -- sanitization configuration reference

--- a/docs/synthesis.md
+++ b/docs/synthesis.md
@@ -1,0 +1,144 @@
+# Synthesis Mode
+
+Synthesis mode enables httptape to generate responses for URL patterns using
+exemplar tapes. Instead of requiring an exact recorded tape for every URL,
+you author a single exemplar with a URL pattern (e.g., `/users/:id`) and
+httptape synthesizes responses for any matching request.
+
+## When to use synthesis
+
+Synthesis is designed for **frontend-first development workflows** where:
+
+- The backend is partially specified and the UI is being built against a mock.
+- You want realistic, deterministic responses for a family of URLs (e.g.,
+  `/users/1`, `/users/2`, `/users/999`) without recording each one.
+- You need the mock server to behave like a lightweight contract-driven stub.
+
+Synthesis is **not** intended for integration tests where unexpected requests
+should fail fast. In that case, leave synthesis disabled (the default).
+
+## How it differs from replay
+
+| Feature | Replay (default) | Synthesis |
+|---|---|---|
+| Matching | Exact URL | URL pattern (e.g., `/users/:id`) |
+| Response source | Recorded tape | Exemplar tape with template expressions |
+| Opt-in | Always on | Requires `WithSynthesis()` or `--synthesize` |
+| Template resolution | Optional (bodies with `{{...}}`) | Always (exemplar bodies are templates) |
+| Type coercion | Not applicable | `| int`, `| float`, `| bool` in JSON bodies |
+
+## Opt-in gating (two levels)
+
+Synthesis requires two levels of opt-in:
+
+1. **Per-tape**: the `"exemplar": true` field marks a tape as an exemplar.
+2. **Per-server**: the `WithSynthesis()` option (or `--synthesize` CLI flag)
+   enables the exemplar fallback path.
+
+Without both, exemplar tapes are loaded but never consulted.
+
+## Authoring exemplar tapes
+
+An exemplar tape is a JSON fixture with:
+
+- `"exemplar": true` at the tape level.
+- `"url_pattern"` on the request (instead of `"url"`).
+- Template expressions in the response body.
+
+Example (`fixtures/users-exemplar.json`):
+
+```json
+{
+  "id": "users-exemplar",
+  "route": "",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "exemplar": true,
+  "request": {
+    "method": "GET",
+    "url_pattern": "/users/:id",
+    "headers": {},
+    "body": null,
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {
+      "Content-Type": ["application/json"]
+    },
+    "body": {
+      "id": "{{pathParam.id | int}}",
+      "name": "{{faker.name seed=user-{{pathParam.id}}}}",
+      "email": "{{faker.email seed=user-{{pathParam.id}}}}"
+    }
+  }
+}
+```
+
+### Validation rules
+
+- `exemplar: true` requires `url_pattern` to be set.
+- `url_pattern` requires `exemplar: true`.
+- `url` and `url_pattern` are mutually exclusive.
+- SSE exemplar tapes are not supported.
+
+Invalid tapes produce a startup error when loading fixtures.
+
+## Type coercion
+
+In JSON response bodies, template expressions can include a type coercion
+pipe to emit native JSON types instead of strings:
+
+- `{{pathParam.id | int}}` -- emits a JSON number (e.g., `42`).
+- `{{request.query.price | float}}` -- emits a JSON float (e.g., `19.99`).
+- `{{request.query.active | bool}}` -- emits a JSON boolean (e.g., `true`).
+
+Coercion is only meaningful in JSON bodies. In text bodies, everything is
+a string and coercion is ignored.
+
+If coercion fails (e.g., `"abc" | int`):
+- **Strict mode**: returns HTTP 500 with `X-Httptape-Error: template`.
+- **Lenient mode** (default): emits the uncoerced string value.
+
+## Match flow
+
+When synthesis is enabled, the server uses a two-phase match flow:
+
+1. **Phase 1 -- exact match**: all non-exemplar tapes are checked first.
+   If an exact match is found, synthesis is not consulted.
+2. **Phase 2 -- exemplar fallback**: if no exact match is found, exemplar
+   tapes are checked. The request path is tested against each exemplar's
+   `url_pattern`. The exemplar must also pass all other configured criteria
+   (method, headers, body_fuzzy, etc.).
+
+Among matching exemplars, the highest-scoring one wins. Ties are broken by
+declaration order.
+
+## Seed stability
+
+Faker seeds in exemplar tapes are content-derived. For example, the seed
+`user-{{pathParam.id}}` evaluates to `user-42` for `/users/42`. This means:
+
+- Renaming the tape file has no effect on generated data.
+- Changing the tape ID has no effect.
+- The same request always produces the same fake data (deterministic).
+
+## CLI usage
+
+```bash
+httptape serve --fixtures ./fixtures --synthesize
+```
+
+The `--synthesize` flag enables synthesis mode. Without it, exemplar tapes
+in the fixture directory are loaded but ignored.
+
+## Library usage
+
+```go
+srv, err := httptape.NewServer(store, httptape.WithSynthesis())
+```
+
+## Known limitations
+
+- SSE exemplar tapes are not supported. A follow-up issue can add support.
+- Type coercion is limited to `| int`, `| float`, `| bool`.
+- Coercion is only effective in JSON response bodies, not text bodies.

--- a/integration_test.go
+++ b/integration_test.go
@@ -1118,3 +1118,165 @@ func TestIntegration_PathParamFaker(t *testing.T) {
 		t.Errorf("expected first+last name, got %q", name)
 	}
 }
+
+// --- ADR-43: Exemplar synthesis integration tests ---
+
+func TestIntegration_ExemplarSynthesis(t *testing.T) {
+	store := NewMemoryStore()
+
+	// Exact tape for /users/1.
+	exactTape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/users/1",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"id":1,"name":"Exact Alice"}`),
+	})
+	if err := store.Save(context.Background(), exactTape); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exemplar tape for /users/:id.
+	exemplar := Tape{
+		ID:       newUUID(),
+		Exemplar: true,
+		Request: RecordedReq{
+			Method:     "GET",
+			URLPattern: "/users/:id",
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/json"}},
+			Body:       []byte(`{"id":"{{pathParam.id | int}}","synthetic":true}`),
+		},
+	}
+	if err := store.Save(context.Background(), exemplar); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Request /users/1 -> exact replay (no synthesis).
+	resp, err := http.Get(ts.URL + "/users/1")
+	if err != nil {
+		t.Fatalf("GET /users/1: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET /users/1: status=%d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `"Exact Alice"`) {
+		t.Errorf("GET /users/1 should return exact tape, got: %s", body)
+	}
+
+	// Request /users/2 -> synthesized response.
+	resp, err = http.Get(ts.URL + "/users/2")
+	if err != nil {
+		t.Fatalf("GET /users/2: %v", err)
+	}
+	body2, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET /users/2: status=%d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body2), `"id":2`) {
+		t.Errorf("GET /users/2 should have id=2, got: %s", body2)
+	}
+	if !strings.Contains(string(body2), `"synthetic":true`) {
+		t.Errorf("GET /users/2 should have synthetic=true, got: %s", body2)
+	}
+
+	// Request /users/7 -> synthesized response with different id.
+	resp, err = http.Get(ts.URL + "/users/7")
+	if err != nil {
+		t.Fatalf("GET /users/7: %v", err)
+	}
+	body7, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET /users/7: status=%d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body7), `"id":7`) {
+		t.Errorf("GET /users/7 should have id=7, got: %s", body7)
+	}
+
+	// Verify /users/2 and /users/7 produce different bodies.
+	if string(body2) == string(body7) {
+		t.Error("different path params should produce different bodies")
+	}
+
+	// Verify determinism: re-request /users/2.
+	resp, err = http.Get(ts.URL + "/users/2")
+	if err != nil {
+		t.Fatalf("re-GET /users/2: %v", err)
+	}
+	body2Again, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if string(body2) != string(body2Again) {
+		t.Errorf("determinism failure: first=%q, second=%q", body2, body2Again)
+	}
+}
+
+func TestIntegration_SynthesisDisabled_ExemplarIgnored(t *testing.T) {
+	store := NewMemoryStore()
+
+	// Exact tape for /users/1.
+	exactTape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/users/1",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"id":1}`),
+	})
+	if err := store.Save(context.Background(), exactTape); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exemplar tape for /users/:id.
+	exemplar := Tape{
+		ID:       newUUID(),
+		Exemplar: true,
+		Request: RecordedReq{
+			Method:     "GET",
+			URLPattern: "/users/:id",
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/json"}},
+			Body:       []byte(`{"id":"{{pathParam.id | int}}"}`),
+		},
+	}
+	if err := store.Save(context.Background(), exemplar); err != nil {
+		t.Fatal(err)
+	}
+
+	// No WithSynthesis -- exemplar should be ignored.
+	srv, err := NewServer(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/users/2")
+	if err != nil {
+		t.Fatalf("GET /users/2: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Errorf("GET /users/2: status=%d, want 404 (synthesis disabled)", resp.StatusCode)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -504,10 +504,10 @@ func (s *Server) matchExemplar(r *http.Request, exemplars []Tape) (Tape, map[str
 			params = map[string]string{}
 		}
 
-		// Score the path match using the PathPatternCriterion's score logic.
-		// We create a temporary tape with the URL set to the request path so
-		// that the criterion's Score method can compare.
-		pathScore := 3 // PathPatternCriterion always returns 3 on match
+		// PathPatternCriterion's Score returns a flat 3 on match. Same-depth
+		// literal-vs-parameterized exemplars therefore tie and fall back to
+		// declaration order (see follow-up issue for true specificity sort).
+		pathScore := 3
 
 		// Run other criteria against the exemplar. The exemplar must pass all.
 		totalScore := pathScore

--- a/server.go
+++ b/server.go
@@ -33,6 +33,7 @@ type Server struct {
 	sseTiming        SSETimingMode       // controls SSE replay inter-event timing
 	counters         *counterState       // per-server counter state for {{counter}}
 	randSource       io.Reader           // randomness source for template helpers
+	synthesis        bool                // if true, exemplar tapes are consulted on miss
 }
 
 // ServerOption configures a Server.
@@ -124,6 +125,22 @@ func WithReplayHeaders(key, value string) ServerOption {
 //   - SSETimingInstant(): emit all events immediately, no delay
 func WithSSETiming(mode SSETimingMode) ServerOption {
 	return func(s *Server) { s.sseTiming = mode }
+}
+
+// WithSynthesis enables synthesis mode on the Server. When enabled, requests
+// that don't match any exact-URL tape fall back to exemplar tapes -- tapes
+// with Exemplar: true and a URLPattern. The exemplar's response body is
+// rendered using template helpers (path params, fakers, etc.) to produce a
+// unique, deterministic response.
+//
+// Synthesis is disabled by default. When disabled, exemplar tapes are loaded
+// but never consulted, ensuring integration tests are not affected by
+// exemplar tapes in the fixture directory.
+//
+// Requires that tapes are loaded from a store that includes exemplar fixtures.
+// Exemplar tapes must pass validation (see ValidateExemplar).
+func WithSynthesis() ServerOption {
+	return func(s *Server) { s.synthesis = true }
 }
 
 // WithTemplating controls whether Mustache-style {{request.*}} template
@@ -287,10 +304,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 4. Find a matching tape.
-	tape, ok := s.matcher.Match(r, tapes)
+	// 4. Partition tapes into exact and exemplar sets.
+	// When synthesis is disabled, exemplar tapes are explicitly filtered out
+	// to guarantee they are inert regardless of matcher configuration.
+	var exactTapes, exemplarTapes []Tape
+	for _, t := range tapes {
+		if t.Exemplar {
+			exemplarTapes = append(exemplarTapes, t)
+		} else {
+			exactTapes = append(exactTapes, t)
+		}
+	}
 
-	// 5. No match.
+	// 5. Phase 1 -- exact match.
+	tape, ok := s.matcher.Match(r, exactTapes)
+
+	// 6. Phase 2 -- exemplar fallback (only when synthesis is enabled and
+	// phase 1 found no match).
+	var pathParams map[string]string
+	if !ok && s.synthesis && len(exemplarTapes) > 0 {
+		tape, pathParams, ok = s.matchExemplar(r, exemplarTapes)
+	}
+
+	// 7. No match at all.
 	if !ok {
 		if s.onNoMatch != nil {
 			s.onNoMatch(r)
@@ -300,7 +336,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 6. Per-fixture error override.
+	// 8. Per-fixture error override.
 	if tape.Metadata != nil {
 		if raw, ok := tape.Metadata["error"]; ok {
 			if errMap, ok := raw.(map[string]any); ok {
@@ -319,7 +355,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 7. Delay (global or per-fixture override).
+	// 9. Delay (global or per-fixture override).
 	effectiveDelay := s.delay
 	if tape.Metadata != nil {
 		if raw, ok := tape.Metadata["delay"]; ok {
@@ -342,27 +378,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 8. Check if this is an SSE tape — SSE responses stream events verbatim
+	// 10. Check if this is an SSE tape -- SSE responses stream events verbatim
 	// (no templating, no replay-header injection on the body path).
 	if tape.Response.IsSSE() {
 		s.serveSSE(w, r, tape)
 		return
 	}
 
-	// 9. Templating -- resolve {{...}} expressions in non-SSE response
+	// 11. Templating -- resolve {{...}} expressions in non-SSE response
 	// body and headers.
 	respBody := tape.Response.Body
 	respHeaders := tape.Response.Headers
 	if s.templating {
 		reqBody := readRequestBody(r)
 
-		// Extract path params from PathPatternCriterion if present.
-		var pathParams map[string]string
-		if cm, ok := s.matcher.(*CompositeMatcher); ok {
-			for _, criterion := range cm.criteria {
-				if ppc, ok := criterion.(*PathPatternCriterion); ok {
-					pathParams = ppc.ExtractParams(r.URL.Path)
-					break
+		// For non-exemplar tapes, extract path params from the matcher's
+		// PathPatternCriterion if present (existing behavior from #196).
+		if pathParams == nil {
+			if cm, ok := s.matcher.(*CompositeMatcher); ok {
+				for _, criterion := range cm.criteria {
+					if ppc, ok := criterion.(*PathPatternCriterion); ok {
+						pathParams = ppc.ExtractParams(r.URL.Path)
+						break
+					}
 				}
 			}
 		}
@@ -376,8 +414,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			randSource: s.randSource,
 		}
 
-		var err error
-		respBody, err = ResolveTemplateBody(respBody, ctx, s.strictTemplating)
+		// For exemplar tapes with JSON Content-Type, use JSON-aware resolution
+		// with type coercion support.
+		if tape.Exemplar {
+			respBody, err = resolveExemplarBody(respBody, tape.Response.Headers, ctx, s.strictTemplating)
+		} else {
+			respBody, err = ResolveTemplateBody(respBody, ctx, s.strictTemplating)
+		}
 		if err != nil {
 			w.Header().Set("X-Httptape-Error", "template")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -391,22 +434,110 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 10. Write the matched tape's response.
-	// 10a: copy response headers (clone slices to prevent aliasing with tape data).
+	// 12. Write the matched tape's response.
+	// 12a: copy response headers (clone slices to prevent aliasing with tape data).
 	for key, values := range respHeaders {
 		w.Header()[key] = append([]string(nil), values...)
 	}
-	// 9b: apply replay header overrides (if any).
+	// 12b: apply replay header overrides (if any).
 	for key, value := range s.replayHeaders {
 		w.Header().Set(key, value)
 	}
-	// 10c: remove Content-Length — the recorded value may be stale if the body
+	// 12c: remove Content-Length -- the recorded value may be stale if the body
 	// was modified by sanitization or templating. Let net/http set it from the actual body.
 	w.Header().Del("Content-Length")
-	// 10d: write status code.
+	// 12d: write status code.
 	w.WriteHeader(tape.Response.StatusCode)
-	// 10e: write body.
+	// 12e: write body.
 	w.Write(respBody) //nolint:errcheck // response write failure is not actionable
+}
+
+// matchExemplar searches for the best-matching exemplar tape for the given
+// request. For each exemplar, it builds a PathPatternCriterion from the
+// tape's URLPattern, tests the incoming request path against it, and also
+// runs the server's other configured criteria (method, headers, body_fuzzy,
+// etc.) to ensure the exemplar matches all dimensions.
+//
+// Returns the best-matching tape, captured path parameters, and true, or
+// (Tape{}, nil, false) if no exemplar matches.
+func (s *Server) matchExemplar(r *http.Request, exemplars []Tape) (Tape, map[string]string, bool) {
+	type match struct {
+		tape      Tape
+		params    map[string]string
+		score     int
+		declOrder int
+	}
+
+	var best *match
+
+	// Extract non-path criteria from the server's matcher for secondary scoring.
+	var otherCriteria []Criterion
+	if cm, ok := s.matcher.(*CompositeMatcher); ok {
+		for _, c := range cm.criteria {
+			switch c.(type) {
+			case PathCriterion, *PathCriterion, *PathPatternCriterion, *PathRegexCriterion:
+				// Skip path-related criteria -- we use our own PathPatternCriterion.
+			default:
+				otherCriteria = append(otherCriteria, c)
+			}
+		}
+	}
+
+	for i, exemplar := range exemplars {
+		ppc, err := NewPathPatternCriterion(exemplar.Request.URLPattern)
+		if err != nil {
+			continue // invalid pattern: skip silently
+		}
+
+		// Test if the request path matches the exemplar's pattern.
+		params := ppc.ExtractParams(r.URL.Path)
+		if params == nil && len(ppc.paramNames) > 0 {
+			// Pattern has parameters but didn't match.
+			if !ppc.re.MatchString(r.URL.Path) {
+				continue
+			}
+		} else if params == nil {
+			// Pattern has no parameters -- check exact regex match.
+			if !ppc.re.MatchString(r.URL.Path) {
+				continue
+			}
+			params = map[string]string{}
+		}
+
+		// Score the path match using the PathPatternCriterion's score logic.
+		// We create a temporary tape with the URL set to the request path so
+		// that the criterion's Score method can compare.
+		pathScore := 3 // PathPatternCriterion always returns 3 on match
+
+		// Run other criteria against the exemplar. The exemplar must pass all.
+		totalScore := pathScore
+		eliminated := false
+		for _, c := range otherCriteria {
+			score := c.Score(r, exemplar)
+			if score == 0 {
+				eliminated = true
+				break
+			}
+			totalScore += score
+		}
+		if eliminated {
+			continue
+		}
+
+		if best == nil || totalScore > best.score || (totalScore == best.score && i < best.declOrder) {
+			best = &match{
+				tape:      exemplar,
+				params:    params,
+				score:     totalScore,
+				declOrder: i,
+			}
+		}
+	}
+
+	if best == nil {
+		return Tape{}, nil, false
+	}
+	return best.tape, best.params, true
 }
 
 // serveSSE handles SSE tape replay. It writes response headers, then

--- a/server_test.go
+++ b/server_test.go
@@ -1712,3 +1712,249 @@ func TestServer_CounterAcrossRequests(t *testing.T) {
 		}
 	}
 }
+
+// --- ADR-43: Synthesis mode tests ---
+
+// storeExemplarTape creates and saves an exemplar tape to the store.
+func storeExemplarTape(t *testing.T, store *MemoryStore, method, urlPattern string, status int, body string, headers http.Header) Tape {
+	t.Helper()
+	tape := Tape{
+		ID:       newUUID(),
+		Exemplar: true,
+		Request: RecordedReq{
+			Method:     method,
+			URLPattern: urlPattern,
+		},
+		Response: RecordedResp{
+			StatusCode: status,
+			Headers:    headers,
+			Body:       []byte(body),
+		},
+	}
+	if err := store.Save(context.Background(), tape); err != nil {
+		t.Fatalf("storeExemplarTape: failed to save tape: %v", err)
+	}
+	return tape
+}
+
+func TestServer_SynthesisDisabled_ExemplarIgnored(t *testing.T) {
+	store := NewMemoryStore()
+	storeExemplarTape(t, store, "GET", "/users/:id", 200,
+		`{"id":"{{pathParam.id | int}}"}`,
+		http.Header{"Content-Type": {"application/json"}})
+
+	srv, err := NewServer(store) // No WithSynthesis
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/users/42", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 404 {
+		t.Errorf("status = %d, want 404 (exemplar should be ignored without synthesis)", rec.Code)
+	}
+}
+
+func TestServer_SynthesisEnabled_ExactWins(t *testing.T) {
+	store := NewMemoryStore()
+	// Exact tape for /users/1
+	storeTape(t, store, "GET", "/users/1", 200, `{"id":1,"exact":true}`,
+		http.Header{"Content-Type": {"application/json"}})
+	// Exemplar for /users/:id
+	storeExemplarTape(t, store, "GET", "/users/:id", 200,
+		`{"id":"{{pathParam.id | int}}","exact":false}`,
+		http.Header{"Content-Type": {"application/json"}})
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/users/1", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"exact":true`) {
+		t.Errorf("exact tape should win over exemplar, got: %s", body)
+	}
+}
+
+func TestServer_SynthesisEnabled_ExemplarFallback(t *testing.T) {
+	store := NewMemoryStore()
+	// Exact tape for /users/1 only
+	storeTape(t, store, "GET", "/users/1", 200, `{"id":1}`,
+		http.Header{"Content-Type": {"application/json"}})
+	// Exemplar for /users/:id
+	storeExemplarTape(t, store, "GET", "/users/:id", 200,
+		`{"id":"{{pathParam.id | int}}"}`,
+		http.Header{"Content-Type": {"application/json"}})
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Request /users/2 -- no exact match, should fall back to exemplar.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/users/2", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"id":2}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body = %s, want %s", got, want)
+	}
+}
+
+func TestServer_SynthesisEnabled_MostSpecificExemplar(t *testing.T) {
+	store := NewMemoryStore()
+	// Less specific: /users/:id
+	storeExemplarTape(t, store, "GET", "/users/:id", 200,
+		`{"type":"user"}`,
+		http.Header{"Content-Type": {"application/json"}})
+	// More specific: /users/:id/orders
+	storeExemplarTape(t, store, "GET", "/users/:id/orders", 200,
+		`{"type":"orders"}`,
+		http.Header{"Content-Type": {"application/json"}})
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/users/42/orders", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"type":"orders"}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body = %s, want %s (more specific exemplar should win)", got, want)
+	}
+}
+
+func TestServer_SynthesisEnabled_MethodFilter(t *testing.T) {
+	store := NewMemoryStore()
+	// Exemplar for GET /users/:id only
+	storeExemplarTape(t, store, "GET", "/users/:id", 200,
+		`{"id":"{{pathParam.id | int}}"}`,
+		http.Header{"Content-Type": {"application/json"}})
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// POST /users/42 should not match GET exemplar.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/users/42", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 404 {
+		t.Errorf("status = %d, want 404 (method mismatch should eliminate exemplar)", rec.Code)
+	}
+}
+
+func TestServer_SynthesisEnabled_NoExemplars(t *testing.T) {
+	store := NewMemoryStore()
+	storeTape(t, store, "GET", "/users/1", 200, `{"id":1}`,
+		http.Header{"Content-Type": {"application/json"}})
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Request for unmatched URL, no exemplars in store.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/users/999", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 404 {
+		t.Errorf("status = %d, want 404 (no exemplars available)", rec.Code)
+	}
+}
+
+func TestServer_SynthesisEnabled_DeterministicResponse(t *testing.T) {
+	store := NewMemoryStore()
+	storeExemplarTape(t, store, "GET", "/users/:id", 200,
+		`{"id":"{{pathParam.id | int}}"}`,
+		http.Header{"Content-Type": {"application/json"}})
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Request /users/42 twice, expect identical responses.
+	var bodies [2]string
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/users/42", nil)
+		srv.ServeHTTP(rec, req)
+		bodies[i] = rec.Body.String()
+	}
+
+	if bodies[0] != bodies[1] {
+		t.Errorf("deterministic mismatch: first=%q, second=%q", bodies[0], bodies[1])
+	}
+}
+
+func TestServer_SynthesisEnabled_ExemplarWithTextBody(t *testing.T) {
+	store := NewMemoryStore()
+	storeExemplarTape(t, store, "GET", "/greet/:name", 200,
+		"Hello, {{pathParam.name}}!",
+		http.Header{"Content-Type": {"text/plain"}})
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/greet/Alice", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := "Hello, Alice!"
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestServer_SynthesisEnabled_PatternWithNoParams(t *testing.T) {
+	store := NewMemoryStore()
+	// An exemplar with a pattern that has no parameters (effectively exact path).
+	storeExemplarTape(t, store, "GET", "/api/health", 200,
+		`{"status":"ok"}`,
+		http.Header{"Content-Type": {"application/json"}})
+
+	srv, err := NewServer(store, WithSynthesis())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"status":"ok"}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body = %s, want %s", got, want)
+	}
+}

--- a/tape.go
+++ b/tape.go
@@ -415,9 +415,6 @@ func ValidateExemplar(t Tape) error {
 		if !hasPattern {
 			return fmt.Errorf("httptape: exemplar tape %s: url_pattern is required", t.ID)
 		}
-		if hasURL {
-			return fmt.Errorf("httptape: exemplar tape %s: url and url_pattern are mutually exclusive", t.ID)
-		}
 		if len(t.Response.SSEEvents) > 0 {
 			return fmt.Errorf("httptape: exemplar tape %s: SSE exemplars are not supported", t.ID)
 		}

--- a/tape.go
+++ b/tape.go
@@ -35,6 +35,16 @@ type Tape struct {
 	// configuration (e.g., delay, error simulation). Not used for
 	// matching. Values are preserved through JSON round-trip.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// Exemplar marks this tape as a pattern-based template for synthesis mode.
+	// When true, the tape's request uses URLPattern instead of URL, and the
+	// response body may contain template expressions that are resolved at
+	// serve time using captured path parameters and other template helpers.
+	//
+	// Exemplar tapes are only consulted when the server has synthesis enabled
+	// (WithSynthesis option). When synthesis is disabled, exemplar tapes are
+	// loaded but ignored.
+	Exemplar bool `json:"exemplar,omitempty"`
 }
 
 // RecordedReq captures the essential parts of an HTTP request for matching and replay.
@@ -51,6 +61,16 @@ type RecordedReq struct {
 
 	// URL is the full request URL as a string.
 	URL string `json:"url"`
+
+	// URLPattern is a colon-prefixed path pattern (e.g., "/users/:id") used
+	// by exemplar tapes for pattern-based matching. Mutually exclusive with
+	// URL: a tape must have either URL (exact match) or URLPattern (pattern
+	// match via PathPatternCriterion), never both.
+	//
+	// Only meaningful when the parent Tape has Exemplar set to true.
+	// Validation enforces: Exemplar==true requires URLPattern!="",
+	// and URLPattern!="" requires Exemplar==true.
+	URLPattern string `json:"url_pattern,omitempty"`
 
 	// Headers contains the request headers. Only non-sensitive headers are stored
 	// after sanitization (handled by the sanitizer, not by this type).
@@ -124,6 +144,7 @@ func (r RecordedReq) MarshalJSON() ([]byte, error) {
 	type alias struct {
 		Method           string      `json:"method"`
 		URL              string      `json:"url"`
+		URLPattern       string      `json:"url_pattern,omitempty"`
 		Headers          http.Header `json:"headers"`
 		Body             any         `json:"body"`
 		BodyHash         string      `json:"body_hash"`
@@ -134,6 +155,7 @@ func (r RecordedReq) MarshalJSON() ([]byte, error) {
 	a := alias{
 		Method:           r.Method,
 		URL:              r.URL,
+		URLPattern:       r.URLPattern,
 		Headers:          r.Headers,
 		Body:             nil, // default: null
 		BodyHash:         r.BodyHash,
@@ -154,6 +176,7 @@ func (r *RecordedReq) UnmarshalJSON(data []byte) error {
 	type alias struct {
 		Method           string          `json:"method"`
 		URL              string          `json:"url"`
+		URLPattern       string          `json:"url_pattern,omitempty"`
 		Headers          http.Header     `json:"headers"`
 		Body             json.RawMessage `json:"body"`
 		BodyHash         string          `json:"body_hash"`
@@ -168,6 +191,7 @@ func (r *RecordedReq) UnmarshalJSON(data []byte) error {
 
 	r.Method = a.Method
 	r.URL = a.URL
+	r.URLPattern = a.URLPattern
 	r.Headers = a.Headers
 	r.BodyHash = a.BodyHash
 	r.Truncated = a.Truncated
@@ -186,7 +210,7 @@ func (r *RecordedReq) UnmarshalJSON(data []byte) error {
 // (same rules as RecordedReq.MarshalJSON).
 func (r RecordedResp) MarshalJSON() ([]byte, error) {
 	type alias struct {
-		StatusCode       int        `json:"status_code"`
+		StatusCode       int         `json:"status_code"`
 		Headers          http.Header `json:"headers"`
 		Body             any         `json:"body"`
 		Truncated        bool        `json:"truncated,omitempty"`
@@ -357,6 +381,53 @@ func NewTape(route string, req RecordedReq, resp RecordedResp) Tape {
 		Request:    req,
 		Response:   resp,
 	}
+}
+
+// ValidateTape checks a tape for structural validity. Currently validates
+// exemplar-specific constraints via ValidateExemplar. Returns nil if valid.
+func ValidateTape(t Tape) error {
+	return ValidateExemplar(t)
+}
+
+// ValidateExemplar checks that a tape marked as an exemplar is structurally
+// valid. Returns nil if the tape is valid, or an error describing the issue.
+//
+// Validation rules:
+//   - Exemplar==true requires URLPattern to be non-empty.
+//   - Exemplar==true requires URL to be empty.
+//   - URLPattern is only valid when Exemplar==true.
+//   - SSE exemplars (Exemplar==true with non-empty SSEEvents) are not
+//     supported and produce an error.
+//   - Non-exemplar tapes with URLPattern set produce an error.
+//   - URL and URLPattern set simultaneously produce an error.
+//
+// ValidateExemplar does not validate the URLPattern syntax -- that is the
+// responsibility of PathPatternCriterion.
+func ValidateExemplar(t Tape) error {
+	hasURL := t.Request.URL != ""
+	hasPattern := t.Request.URLPattern != ""
+
+	if hasURL && hasPattern {
+		return fmt.Errorf("httptape: tape %s: url and url_pattern are mutually exclusive", t.ID)
+	}
+
+	if t.Exemplar {
+		if !hasPattern {
+			return fmt.Errorf("httptape: exemplar tape %s: url_pattern is required", t.ID)
+		}
+		if hasURL {
+			return fmt.Errorf("httptape: exemplar tape %s: url and url_pattern are mutually exclusive", t.ID)
+		}
+		if len(t.Response.SSEEvents) > 0 {
+			return fmt.Errorf("httptape: exemplar tape %s: SSE exemplars are not supported", t.ID)
+		}
+	}
+
+	if hasPattern && !t.Exemplar {
+		return fmt.Errorf("httptape: tape %s: url_pattern requires exemplar to be true", t.ID)
+	}
+
+	return nil
 }
 
 // BodyHashFromBytes computes the hex-encoded SHA-256 hash of the given bytes.

--- a/tape_test.go
+++ b/tape_test.go
@@ -612,3 +612,282 @@ func TestRecordedReq_MarshalJSON_FormUrlencoded(t *testing.T) {
 		t.Errorf("expected text string body for form data, got: %s", data)
 	}
 }
+
+// --- Exemplar validation tests (ADR-43) ---
+
+func TestValidateExemplar(t *testing.T) {
+	tests := []struct {
+		name    string
+		tape    Tape
+		wantErr string // empty means no error expected
+	}{
+		{
+			name: "valid exemplar with url_pattern",
+			tape: Tape{
+				ID:       "t-1",
+				Exemplar: true,
+				Request: RecordedReq{
+					Method:     "GET",
+					URLPattern: "/users/:id",
+				},
+				Response: RecordedResp{StatusCode: 200},
+			},
+		},
+		{
+			name: "valid non-exemplar tape",
+			tape: Tape{
+				ID: "t-2",
+				Request: RecordedReq{
+					Method: "GET",
+					URL:    "/users/1",
+				},
+				Response: RecordedResp{StatusCode: 200},
+			},
+		},
+		{
+			name: "exemplar missing url_pattern",
+			tape: Tape{
+				ID:       "t-3",
+				Exemplar: true,
+				Request: RecordedReq{
+					Method: "GET",
+				},
+				Response: RecordedResp{StatusCode: 200},
+			},
+			wantErr: "url_pattern is required",
+		},
+		{
+			name: "exemplar with both url and url_pattern",
+			tape: Tape{
+				ID:       "t-4",
+				Exemplar: true,
+				Request: RecordedReq{
+					Method:     "GET",
+					URL:        "/users/1",
+					URLPattern: "/users/:id",
+				},
+				Response: RecordedResp{StatusCode: 200},
+			},
+			wantErr: "url and url_pattern are mutually exclusive",
+		},
+		{
+			name: "url_pattern without exemplar flag",
+			tape: Tape{
+				ID: "t-5",
+				Request: RecordedReq{
+					Method:     "GET",
+					URLPattern: "/users/:id",
+				},
+				Response: RecordedResp{StatusCode: 200},
+			},
+			wantErr: "url_pattern requires exemplar to be true",
+		},
+		{
+			name: "SSE exemplar rejected",
+			tape: Tape{
+				ID:       "t-6",
+				Exemplar: true,
+				Request: RecordedReq{
+					Method:     "GET",
+					URLPattern: "/events/:id",
+				},
+				Response: RecordedResp{
+					StatusCode: 200,
+					SSEEvents:  []SSEEvent{{Data: "hello"}},
+				},
+			},
+			wantErr: "SSE exemplars are not supported",
+		},
+		{
+			name: "non-exemplar url and url_pattern both set",
+			tape: Tape{
+				ID: "t-7",
+				Request: RecordedReq{
+					Method:     "GET",
+					URL:        "/users/1",
+					URLPattern: "/users/:id",
+				},
+				Response: RecordedResp{StatusCode: 200},
+			},
+			wantErr: "url and url_pattern are mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExemplar(tt.tape)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("ValidateExemplar() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("ValidateExemplar() = nil, want error containing %q", tt.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("ValidateExemplar() error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateTape_DelegatesToValidateExemplar(t *testing.T) {
+	invalid := Tape{
+		ID:       "t-bad",
+		Exemplar: true,
+		Request:  RecordedReq{Method: "GET"},
+		Response: RecordedResp{StatusCode: 200},
+	}
+	err := ValidateTape(invalid)
+	if err == nil {
+		t.Error("ValidateTape() = nil, want error for exemplar missing url_pattern")
+	}
+}
+
+func TestTape_MarshalJSON_Exemplar(t *testing.T) {
+	tape := Tape{
+		ID:       "exemplar-1",
+		Route:    "api",
+		Exemplar: true,
+		Request: RecordedReq{
+			Method:     "GET",
+			URLPattern: "/users/:id",
+			Headers:    http.Header{"Accept": {"application/json"}},
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/json"}},
+			Body:       []byte(`{"id":"{{pathParam.id | int}}"}`),
+		},
+	}
+
+	data, err := json.MarshalIndent(tape, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	s := string(data)
+	if !strings.Contains(s, `"exemplar": true`) {
+		t.Errorf("marshal should contain exemplar: true, got:\n%s", s)
+	}
+	if !strings.Contains(s, `"url_pattern": "/users/:id"`) {
+		t.Errorf("marshal should contain url_pattern, got:\n%s", s)
+	}
+}
+
+func TestTape_UnmarshalJSON_Exemplar(t *testing.T) {
+	input := `{
+		"id": "exemplar-1",
+		"route": "api",
+		"recorded_at": "2026-01-01T00:00:00Z",
+		"exemplar": true,
+		"request": {
+			"method": "GET",
+			"url_pattern": "/users/:id",
+			"headers": {},
+			"body": null,
+			"body_hash": ""
+		},
+		"response": {
+			"status_code": 200,
+			"headers": {"Content-Type": ["application/json"]},
+			"body": {"id": "{{pathParam.id | int}}"}
+		}
+	}`
+
+	var tape Tape
+	if err := json.Unmarshal([]byte(input), &tape); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !tape.Exemplar {
+		t.Error("Exemplar should be true after unmarshal")
+	}
+	if tape.Request.URLPattern != "/users/:id" {
+		t.Errorf("URLPattern = %q, want %q", tape.Request.URLPattern, "/users/:id")
+	}
+	if tape.Request.URL != "" {
+		t.Errorf("URL = %q, want empty for exemplar tape", tape.Request.URL)
+	}
+}
+
+func TestTape_UnmarshalJSON_NoExemplar(t *testing.T) {
+	input := `{
+		"id": "normal-1",
+		"route": "api",
+		"recorded_at": "2026-01-01T00:00:00Z",
+		"request": {
+			"method": "GET",
+			"url": "http://example.com/users/1",
+			"headers": {},
+			"body": null,
+			"body_hash": ""
+		},
+		"response": {
+			"status_code": 200,
+			"headers": {"Content-Type": ["application/json"]},
+			"body": {"id": 1}
+		}
+	}`
+
+	var tape Tape
+	if err := json.Unmarshal([]byte(input), &tape); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if tape.Exemplar {
+		t.Error("Exemplar should be false when field is absent")
+	}
+	if tape.Request.URLPattern != "" {
+		t.Errorf("URLPattern = %q, want empty for normal tape", tape.Request.URLPattern)
+	}
+}
+
+func TestTape_MarshalJSON_RoundTrip_Exemplar(t *testing.T) {
+	original := Tape{
+		ID:       "rt-1",
+		Route:    "api",
+		Exemplar: true,
+		Request: RecordedReq{
+			Method:     "GET",
+			URLPattern: "/items/:category/:id",
+			Headers:    http.Header{},
+		},
+		Response: RecordedResp{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": {"application/json"}},
+			Body:       []byte(`{"category":"{{pathParam.category}}"}`),
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var roundTripped Tape
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if roundTripped.Exemplar != original.Exemplar {
+		t.Errorf("Exemplar = %v, want %v", roundTripped.Exemplar, original.Exemplar)
+	}
+	if roundTripped.Request.URLPattern != original.Request.URLPattern {
+		t.Errorf("URLPattern = %q, want %q", roundTripped.Request.URLPattern, original.Request.URLPattern)
+	}
+	if roundTripped.Request.URL != "" {
+		t.Errorf("URL = %q, want empty after round-trip", roundTripped.Request.URL)
+	}
+
+	// Re-marshal and compare.
+	data2, err := json.Marshal(roundTripped)
+	if err != nil {
+		t.Fatalf("re-marshal error: %v", err)
+	}
+	if string(data) != string(data2) {
+		t.Errorf("round-trip mismatch:\n  first:  %s\n  second: %s", data, data2)
+	}
+}

--- a/templating.go
+++ b/templating.go
@@ -1005,9 +1005,6 @@ func resolveStringWithCoercion(s string, ctx *templateCtx, strict bool, errOut *
 				*errOut = fmt.Errorf("httptape: unresolvable template expression: {{%s}}", rawExpr)
 				return s
 			}
-			if hasCoercion {
-				return ""
-			}
 			return ""
 		}
 

--- a/templating.go
+++ b/templating.go
@@ -840,3 +840,217 @@ func readRequestBody(r *http.Request) []byte {
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	return body
 }
+
+// parseCoercion splits a template expression into the expression body and
+// an optional type coercion. Returns the expression without the coercion
+// pipe, the coercion type (or ""), and whether a coercion was found.
+//
+// Examples:
+//
+//	"pathParam.id | int"          -> ("pathParam.id", "int", true)
+//	"pathParam.id"                -> ("pathParam.id", "", false)
+//	"faker.name seed=foo"         -> ("faker.name seed=foo", "", false)
+//	"request.query.page | float"  -> ("request.query.page", "float", true)
+func parseCoercion(raw string) (expr string, coercion string, ok bool) {
+	// Look for " | type" at the end. Coercion pipes are always preceded and
+	// followed by whitespace.
+	idx := strings.LastIndex(raw, " | ")
+	if idx < 0 {
+		return raw, "", false
+	}
+
+	// The coercion type is the token after the last " | ".
+	candidate := strings.TrimSpace(raw[idx+3:])
+	switch candidate {
+	case "int", "float", "bool":
+		return strings.TrimSpace(raw[:idx]), candidate, true
+	default:
+		// Not a recognized coercion -- treat the entire string as the expression.
+		return raw, "", false
+	}
+}
+
+// coerceValue converts a string value to the specified type. Supported
+// coercions: "int" (float64 with integer value), "float" (float64),
+// "bool" (bool). Returns the typed value or an error if conversion fails.
+func coerceValue(s string, coercion string) (any, error) {
+	switch coercion {
+	case "int":
+		f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return nil, fmt.Errorf("httptape: coercion | int: cannot parse %q as number: %w", s, err)
+		}
+		// Truncate to integer, emit as float64 (JSON number).
+		return math.Trunc(f), nil
+	case "float":
+		f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return nil, fmt.Errorf("httptape: coercion | float: cannot parse %q as number: %w", s, err)
+		}
+		return f, nil
+	case "bool":
+		b, err := strconv.ParseBool(strings.TrimSpace(s))
+		if err != nil {
+			return nil, fmt.Errorf("httptape: coercion | bool: cannot parse %q as boolean: %w", s, err)
+		}
+		return b, nil
+	default:
+		return s, nil
+	}
+}
+
+// resolveExemplarBody resolves template expressions in an exemplar tape's
+// response body. The dispatch is based on the response Content-Type:
+//   - JSON: unmarshal, walk with coercion-aware resolution, re-marshal.
+//   - Text: byte-level template substitution (existing ResolveTemplateBody).
+//   - Binary: no resolution.
+func resolveExemplarBody(body []byte, headers http.Header, ctx *templateCtx, strict bool) ([]byte, error) {
+	if len(body) == 0 || !bytes.Contains(body, []byte("{{")) {
+		return body, nil
+	}
+
+	ct := ""
+	if headers != nil {
+		ct = headers.Get("Content-Type")
+	}
+
+	mt, parseErr := ParseMediaType(ct)
+	if parseErr == nil && IsJSON(mt) {
+		return resolveTemplateJSONWithCoercion(body, ctx, strict)
+	}
+	if parseErr == nil && IsBinary(mt) {
+		// Binary: no template resolution.
+		return body, nil
+	}
+	// Text or unknown: use standard byte-level resolution.
+	return resolveTemplateBytes(body, ctx, strict)
+}
+
+// resolveTemplateJSONWithCoercion resolves template expressions in a JSON
+// body, supporting type coercion via the | int, | float, | bool pipe syntax.
+// When a string value is a single template expression with a coercion suffix,
+// the resolved string value is converted to the specified type (producing a
+// JSON number or boolean instead of a string).
+func resolveTemplateJSONWithCoercion(body []byte, ctx *templateCtx, strict bool) ([]byte, error) {
+	var data any
+	if err := json.Unmarshal(body, &data); err != nil {
+		// Not valid JSON -- fall back to byte-level substitution.
+		return resolveTemplateBytes(body, ctx, strict)
+	}
+
+	var walkErr error
+	data = walkJSONWithCoercion(data, ctx, strict, &walkErr)
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	result, err := json.Marshal(data)
+	if err != nil {
+		return body, nil
+	}
+	return result, nil
+}
+
+// walkJSONWithCoercion recursively walks a JSON tree and resolves template
+// expressions in string values, with support for type coercion. When a string
+// value is entirely a single {{...}} expression with a | int/float/bool pipe,
+// the resolved value's type is changed from string to the target type.
+func walkJSONWithCoercion(data any, ctx *templateCtx, strict bool, errOut *error) any {
+	if *errOut != nil {
+		return data
+	}
+
+	switch v := data.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(v))
+		for key, val := range v {
+			result[key] = walkJSONWithCoercion(val, ctx, strict, errOut)
+		}
+		return result
+	case []any:
+		result := make([]any, len(v))
+		for i, val := range v {
+			result[i] = walkJSONWithCoercion(val, ctx, strict, errOut)
+		}
+		return result
+	case string:
+		if !strings.Contains(v, "{{") {
+			return v
+		}
+		return resolveStringWithCoercion(v, ctx, strict, errOut)
+	default:
+		return data
+	}
+}
+
+// resolveStringWithCoercion resolves template expressions in a string value
+// within a JSON context. If the entire string is a single template expression
+// with a type coercion pipe (e.g., "{{pathParam.id | int}}"), the result is
+// a typed value (float64 or bool). Otherwise, the result is a string.
+func resolveStringWithCoercion(s string, ctx *templateCtx, strict bool, errOut *error) any {
+	src := []byte(s)
+	exprs := scanTemplateExprs(src)
+	if len(exprs) == 0 {
+		return s
+	}
+
+	// Check if the entire string is a single template expression (possibly with coercion).
+	if len(exprs) == 1 && exprs[0].start == 0 && exprs[0].end == len(src) {
+		rawExpr := exprs[0].raw
+		exprBody, coercion, hasCoercion := parseCoercion(rawExpr)
+
+		resolved, ok := resolveExpr(exprBody, ctx)
+		if !ok {
+			if strict {
+				*errOut = fmt.Errorf("httptape: unresolvable template expression: {{%s}}", rawExpr)
+				return s
+			}
+			if hasCoercion {
+				return ""
+			}
+			return ""
+		}
+
+		if hasCoercion {
+			typed, err := coerceValue(resolved, coercion)
+			if err != nil {
+				if strict {
+					*errOut = err
+					return s
+				}
+				// Lenient: return the uncoerced string value.
+				return resolved
+			}
+			return typed
+		}
+		return resolved
+	}
+
+	// Mixed content: multiple expressions or expressions with surrounding text.
+	// Resolve all expressions and concatenate as a string.
+	// Coercion in mixed content is not supported.
+	var buf bytes.Buffer
+	buf.Grow(len(s))
+	prev := 0
+
+	for _, expr := range exprs {
+		buf.Write(src[prev:expr.start])
+		rawExpr := expr.raw
+
+		// Strip coercion if present (mixed content ignores it).
+		exprBody, _, _ := parseCoercion(rawExpr)
+		resolved, ok := resolveExpr(exprBody, ctx)
+		if !ok {
+			if strict {
+				*errOut = fmt.Errorf("httptape: unresolvable template expression: {{%s}}", rawExpr)
+				return s
+			}
+			// Lenient: empty string.
+		} else {
+			buf.WriteString(resolved)
+		}
+		prev = expr.end
+	}
+	buf.Write(src[prev:])
+	return buf.String()
+}

--- a/templating_test.go
+++ b/templating_test.go
@@ -1364,3 +1364,397 @@ func TestFindMatchingClose(t *testing.T) {
 		})
 	}
 }
+
+// --- ADR-43: Type coercion tests ---
+
+func TestParseCoercion(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantExpr string
+		wantType string
+		wantOK   bool
+	}{
+		{
+			name:     "int coercion",
+			raw:      "pathParam.id | int",
+			wantExpr: "pathParam.id",
+			wantType: "int",
+			wantOK:   true,
+		},
+		{
+			name:     "float coercion",
+			raw:      "request.query.price | float",
+			wantExpr: "request.query.price",
+			wantType: "float",
+			wantOK:   true,
+		},
+		{
+			name:     "bool coercion",
+			raw:      "request.query.active | bool",
+			wantExpr: "request.query.active",
+			wantType: "bool",
+			wantOK:   true,
+		},
+		{
+			name:     "no coercion",
+			raw:      "pathParam.id",
+			wantExpr: "pathParam.id",
+			wantType: "",
+			wantOK:   false,
+		},
+		{
+			name:     "faker with seed (no coercion)",
+			raw:      "faker.name seed=foo",
+			wantExpr: "faker.name seed=foo",
+			wantType: "",
+			wantOK:   false,
+		},
+		{
+			name:     "unknown coercion type treated as no coercion",
+			raw:      "pathParam.id | string",
+			wantExpr: "pathParam.id | string",
+			wantType: "",
+			wantOK:   false,
+		},
+		{
+			name:     "faker with coercion",
+			raw:      "faker.randomInt seed=x min=1 max=100 | int",
+			wantExpr: "faker.randomInt seed=x min=1 max=100",
+			wantType: "int",
+			wantOK:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotExpr, gotType, gotOK := parseCoercion(tt.raw)
+			if gotExpr != tt.wantExpr {
+				t.Errorf("parseCoercion(%q) expr = %q, want %q", tt.raw, gotExpr, tt.wantExpr)
+			}
+			if gotType != tt.wantType {
+				t.Errorf("parseCoercion(%q) type = %q, want %q", tt.raw, gotType, tt.wantType)
+			}
+			if gotOK != tt.wantOK {
+				t.Errorf("parseCoercion(%q) ok = %v, want %v", tt.raw, gotOK, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestCoerceValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		coercion string
+		want     any
+		wantErr  bool
+	}{
+		{name: "int from integer string", s: "42", coercion: "int", want: float64(42)},
+		{name: "int from float string truncates", s: "42.7", coercion: "int", want: float64(42)},
+		{name: "int from invalid string", s: "abc", coercion: "int", wantErr: true},
+		{name: "float from valid string", s: "19.99", coercion: "float", want: float64(19.99)},
+		{name: "float from integer string", s: "42", coercion: "float", want: float64(42)},
+		{name: "float from invalid string", s: "xyz", coercion: "float", wantErr: true},
+		{name: "bool from true", s: "true", coercion: "bool", want: true},
+		{name: "bool from false", s: "false", coercion: "bool", want: false},
+		{name: "bool from 1", s: "1", coercion: "bool", want: true},
+		{name: "bool from invalid string", s: "maybe", coercion: "bool", wantErr: true},
+		{name: "unknown coercion returns string", s: "hello", coercion: "unknown", want: "hello"},
+		{name: "int with whitespace", s: " 42 ", coercion: "int", want: float64(42)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := coerceValue(tt.s, tt.coercion)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("coerceValue(%q, %q) = %v, want error", tt.s, tt.coercion, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("coerceValue(%q, %q) unexpected error: %v", tt.s, tt.coercion, err)
+			}
+			if got != tt.want {
+				t.Errorf("coerceValue(%q, %q) = %v (%T), want %v (%T)", tt.s, tt.coercion, got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_Object(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/alice", nil),
+		pathParams: map[string]string{"name": "alice"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"name":"{{pathParam.name}}"}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := `{"name":"alice"}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_NestedObject(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/42", nil),
+		pathParams: map[string]string{"id": "42"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"user":{"id":"{{pathParam.id | int}}"}}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := `{"user":{"id":42}}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_Array(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/1", nil),
+		pathParams: map[string]string{"id": "1"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`[{"id":"{{pathParam.id | int}}"}]`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := `[{"id":1}]`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_NonStringLeaf(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/", nil),
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"count":5,"active":true}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := `{"active":true,"count":5}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_MixedContent(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/alice", nil),
+		pathParams: map[string]string{"name": "alice"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"greeting":"Hello, {{pathParam.name}}!"}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := `{"greeting":"Hello, alice!"}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_CoercionInt(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/42", nil),
+		pathParams: map[string]string{"id": "42"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"id":"{{pathParam.id | int}}"}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The value should be a JSON number, not a string.
+	want := `{"id":42}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_CoercionFloat(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/items?price=19.99", nil),
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"price":"{{request.query.price | float}}"}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := `{"price":19.99}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_CoercionBool(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/items?active=true", nil),
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"active":"{{request.query.active | bool}}"}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := `{"active":true}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_CoercionFailure_Strict(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/abc", nil),
+		pathParams: map[string]string{"id": "abc"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"id":"{{pathParam.id | int}}"}`)
+	_, err := resolveTemplateJSONWithCoercion(body, ctx, true)
+	if err == nil {
+		t.Error("expected error for strict coercion failure, got nil")
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_CoercionFailure_Lenient(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/abc", nil),
+		pathParams: map[string]string{"id": "abc"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"id":"{{pathParam.id | int}}"}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error in lenient mode: %v", err)
+	}
+
+	// Lenient mode: uncoerced string value is emitted.
+	want := `{"id":"abc"}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTemplateJSONWithCoercion_NoTemplates(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/", nil),
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	body := []byte(`{"id":1,"name":"Alice"}`)
+	got, err := resolveTemplateJSONWithCoercion(body, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// JSON keys are sorted by Go's json.Marshal.
+	want := `{"id":1,"name":"Alice"}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveExemplarBody_JSON(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/42", nil),
+		pathParams: map[string]string{"id": "42"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	headers := http.Header{"Content-Type": {"application/json"}}
+	body := []byte(`{"id":"{{pathParam.id | int}}","name":"{{pathParam.id}}"}`)
+	got, err := resolveExemplarBody(body, headers, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := `{"id":42,"name":"42"}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveExemplarBody_Text(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/users/42", nil),
+		pathParams: map[string]string{"id": "42"},
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	headers := http.Header{"Content-Type": {"text/plain"}}
+	body := []byte("User ID: {{pathParam.id}}")
+	got, err := resolveExemplarBody(body, headers, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := "User ID: 42"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveExemplarBody_Binary_NoResolution(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/", nil),
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	headers := http.Header{"Content-Type": {"image/png"}}
+	body := []byte{0x89, 0x50, 0x4E, 0x47}
+	got, err := resolveExemplarBody(body, headers, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !bytes.Equal(got, body) {
+		t.Errorf("binary body should be unchanged, got %v, want %v", got, body)
+	}
+}
+
+func TestResolveExemplarBody_EmptyBody(t *testing.T) {
+	ctx := &templateCtx{
+		req:        httptest.NewRequest("GET", "/", nil),
+		randSource: bytes.NewReader(make([]byte, 256)),
+	}
+
+	got, err := resolveExemplarBody(nil, nil, ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil body, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #199

## Summary

Implements synthesis mode (ADR-43) -- exemplar tapes with URL patterns and template expressions generate responses for unmatched URLs.

**New public API surface:**
- `Tape.Exemplar bool` -- marks a tape as a pattern-based template
- `RecordedReq.URLPattern string` -- colon-prefixed path pattern (e.g., `/users/:id`)
- `WithSynthesis() ServerOption` -- enables exemplar fallback on the Server
- `ValidateTape(t Tape) error` -- structural validation (calls ValidateExemplar)
- `ValidateExemplar(t Tape) error` -- exemplar-specific constraint checks
- `--synthesize` CLI flag for `httptape serve`

**Type coercion in JSON bodies:**
- `| int`, `| float`, `| bool` pipes convert resolved template strings to native JSON types
- Only effective in JSON response bodies of exemplar tapes
- Strict mode: coercion failure returns HTTP 500; lenient mode: emits uncoerced string

**Two-phase match flow:**
1. Phase 1: exact tapes checked first via existing matcher
2. Phase 2: exemplar fallback (only when synthesis enabled and phase 1 misses)
3. Exemplars must pass all configured criteria (method, headers, body_fuzzy, etc.)

**Opt-in design (fail-safe defaults):**
- Synthesis disabled by default -- integration tests are unaffected
- Exemplar tapes are loaded but never consulted unless `WithSynthesis()` is set
- CLI warns when exemplar tapes exist but synthesis is disabled

**Startup validation:**
- CLI validates all loaded tapes at startup
- Invalid exemplar tapes (missing url_pattern, SSE exemplar, etc.) cause startup error

## Test plan

- [x] `TestValidateExemplar` -- all 7 validation rules (valid exemplar, missing url_pattern, mutual exclusivity, SSE rejection, etc.)
- [x] `TestValidateTape_DelegatesToValidateExemplar` -- ValidateTape dispatches to ValidateExemplar
- [x] `TestTape_MarshalJSON_Exemplar` -- exemplar fields appear in JSON output
- [x] `TestTape_UnmarshalJSON_Exemplar` -- exemplar fields parsed correctly
- [x] `TestTape_UnmarshalJSON_NoExemplar` -- backward compatibility (no exemplar fields)
- [x] `TestTape_MarshalJSON_RoundTrip_Exemplar` -- marshal/unmarshal/re-marshal identity
- [x] `TestServer_SynthesisDisabled_ExemplarIgnored` -- 404 when synthesis off
- [x] `TestServer_SynthesisEnabled_ExactWins` -- exact tape beats exemplar
- [x] `TestServer_SynthesisEnabled_ExemplarFallback` -- exemplar consulted on miss
- [x] `TestServer_SynthesisEnabled_MostSpecificExemplar` -- /users/:id/orders wins over /users/:id
- [x] `TestServer_SynthesisEnabled_MethodFilter` -- POST doesn't match GET exemplar
- [x] `TestServer_SynthesisEnabled_NoExemplars` -- 404 when no exemplars exist
- [x] `TestServer_SynthesisEnabled_DeterministicResponse` -- same request = same output
- [x] `TestServer_SynthesisEnabled_ExemplarWithTextBody` -- text/plain body resolution
- [x] `TestServer_SynthesisEnabled_PatternWithNoParams` -- exact path exemplar works
- [x] `TestParseCoercion` -- 7 cases including edge cases
- [x] `TestCoerceValue` -- int, float, bool, error, whitespace handling
- [x] `TestResolveTemplateJSONWithCoercion_*` -- 10 tests covering objects, arrays, nesting, coercion, mixed content, strict/lenient failure
- [x] `TestResolveExemplarBody_*` -- JSON, text, binary, empty body dispatch
- [x] `TestIntegration_ExemplarSynthesis` -- end-to-end with httptest.NewServer
- [x] `TestIntegration_SynthesisDisabled_ExemplarIgnored` -- end-to-end negative case
- [x] `TestServeWithSynthesize` -- CLI flag acceptance
- [x] `TestServeWithSynthesizeLogging` -- CLI with exemplar fixture
- [x] `TestServeWithInvalidExemplarTape` -- startup validation rejects bad exemplar
- [x] All existing tests pass (no regressions)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` clean
- [x] `gofmt -l .` clean (only pre-existing issues in unmodified files)

Generated with [Claude Code](https://claude.com/claude-code)