### PR TITLE
docs(#197): ADR-47 inbound TLS listener design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`WithCacheLookupDisabled()`**: CachingOption that disables the cache
+  hit path entirely. Every request is forwarded to upstream and recorded.
+  Single-flight dedup, SSE tee, sanitization, and stale fallback remain
+  active. Replaces the internal `neverMatcher` workaround used by Proxy. (#208)
+
 - **Template helpers**: `{{now}}`, `{{uuid}}`, `{{randomHex}}`, `{{randomInt}}`,
   `{{counter}}`, and `{{faker.*}}` template expressions in response bodies and
   headers. Helpers support keyword arguments (e.g., `{{now format=unix}}`). (#196)

--- a/caching_transport.go
+++ b/caching_transport.go
@@ -31,9 +31,10 @@ type CachingTransport struct {
 	onError     func(error)
 	cacheFilter func(*http.Response) bool
 
-	singleFlight bool
-	maxBodySize  int
-	sseRecording bool
+	singleFlight   bool
+	lookupDisabled bool
+	maxBodySize    int
+	sseRecording   bool
 
 	// stale-fallback (#164)
 	staleFallback   bool
@@ -143,6 +144,25 @@ func WithCacheSSERecording(enabled bool) CachingOption {
 	}
 }
 
+// WithCacheLookupDisabled disables the cache hit path entirely.
+// Every request is treated as a miss: forwarded to upstream, recorded
+// via the sanitization pipeline (if configured), and returned.
+// Single-flight dedup, SSE tee, and sanitization remain active.
+//
+// The configured Matcher is still used by stale fallback
+// (WithCacheUpstreamDownFallback), so the two options compose:
+// disable the hit path but still serve stale tapes when upstream is down.
+//
+// Useful when the embedder owns its own hit-path logic (e.g., Proxy
+// uses an L1 store consulted before this transport runs) and wants
+// CachingTransport's other cross-cutting concerns without the cache
+// lookup it would otherwise perform.
+func WithCacheLookupDisabled() CachingOption {
+	return func(ct *CachingTransport) {
+		ct.lookupDisabled = true
+	}
+}
+
 // WithCacheUpstreamDownFallback enables stale-response fallback when
 // upstream is unreachable or returns a transport error on a cache miss.
 // When enabled, CachingTransport searches the store for the best-matching
@@ -249,31 +269,33 @@ func (ct *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		}
 	}
 
-	// 4. Cache lookup.
-	tapes, listErr := ct.store.List(req.Context(), Filter{Route: ct.route})
-	if listErr != nil {
-		// Store failure on lookup: proceed as miss.
-		ct.onErrorSafe(fmt.Errorf("httptape: caching transport store list: %w", listErr))
-		tapes = nil
-	}
+	// 4. Cache lookup (skipped when lookupDisabled is true).
+	if !ct.lookupDisabled {
+		tapes, listErr := ct.store.List(req.Context(), Filter{Route: ct.route})
+		if listErr != nil {
+			// Store failure on lookup: proceed as miss.
+			ct.onErrorSafe(fmt.Errorf("httptape: caching transport store list: %w", listErr))
+			tapes = nil
+		}
 
-	// Restore body for matcher consumption.
-	if reqBody != nil {
-		req.Body = io.NopCloser(bytes.NewReader(reqBody))
-	}
+		// Restore body for matcher consumption.
+		if reqBody != nil {
+			req.Body = io.NopCloser(bytes.NewReader(reqBody))
+		}
 
-	if tapes != nil {
-		tape, ok := ct.matcher.Match(req, tapes)
-		if ok {
-			// 5. HIT: synthesize response from tape.
-			if tape.Response.IsSSE() {
-				return ct.sseResponseFromTape(tape), nil
+		if tapes != nil {
+			tape, ok := ct.matcher.Match(req, tapes)
+			if ok {
+				// 5. HIT: synthesize response from tape.
+				if tape.Response.IsSSE() {
+					return ct.sseResponseFromTape(tape), nil
+				}
+				return ct.tapeToResponse(tape), nil
 			}
-			return ct.tapeToResponse(tape), nil
 		}
 	}
 
-	// Restore body again before upstream call.
+	// Restore body before upstream call.
 	if reqBody != nil {
 		req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	}

--- a/caching_transport_test.go
+++ b/caching_transport_test.go
@@ -1417,3 +1417,167 @@ func TestCachingTransport_SingleFlightStaleFallbackForWaiters(t *testing.T) {
 		}
 	}
 }
+
+// --- WithCacheLookupDisabled tests ---
+
+// spyStore wraps a MemoryStore and counts List calls. Used to verify that
+// Store.List is not called when cache lookup is disabled.
+type spyStore struct {
+	*MemoryStore
+	listCalls atomic.Int64
+}
+
+func (s *spyStore) List(ctx context.Context, filter Filter) ([]Tape, error) {
+	s.listCalls.Add(1)
+	return s.MemoryStore.List(ctx, filter)
+}
+
+func TestCachingTransport_LookupDisabledAlwaysMisses(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	// Pre-seed the store with a tape that would match.
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/data",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("cached-response"),
+	})
+	store.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("from-upstream")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheLookupDisabled(),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "from-upstream" {
+		t.Errorf("got body %q, want %q (lookup disabled should bypass cache)", string(body), "from-upstream")
+	}
+}
+
+func TestCachingTransport_LookupDisabledStillRecords(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("recorded-response")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheLookupDisabled(),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	// Verify the response was persisted to the store.
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("store has %d tapes, want 1 (recording-only mode)", len(tapes))
+	}
+	if string(tapes[0].Response.Body) != "recorded-response" {
+		t.Errorf("stored body %q, want %q", string(tapes[0].Response.Body), "recorded-response")
+	}
+}
+
+func TestCachingTransport_LookupDisabledWithStaleFallback(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	// Pre-seed the store with a matching tape.
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api/data",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("stale-data"),
+	})
+	store.Save(context.Background(), tape)
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("upstream down")
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheLookupDisabled(),
+		WithCacheUpstreamDownFallback(true),
+		WithCacheSingleFlight(false),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "stale-data" {
+		t.Errorf("got body %q, want %q", string(body), "stale-data")
+	}
+	if stale := resp.Header.Get("X-Httptape-Stale"); stale != "true" {
+		t.Errorf("got X-Httptape-Stale=%q, want %q", stale, "true")
+	}
+}
+
+func TestCachingTransport_LookupDisabledSkipsStoreList(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyStore{MemoryStore: NewMemoryStore()}
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, spy,
+		WithCacheLookupDisabled(),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/data", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	if calls := spy.listCalls.Load(); calls != 0 {
+		t.Errorf("Store.List was called %d times, want 0 (lookup disabled should skip store query)", calls)
+	}
+}

