### PR TITLE
feat(#208): WithCacheLookupDisabled() option (replaces neverMatcher workaround)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`WithCacheLookupDisabled()`**: CachingOption that disables the cache
+  hit path entirely. Every request is forwarded to upstream and recorded.
+  Single-flight dedup, SSE tee, sanitization, and stale fallback remain
+  active. Replaces the internal `neverMatcher` workaround used by Proxy. (#208)
+
 - **Template helpers**: `{{now}}`, `{{uuid}}`, `{{randomHex}}`, `{{randomInt}}`,
   `{{counter}}`, and `{{faker.*}}` template expressions in response bodies and
   headers. Helpers support keyword arguments (e.g., `{{now format=unix}}`). (#196)

--- a/caching_transport.go
+++ b/caching_transport.go
@@ -31,9 +31,10 @@ type CachingTransport struct {
 	onError     func(error)
 	cacheFilter func(*http.Response) bool
 
-	singleFlight bool
-	maxBodySize  int
-	sseRecording bool
+	singleFlight   bool
+	lookupDisabled bool
+	maxBodySize    int
+	sseRecording   bool
 
 	// stale-fallback (#164)
 	staleFallback   bool
@@ -143,6 +144,25 @@ func WithCacheSSERecording(enabled bool) CachingOption {
 	}
 }
 
+// WithCacheLookupDisabled disables the cache hit path entirely.
+// Every request is treated as a miss: forwarded to upstream, recorded
+// via the sanitization pipeline (if configured), and returned.
+// Single-flight dedup, SSE tee, and sanitization remain active.
+//
+// The configured Matcher is still used by stale fallback
+// (WithCacheUpstreamDownFallback), so the two options compose:
+// disable the hit path but still serve stale tapes when upstream is down.
+//
+// Useful when the embedder owns its own hit-path logic (e.g., Proxy
+// uses an L1 store consulted before this transport runs) and wants
+// CachingTransport's other cross-cutting concerns without the cache
+// lookup it would otherwise perform.
+func WithCacheLookupDisabled() CachingOption {
+	return func(ct *CachingTransport) {
+		ct.lookupDisabled = true
+	}
+}
+
 // WithCacheUpstreamDownFallback enables stale-response fallback when
 // upstream is unreachable or returns a transport error on a cache miss.
 // When enabled, CachingTransport searches the store for the best-matching
@@ -249,31 +269,33 @@ func (ct *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		}
 	}
 
-	// 4. Cache lookup.
-	tapes, listErr := ct.store.List(req.Context(), Filter{Route: ct.route})
-	if listErr != nil {
-		// Store failure on lookup: proceed as miss.
-		ct.onErrorSafe(fmt.Errorf("httptape: caching transport store list: %w", listErr))
-		tapes = nil
-	}
+	// 4. Cache lookup (skipped when lookupDisabled is true).
+	if !ct.lookupDisabled {
+		tapes, listErr := ct.store.List(req.Context(), Filter{Route: ct.route})
+		if listErr != nil {
+			// Store failure on lookup: proceed as miss.
+			ct.onErrorSafe(fmt.Errorf("httptape: caching transport store list: %w", listErr))
+			tapes = nil
+		}
 
-	// Restore body for matcher consumption.
-	if reqBody != nil {
-		req.Body = io.NopCloser(bytes.NewReader(reqBody))
-	}
+		// Restore body for matcher consumption.
+		if reqBody != nil {
+			req.Body = io.NopCloser(bytes.NewReader(reqBody))
+		}
 
-	if tapes != nil {
-		tape, ok := ct.matcher.Match(req, tapes)
-		if ok {
-			// 5. HIT: synthesize response from tape.
-			if tape.Response.IsSSE() {
-				return ct.sseResponseFromTape(tape), nil
+		if tapes != nil {
+			tape, ok := ct.matcher.Match(req, tapes)
+			if ok {
+				// 5. HIT: synthesize response from tape.
+				if tape.Response.IsSSE() {
+					return ct.sseResponseFromTape(tape), nil
+				}
+				return ct.tapeToResponse(tape), nil
 			}
-			return ct.tapeToResponse(tape), nil
 		}
 	}
 
-	// Restore body again before upstream call.
+	// Restore body before upstream call.
 	if reqBody != nil {
 		req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	}

--- a/caching_transport_test.go
+++ b/caching_transport_test.go
@@ -1417,3 +1417,167 @@ func TestCachingTransport_SingleFlightStaleFallbackForWaiters(t *testing.T) {
 		}
 	}
 }
+
+// --- WithCacheLookupDisabled tests ---
+
+// spyStore wraps a MemoryStore and counts List calls. Used to verify that
+// Store.List is not called when cache lookup is disabled.
+type spyStore struct {
+	*MemoryStore
+	listCalls atomic.Int64
+}
+
+func (s *spyStore) List(ctx context.Context, filter Filter) ([]Tape, error) {
+	s.listCalls.Add(1)
+	return s.MemoryStore.List(ctx, filter)
+}
+
+func TestCachingTransport_LookupDisabledAlwaysMisses(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	// Pre-seed the store with a tape that would match.
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/data",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("cached-response"),
+	})
+	store.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("from-upstream")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheLookupDisabled(),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "from-upstream" {
+		t.Errorf("got body %q, want %q (lookup disabled should bypass cache)", string(body), "from-upstream")
+	}
+}
+
+func TestCachingTransport_LookupDisabledStillRecords(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("recorded-response")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheLookupDisabled(),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// Verify the response was persisted to the store.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("store has %d tapes, want 1 (recording-only mode)", len(tapes))
+	}
+	if string(tapes[0].Response.Body) != "recorded-response" {
+		t.Errorf("stored body %q, want %q", string(tapes[0].Response.Body), "recorded-response")
+	}
+}
+
+func TestCachingTransport_LookupDisabledWithStaleFallback(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	// Pre-seed the store with a matching tape.
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/data",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("stale-data"),
+	})
+	store.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("upstream down")
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheLookupDisabled(),
+		WithCacheUpstreamDownFallback(true),
+		WithCacheSingleFlight(false),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "stale-data" {
+		t.Errorf("got body %q, want %q", string(body), "stale-data")
+	}
+	if stale := resp.Header.Get("X-Httptape-Stale"); stale != "true" {
+		t.Errorf("got X-Httptape-Stale=%q, want %q", stale, "true")
+	}
+}
+
+func TestCachingTransport_LookupDisabledSkipsStoreList(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyStore{MemoryStore: NewMemoryStore()}
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, spy,
+		WithCacheLookupDisabled(),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	if calls := spy.listCalls.Load(); calls != 0 {
+		t.Errorf("Store.List was called %d times, want 0 (lookup disabled should skip store query)", calls)
+	}
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -141,6 +141,7 @@ Panics if `upstream` or `store` is nil.
 | WithCacheRoute | `WithCacheRoute(route string)` | `""` |
 | WithCacheOnError | `WithCacheOnError(fn func(error))` | no-op |
 | WithCacheSSERecording | `WithCacheSSERecording(enabled bool)` | `true` |
+| WithCacheLookupDisabled | `WithCacheLookupDisabled()` | `false` |
 | WithCacheUpstreamDownFallback | `WithCacheUpstreamDownFallback(enabled bool)` | `false` |
 | WithCacheUpstreamTimeout | `WithCacheUpstreamTimeout(d time.Duration)` | `0` (no timeout) |
 

--- a/docs/caching-transport.md
+++ b/docs/caching-transport.md
@@ -159,6 +159,20 @@ httptape.WithCacheSSERecording(false) // disable
 
 Controls whether SSE (Server-Sent Events) stream recording is enabled. When enabled, SSE responses on the miss path are tee'd to the caller while events are accumulated and persisted as a tape. See [SSE recording](#sse-recording) below.
 
+### WithCacheLookupDisabled
+
+```go
+httptape.WithCacheLookupDisabled()
+```
+
+Disables the cache hit path entirely. Every request is treated as a miss: forwarded to upstream, recorded via the sanitization pipeline (if configured), and returned. Single-flight dedup, SSE tee, and sanitization remain active.
+
+The configured Matcher is still used by stale fallback (`WithCacheUpstreamDownFallback`), so the two options compose: disable the hit path but still serve stale tapes when upstream is down.
+
+Useful when the embedder owns its own hit-path logic (e.g., Proxy uses an L1 store consulted before this transport runs) and wants CachingTransport's other cross-cutting concerns without the cache lookup it would otherwise perform.
+
+Unlike using a never-matching Matcher, this option skips `Store.List` entirely on the hot path, avoiding unnecessary I/O.
+
 ### WithCacheUpstreamDownFallback
 
 ```go

--- a/proxy.go
+++ b/proxy.go
@@ -97,16 +97,6 @@ type Proxy struct {
 	upstreamURLHint string
 }
 
-// neverMatcher is a Matcher that never matches any request. It is used
-// by Proxy's internal CachingTransport to ensure every request is treated
-// as a cache miss and forwarded to upstream. Proxy handles its own
-// L1/L2 cache lookup in the fallback path with the user-configured matcher.
-type neverMatcher struct{}
-
-func (neverMatcher) Match(_ *http.Request, _ []Tape) (Tape, bool) {
-	return Tape{}, false
-}
-
 // l1RecordingTransport wraps an http.RoundTripper to intercept upstream
 // responses and save raw (unsanitized) tapes to the L1 store. This is
 // used by Proxy to inject L1 recording into CachingTransport's miss path
@@ -157,8 +147,12 @@ func (t *l1RecordingTransport) RoundTrip(req *http.Request) (*http.Response, err
 	if req.GetBody != nil {
 		body, gbErr := req.GetBody()
 		if gbErr == nil {
-			reqBody, _ = io.ReadAll(body)
+			var readErr error
+			reqBody, readErr = io.ReadAll(body)
 			body.Close()
+			if readErr != nil {
+				t.onErrorSafe(fmt.Errorf("httptape: l1 recording read request body: %w", readErr))
+			}
 		}
 	}
 
@@ -541,10 +535,11 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) (*Proxy, error) {
 	// CachingTransport handles: upstream forwarding (via l1RecordingTransport),
 	// sanitization, L2 recording, SSE tee recording, single-flight dedup.
 	//
-	// neverMatcher ensures CachingTransport always treats requests as cache
-	// misses. Proxy handles its own L1/L2 lookup in the fallback path using
-	// the user-configured matcher. This preserves the original Proxy semantics
-	// where the upstream is always consulted first (caches are fallback-only).
+	// WithCacheLookupDisabled ensures CachingTransport skips the cache hit
+	// path entirely (no Store.List, no Matcher.Match). Proxy handles its own
+	// L1/L2 lookup in the fallback path using the user-configured matcher.
+	// This preserves the original Proxy semantics where the upstream is always
+	// consulted first (caches are fallback-only).
 	//
 	// The cacheFilter prevents CachingTransport from recording responses that
 	// would trigger Proxy's fallback. In the original Proxy, fallback-triggering
@@ -556,7 +551,7 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) (*Proxy, error) {
 	}
 
 	p.ct = NewCachingTransport(l1RT, p.l2,
-		WithCacheMatcher(neverMatcher{}),
+		WithCacheLookupDisabled(),
 		WithCacheSanitizer(p.sanitizer),
 		WithCacheRoute(p.route),
 		WithCacheOnError(p.onError),
@@ -606,8 +601,8 @@ func (p *Proxy) Close() error {
 // RoundTrip implements http.RoundTripper. The request flow is:
 //
 //  1. Capture request body (needed for fallback matching).
-//  2. Forward to CachingTransport.RoundTrip. CachingTransport always
-//     treats the request as a cache miss (neverMatcher) and forwards to
+//  2. Forward to CachingTransport.RoundTrip. CachingTransport has cache
+//     lookup disabled (WithCacheLookupDisabled) so it always forwards to
 //     upstream via l1RecordingTransport (saves raw to L1), then sanitizes
 //     and saves to L2.
 //  3. On success: check isFallback. If true (e.g., 5xx fallback), enter
@@ -630,10 +625,10 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	// 2. Forward to CachingTransport. CachingTransport uses a neverMatcher
-	// so it always treats the request as a cache miss and forwards to
-	// upstream via l1RecordingTransport (which saves raw to L1).
-	// CachingTransport then sanitizes and saves to L2.
+	// 2. Forward to CachingTransport. CachingTransport has cache lookup
+	// disabled so it always forwards to upstream via l1RecordingTransport
+	// (which saves raw to L1). CachingTransport then sanitizes and saves
+	// to L2.
 	resp, transportErr := p.ct.RoundTrip(req)
 
 	// 3. Decide: success or fallback?


### PR DESCRIPTION
Closes #208

## Summary

- Add `WithCacheLookupDisabled()` CachingOption that disables the cache hit path entirely. When set, `RoundTrip` skips `Store.List` and `Matcher.Match`, jumping straight to the miss path. Single-flight dedup, SSE tee, sanitization, and stale fallback remain active.
- Delete the unexported `neverMatcher` type from `proxy.go`. Proxy now uses `WithCacheLookupDisabled()` instead of `WithCacheMatcher(neverMatcher{})`.
- Fix swallowed `io.ReadAll` error in `l1RecordingTransport.RoundTrip` (proxy.go line 160) -- now invokes `onError` consistently with the response body read a few lines later.
- Update `docs/caching-transport.md` and `docs/api-reference.md` with new option documentation.
- Add CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `TestCachingTransport_LookupDisabledAlwaysMisses` -- pre-seeded cache is bypassed, upstream is contacted
- [x] `TestCachingTransport_LookupDisabledStillRecords` -- responses are still persisted to the store
- [x] `TestCachingTransport_LookupDisabledWithStaleFallback` -- stale fallback still works when lookup is disabled (key semantic difference vs neverMatcher)
- [x] `TestCachingTransport_LookupDisabledSkipsStoreList` -- spy store confirms `Store.List` is NOT called (validates perf benefit)
- [x] All existing tests pass: `go test -race -count=1 ./...`
- [x] `go build ./...` and `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)