--- a/decisions.md
+++ b/decisions.md
@@ -16171,3 +16171,386 @@ conforming to it.
   changes needed.
 - **No impact on `NewRecorder`, `NewCachingTransport`, `NewMemoryStore`,
   `NewHealthMonitor`** — their signatures remain unchanged.
+
+---
+
+### ADR-47: Inbound TLS listener (self-signed cert or user-provided)
+
+**Date**: 2026-04-23
+**Issue**: #197
+**Status**: Accepted
+
+#### Context
+
+httptape currently listens on plain HTTP only. Outbound TLS (httptape to
+upstream) is well-supported via `BuildTLSConfig` and the `--tls-cert`,
+`--tls-key`, `--tls-ca`, `--tls-insecure` CLI flags. But for test scenarios
+where the client SDK under test hardcodes HTTPS (e.g., LLM SDK clients that
+default to `https://api.openai.com`), inbound plaintext breaks the test flow.
+
+The current workaround is "put a reverse proxy in front" which works in CI
+but is annoying for embedded Go tests and quick local runs.
+
+This ADR covers two capabilities:
+
+1. A library function that generates an ephemeral self-signed TLS certificate
+   (zero-config TLS for local dev and tests).
+2. CLI flags for all three listener commands (`serve`, `record`, `proxy`) to
+   enable TLS on the inbound listener, either with a user-provided cert/key
+   pair or with an auto-generated self-signed cert.
+
+##### Key architectural constraint
+
+`Server` is an `http.Handler`. It does not own a listener. Per CLAUDE.md
+layer rules, core types and services have zero I/O. The TLS listener is
+therefore the responsibility of the **caller** (the CLI, or a Go embedder
+using `net/http/httptest.NewUnstartedServer` + `StartTLS`). The library's
+role is limited to providing a helper function that generates a `tls.Config`
+from a self-signed cert.
+
+This design keeps the hexagonal boundary clean: the library produces a
+`*tls.Config`, the CLI calls `httpServer.ServeTLS()` or
+`httpServer.ListenAndServeTLS()`, and Go embedders use `httptest.NewTLSServer`
+or equivalent. No `ServerOption` is needed.
+
+#### Decision
+
+##### No new ServerOption types
+
+The PM spec proposed `WithTLSListenerCert` and `WithTLSListenerAutoCert`
+ServerOptions. This ADR rejects that approach. `Server` is an `http.Handler`.
+Adding TLS listener state to it would violate the hexagonal boundary (core
+service owns I/O) and couple the handler to a specific listener strategy.
+
+Instead, TLS is configured at the listener layer:
+
+- **CLI**: flags on the CLI command, calling `ServeTLS` or
+  `ListenAndServeTLS` on the `http.Server`.
+- **Go library embedders**: use `GenerateSelfSignedCert` to get a
+  `tls.Certificate`, then configure their own `tls.Config` and pass it to
+  `httptest.NewUnstartedServer` or `net/http.Server.TLSConfig`.
+
+This matches how Go's standard library works: `http.Handler` knows nothing
+about TLS; `http.Server` owns the listener.
+
+##### New library function: `GenerateSelfSignedCert`
+
+```go
+// SelfSignedCert holds an ephemeral self-signed TLS certificate and its
+// metadata. The certificate is generated in-memory and never touches disk.
+type SelfSignedCert struct {
+    // TLSCertificate is the parsed TLS certificate suitable for use in
+    // tls.Config.Certificates.
+    TLSCertificate tls.Certificate
+
+    // CertPEM is the PEM-encoded X.509 certificate. Useful for writing to
+    // a file, logging, or configuring client trust.
+    CertPEM []byte
+
+    // Fingerprint is the SHA-256 fingerprint of the DER-encoded certificate,
+    // hex-encoded with colon separators (e.g., "AB:CD:EF:..."). Useful for
+    // pinning and log identification.
+    Fingerprint string
+}
+
+// GenerateSelfSignedCert creates an ephemeral self-signed TLS certificate
+// suitable for inbound HTTPS listeners in tests and local development.
+//
+// The certificate is valid for the given hosts (DNS names and/or IP addresses).
+// If hosts is empty, the certificate covers "localhost" and "127.0.0.1".
+//
+// The generated certificate:
+//   - Uses ECDSA P-256 for fast generation and small key size.
+//   - Is valid for 24 hours from the current time.
+//   - Includes both DNS SANs and IP SANs based on the provided hosts.
+//   - Is generated in-memory and never touches disk.
+//
+// Returns an error if key generation or certificate creation fails.
+func GenerateSelfSignedCert(hosts ...string) (*SelfSignedCert, error)
+```
+
+##### Key algorithm: ECDSA P-256
+
+ECDSA P-256 is chosen over RSA and Ed25519:
+
+- **vs RSA 2048**: P-256 key generation is significantly faster (~1ms vs
+  ~50ms), keys are smaller (256-bit vs 2048-bit), and the cert is for test
+  use where RSA compatibility with legacy clients is irrelevant.
+- **vs Ed25519**: Ed25519 is modern and fast, but Go's `crypto/tls` did not
+  support Ed25519 certificates until Go 1.15, and some clients may not
+  support it. ECDSA P-256 is universally supported. Additionally, the
+  existing test helper in `tls_test.go` already uses ECDSA P-256
+  (`generateTestCA`, `generateTestLeaf`), so this is consistent.
+
+##### Certificate validity: 24 hours
+
+The generated cert is valid for 24 hours from the current time. This is
+long enough for any test run or local dev session, short enough that
+accidentally trusting the cert has minimal blast radius. The `NotBefore`
+is set to 1 hour in the past to accommodate minor clock skew.
+
+##### Default SANs
+
+When `hosts` is empty, the cert includes:
+
+- DNS SAN: `localhost`
+- IP SAN: `127.0.0.1`
+- IP SAN: `::1`
+
+When `hosts` is provided, each entry is classified as either a DNS name or
+an IP address (using `net.ParseIP`). No DNS SAN/IP SAN for `localhost` or
+loopback addresses is added automatically when explicit hosts are provided
+-- the caller has full control.
+
+##### No mTLS support (inbound)
+
+Inbound client cert verification (mTLS) is explicitly out of scope for this
+issue. The PM spec calls this out as a follow-up issue. The design is
+forward-compatible: a future `--tls-listener-ca` flag and
+`BuildInboundTLSConfig` helper could add `ClientAuth` and `ClientCAs` to
+the `tls.Config` without changing any code from this issue.
+
+##### CLI flags (all listener commands)
+
+The TLS listener flags apply to all three commands that start an HTTP
+listener: `serve`, `record`, and `proxy`. The PM spec only mentions `serve`,
+but `record` and `proxy` also listen on a port and face the same scheme-
+mismatch problem.
+
+```
+--tls-listener-cert <path>   Path to PEM certificate for inbound TLS
+--tls-listener-key  <path>   Path to PEM private key for inbound TLS
+--tls-listener-auto          Generate a self-signed cert at startup
+--tls-listener-san  <hosts>  Comma-separated SANs for auto-cert (default: localhost,127.0.0.1)
+```
+
+Mutual exclusion rules:
+- `--tls-listener-cert` + `--tls-listener-key` must be provided together
+  (same validation pattern as `--tls-cert` + `--tls-key` for outbound).
+- `--tls-listener-auto` is mutually exclusive with `--tls-listener-cert` /
+  `--tls-listener-key`.
+- `--tls-listener-san` is only valid with `--tls-listener-auto`.
+
+##### Listening port behavior
+
+When TLS is enabled, the default port remains **8081**. The port does not
+change to 8443. Rationale:
+
+- Users already pass `--port` to override. Silently switching the default
+  port based on TLS enablement would be surprising.
+- The `--port` flag already exists and works. Adding 8443 as a second
+  default creates ambiguity and dual-listen complexity.
+- Test code that constructs URLs from `--port` should not need conditional
+  logic based on whether TLS is enabled.
+
+If a user wants port 8443, they pass `--port 8443` explicitly.
+
+##### CLI behavior: startup logging
+
+When TLS is enabled, the CLI logs:
+- The listening address and scheme (`https://`)
+- For auto-cert mode: the SHA-256 fingerprint and the PEM-encoded
+  certificate to stderr, so tests can programmatically parse and trust it.
+
+Example log output (auto-cert):
+
+```
+httptape: serve mode: listening on https://:8081, fixtures=./fixtures
+httptape: auto-generated self-signed certificate
+httptape: fingerprint: SHA256:AB:CD:EF:01:23:...
+httptape: certificate PEM:
+-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJAL...
+-----END CERTIFICATE-----
+```
+
+##### CLI behavior: `ListenAndServe` vs `ListenAndServeTLS`
+
+When TLS flags are present, the CLI calls `httpServer.ListenAndServeTLS`
+(for user-provided cert/key) or configures `httpServer.TLSConfig` and
+calls `httpServer.ListenAndServeTLS("", "")` (for auto-cert, where the
+cert is already in the TLS config).
+
+When TLS flags are absent, behavior is unchanged: `httpServer.ListenAndServe`.
+
+#### Types
+
+```go
+// SelfSignedCert holds an ephemeral self-signed TLS certificate and its
+// metadata. The certificate is generated in-memory and never touches disk.
+type SelfSignedCert struct {
+    TLSCertificate tls.Certificate
+    CertPEM        []byte
+    Fingerprint    string
+}
+```
+
+No new interfaces. No new option types.
+
+#### Functions and methods
+
+```go
+// GenerateSelfSignedCert creates an ephemeral self-signed TLS certificate.
+// hosts are DNS names or IP addresses for the SANs. If empty, defaults to
+// localhost + 127.0.0.1 + ::1.
+func GenerateSelfSignedCert(hosts ...string) (*SelfSignedCert, error)
+```
+
+No new `ServerOption`, `RecorderOption`, or `ProxyOption` functions.
+
+#### File layout
+
+| File | Change | Type |
+|---|---|---|
+| `tls.go` | Add `SelfSignedCert` type and `GenerateSelfSignedCert` function | New code in existing file |
+| `tls_test.go` | Add tests for `GenerateSelfSignedCert` | New tests in existing file |
+| `cmd/httptape/main.go` | Add `--tls-listener-cert`, `--tls-listener-key`, `--tls-listener-auto`, `--tls-listener-san` flags to `runServe`, `runRecord`, `runProxy`. Switch to `ListenAndServeTLS` when TLS is configured. | CLI wiring |
+| `docs/tls.md` | Add "Inbound TLS" section documenting both user-provided and auto-cert modes | Documentation |
+| `docs/cli.md` | Add the four new flags to the serve/record/proxy command reference | Documentation |
+
+No new files are created. All changes are additive to existing files.
+
+#### Sequence
+
+**User-provided cert/key (CLI)**:
+
+```
+1. User invokes: httptape serve --fixtures ./f --tls-listener-cert c.pem --tls-listener-key k.pem
+2. CLI parses flags, validates mutual exclusion rules
+3. CLI creates http.Server{Addr: ":8081", Handler: server}
+4. CLI calls httpServer.ListenAndServeTLS("c.pem", "k.pem")
+5. CLI logs: "serve mode: listening on https://:8081, fixtures=./f"
+6. Incoming HTTPS requests are handled by server.ServeHTTP (unchanged)
+```
+
+**Auto-generated cert (CLI)**:
+
+```
+1. User invokes: httptape serve --fixtures ./f --tls-listener-auto
+2. CLI parses flags, validates mutual exclusion rules
+3. CLI calls httptape.GenerateSelfSignedCert("localhost", "127.0.0.1")
+4. CLI logs fingerprint and PEM certificate to stderr
+5. CLI creates http.Server{
+       Addr:    ":8081",
+       Handler: server,
+       TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert.TLSCertificate}},
+   }
+6. CLI calls httpServer.ListenAndServeTLS("", "")
+7. Incoming HTTPS requests are handled by server.ServeHTTP (unchanged)
+```
+
+**Go library embedder (programmatic)**:
+
+```
+1. Embedder calls cert, err := httptape.GenerateSelfSignedCert()
+2. Embedder creates httptest.NewUnstartedServer(handler)
+3. Embedder sets ts.TLS = &tls.Config{Certificates: []tls.Certificate{cert.TLSCertificate}}
+4. Embedder calls ts.StartTLS()
+5. Embedder creates http.Client with cert trusted in RootCAs:
+       pool := x509.NewCertPool()
+       pool.AppendCertsFromPEM(cert.CertPEM)
+       client := &http.Client{Transport: &http.Transport{
+           TLSClientConfig: &tls.Config{RootCAs: pool},
+       }}
+6. Client makes HTTPS requests to ts.URL
+```
+
+#### Error cases
+
+| Failure mode | How handled |
+|---|---|
+| `--tls-listener-cert` without `--tls-listener-key` (or vice versa) | CLI returns `usageError` before starting listener |
+| `--tls-listener-auto` combined with `--tls-listener-cert` | CLI returns `usageError` before starting listener |
+| `--tls-listener-san` without `--tls-listener-auto` | CLI returns `usageError` before starting listener |
+| PEM file does not exist or is unreadable | `ListenAndServeTLS` returns error, CLI logs and exits with exitRuntime |
+| PEM file contains invalid certificate | `ListenAndServeTLS` returns error, CLI logs and exits with exitRuntime |
+| ECDSA key generation fails in `GenerateSelfSignedCert` | Returns wrapped error |
+| `x509.CreateCertificate` fails in `GenerateSelfSignedCert` | Returns wrapped error |
+
+#### Test strategy
+
+**Unit tests for `GenerateSelfSignedCert` (in `tls_test.go`):**
+
+1. **Default hosts produces valid cert** -- call with no args, verify cert
+   has DNS SAN `localhost`, IP SANs `127.0.0.1` and `::1`, is self-signed,
+   has 24h validity, uses ECDSA P-256.
+
+2. **Custom hosts are classified correctly** -- call with
+   `"myhost.local", "10.0.0.1"`, verify `myhost.local` is a DNS SAN and
+   `10.0.0.1` is an IP SAN.
+
+3. **Fingerprint is non-empty and formatted** -- verify fingerprint matches
+   `XX:XX:XX:...` pattern (colon-separated hex pairs).
+
+4. **CertPEM is valid PEM** -- verify `pem.Decode(cert.CertPEM)` succeeds
+   and the block type is `"CERTIFICATE"`.
+
+5. **TLSCertificate is usable** -- create an `httptest.NewUnstartedServer`,
+   set its TLS config with the generated cert, start TLS, make a request
+   with a client that trusts the cert via `CertPEM`, verify success.
+
+6. **Generated cert is trusted by a client that adds it to RootCAs** --
+   end-to-end with `http.Client` and `x509.NewCertPool`.
+
+**Integration test (in `tls_test.go`):**
+
+7. **Round-trip through httptape Server with auto-cert** -- create a
+   `Server` with `NewServer`, wrap in `httptest.NewUnstartedServer`, apply
+   `GenerateSelfSignedCert`, start TLS, make HTTPS request, verify replay
+   works end-to-end.
+
+**CLI flag validation tests (in `cmd/httptape/main_test.go` or manually):**
+
+8. **Mutual exclusion of `--tls-listener-auto` and `--tls-listener-cert`**
+9. **`--tls-listener-cert` requires `--tls-listener-key`**
+10. **`--tls-listener-san` requires `--tls-listener-auto`**
+
+Test patterns:
+- Table-driven where practical.
+- Use `httptest.NewUnstartedServer` + `StartTLS` for TLS listener tests.
+- Use `x509.NewCertPool` + `AppendCertsFromPEM` for client-side trust.
+- No external dependencies.
+
+#### Alternatives considered
+
+**A. TLS as ServerOption.** Adding `WithTLSListenerCert` and
+`WithTLSListenerAutoCert` to `Server`. Rejected because `Server` is an
+`http.Handler` and should not own listener concerns. This would violate the
+hexagonal architecture boundary and make `Server` harder to embed in
+contexts that manage their own listeners (e.g., `httptest`, Caddy, custom
+`net.Listener`).
+
+**B. Ed25519 keys.** Faster than ECDSA, but not universally supported by
+all TLS clients. ECDSA P-256 is the safe default for test certificates and
+is consistent with the existing test helpers in `tls_test.go`.
+
+**C. RSA 2048 keys.** Most compatible, but significantly slower to generate
+(~50ms vs ~1ms for P-256). For ephemeral test certs, the speed difference
+matters. No compatibility benefit for the test use case.
+
+**D. Port auto-switch to 8443.** Rejected as surprising behavior. Users
+already have `--port`. No need for a magic default change based on TLS
+enablement.
+
+**E. Dual-listen (HTTP + HTTPS).** Explicitly rejected as the PM spec
+notes: "dual-listen is a can of worms." One port, one protocol. If users
+want both, they run two instances.
+
+#### Consequences
+
+- **Additive change.** No breaking changes to any existing API. `Server`,
+  `Recorder`, `Proxy` types are unmodified. New function and type in
+  `tls.go`, new CLI flags.
+- **All three listener commands gain TLS support.** `serve`, `record`, and
+  `proxy` all get the same four flags, avoiding a consistency gap.
+- **Go embedders get a first-class primitive** (`GenerateSelfSignedCert`)
+  for zero-config TLS in tests. This is more useful than CLI-only support
+  because most httptape users are Go developers writing tests.
+- **No new dependencies.** All crypto is from `crypto/ecdsa`,
+  `crypto/elliptic`, `crypto/rand`, `crypto/sha256`, `crypto/tls`,
+  `crypto/x509`, `encoding/pem`, `math/big`, `net`, `time` -- all stdlib.
+- **mTLS is deferred.** Inbound client cert verification is explicitly out
+  of scope. The design is forward-compatible with a future
+  `--tls-listener-ca` flag.
+- **No runtime cert rotation.** The cert is generated once at startup. No
+  hot-reload. This matches the ephemeral nature of test fixtures.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -141,6 +141,7 @@ Panics if `upstream` or `store` is nil.
 | WithCacheRoute | `WithCacheRoute(route string)` | `""` |
 | WithCacheOnError | `WithCacheOnError(fn func(error))` | no-op |
 | WithCacheSSERecording | `WithCacheSSERecording(enabled bool)` | `true` |
+| WithCacheLookupDisabled | `WithCacheLookupDisabled()` | `false` |
 | WithCacheUpstreamDownFallback | `WithCacheUpstreamDownFallback(enabled bool)` | `false` |
 | WithCacheUpstreamTimeout | `WithCacheUpstreamTimeout(d time.Duration)` | `0` (no timeout) |
 

--- a/docs/caching-transport.md
+++ b/docs/caching-transport.md
@@ -159,6 +159,20 @@ httptape.WithCacheSSERecording(false) // disable
 
 Controls whether SSE (Server-Sent Events) stream recording is enabled. When enabled, SSE responses on the miss path are tee'd to the caller while events are accumulated and persisted as a tape. See [SSE recording](#sse-recording) below.
 
+### WithCacheLookupDisabled
+
+```go
+httptape.WithCacheLookupDisabled()
+```
+
+Disables the cache hit path entirely. Every request is treated as a miss: forwarded to upstream, recorded via the sanitization pipeline (if configured), and returned. Single-flight dedup, SSE tee, and sanitization remain active.
+
+The configured Matcher is still used by stale fallback (`WithCacheUpstreamDownFallback`), so the two options compose: disable the hit path but still serve stale tapes when upstream is down.
+
+Useful when the embedder owns its own hit-path logic (e.g., Proxy uses an L1 store consulted before this transport runs) and wants CachingTransport's other cross-cutting concerns without the cache lookup it would otherwise perform.
+
+Unlike using a never-matching Matcher, this option skips `Store.List` entirely on the hot path, avoiding unnecessary I/O.
+
 ### WithCacheUpstreamDownFallback
 
 ```go

--- a/proxy.go
+++ b/proxy.go
@@ -97,16 +97,6 @@ type Proxy struct {
 	upstreamURLHint string
 }
 
-// neverMatcher is a Matcher that never matches any request. It is used
-// by Proxy's internal CachingTransport to ensure every request is treated
-// as a cache miss and forwarded to upstream. Proxy handles its own
-// L1/L2 cache lookup in the fallback path with the user-configured matcher.
-type neverMatcher struct{}
-
-func (neverMatcher) Match(_ *http.Request, _ []Tape) (Tape, bool) {
-	return Tape{}, false
-}
-
 // l1RecordingTransport wraps an http.RoundTripper to intercept upstream
 // responses and save raw (unsanitized) tapes to the L1 store. This is
 // used by Proxy to inject L1 recording into CachingTransport's miss path
@@ -157,8 +147,12 @@ func (t *l1RecordingTransport) RoundTrip(req *http.Request) (*http.Response, err
 	if req.GetBody != nil {
 		body, gbErr := req.GetBody()
 		if gbErr == nil {
-			reqBody, _ = io.ReadAll(body)
+			var readErr error
+			reqBody, readErr = io.ReadAll(body)
 			body.Close()
+			if readErr != nil {
+				t.onErrorSafe(fmt.Errorf("httptape: l1 recording read request body: %w", readErr))
+			}
 		}
 	}
 
@@ -541,10 +535,11 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) (*Proxy, error) {
 	// CachingTransport handles: upstream forwarding (via l1RecordingTransport),
 	// sanitization, L2 recording, SSE tee recording, single-flight dedup.
 	//
-	// neverMatcher ensures CachingTransport always treats requests as cache
-	// misses. Proxy handles its own L1/L2 lookup in the fallback path using
-	// the user-configured matcher. This preserves the original Proxy semantics
-	// where the upstream is always consulted first (caches are fallback-only).
+	// WithCacheLookupDisabled ensures CachingTransport skips the cache hit
+	// path entirely (no Store.List, no Matcher.Match). Proxy handles its own
+	// L1/L2 lookup in the fallback path using the user-configured matcher.
+	// This preserves the original Proxy semantics where the upstream is always
+	// consulted first (caches are fallback-only).
 	//
 	// The cacheFilter prevents CachingTransport from recording responses that
 	// would trigger Proxy's fallback. In the original Proxy, fallback-triggering
@@ -556,7 +551,7 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) (*Proxy, error) {
 	}
 
 	p.ct = NewCachingTransport(l1RT, p.l2,
-		WithCacheMatcher(neverMatcher{}),
+		WithCacheLookupDisabled(),
 		WithCacheSanitizer(p.sanitizer),
 		WithCacheRoute(p.route),
 		WithCacheOnError(p.onError),
@@ -606,8 +601,8 @@ func (p *Proxy) Close() error {
 // RoundTrip implements http.RoundTripper. The request flow is:
 //
 //  1. Capture request body (needed for fallback matching).
-//  2. Forward to CachingTransport.RoundTrip. CachingTransport always
-//     treats the request as a cache miss (neverMatcher) and forwards to
+//  2. Forward to CachingTransport.RoundTrip. CachingTransport has cache
+//     lookup disabled (WithCacheLookupDisabled) so it always forwards to
 //     upstream via l1RecordingTransport (saves raw to L1), then sanitizes
 //     and saves to L2.
 //  3. On success: check isFallback. If true (e.g., 5xx fallback), enter
@@ -630,10 +625,10 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	// 2. Forward to CachingTransport. CachingTransport uses a neverMatcher
-	// so it always treats the request as a cache miss and forwards to
-	// upstream via l1RecordingTransport (which saves raw to L1).
-	// CachingTransport then sanitizes and saves to L2.
+	// 2. Forward to CachingTransport. CachingTransport has cache lookup
+	// disabled so it always forwards to upstream via l1RecordingTransport
+	// (which saves raw to L1). CachingTransport then sanitizes and saves
+	// to L2.
 	resp, transportErr := p.ct.RoundTrip(req)
 
 	// 3. Decide: success or fallback?


### PR DESCRIPTION
## Summary

ADR-47 for #197: design for inbound TLS listener support. Key decisions:

- `GenerateSelfSignedCert(hosts ...string) (*SelfSignedCert, error)` library function in `tls.go`
- ECDSA P-256, 24h validity, in-memory only (never touches disk)
- CLI flags `--tls-listener-cert`, `--tls-listener-key`, `--tls-listener-auto`, `--tls-listener-san` on all three listener commands (serve, record, proxy)
- No `ServerOption` -- `Server` stays a pure `http.Handler`; TLS is the caller's responsibility
- Port stays 8081 (no magic switch to 8443)
- Inbound mTLS deferred to follow-up issue

## Test plan

- [ ] ADR is internally consistent
- [ ] No contradiction with CLAUDE.md locked decisions
- [ ] No contradiction with existing ADRs in decisions.md

## Related

Closes #197 (design phase)