### PR TITLE
feat(#240): record response elapsed time + opt-in replay delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`RecordedResp.ElapsedMS`**: records total response time in milliseconds
+  for every HTTP interaction (non-SSE and SSE). Always-on, no opt-out.
+  Pre-feature fixtures (missing or zero `elapsed_ms`) are backward
+  compatible. (#240)
+
+- **`ResponseTimingMode`** sealed interface with three constructors for
+  opt-in replay delay based on recorded elapsed time:
+  - `ResponseTimingInstant()` -- no delay (default, preserves pre-feature behavior)
+  - `ResponseTimingRecorded()` -- replay with recorded elapsed time
+  - `ResponseTimingAccelerated(factor)` -- scale recorded elapsed time by factor
+
+- **`WithReplayTiming(mode)`**: ServerOption that applies replay timing
+  delay. Composes additively with `WithDelay` / `metadata.delay`.
+  Pre-feature fixtures incur no delay regardless of mode. (#240)
+
+- **`WithCacheReplayTiming(mode)`**: CachingOption that applies replay
+  timing delay on cache-hit responses. (#240)
+
 - **`WithCacheLookupDisabled()`**: CachingOption that disables the cache
   hit path entirely. Every request is forwarded to upstream and recorded.
   Single-flight dedup, SSE tee, sanitization, and stale fallback remain

--- a/caching_transport.go
+++ b/caching_transport.go
@@ -36,6 +36,11 @@ type CachingTransport struct {
 	maxBodySize    int
 	sseRecording   bool
 
+	// response timing
+	replayTiming ResponseTimingMode
+	nowFunc      func() time.Time
+	sleepFunc    func(context.Context, time.Duration) error
+
 	// stale-fallback (#164)
 	staleFallback   bool
 	upstreamTimeout time.Duration
@@ -188,6 +193,33 @@ func WithCacheUpstreamTimeout(d time.Duration) CachingOption {
 	}
 }
 
+// WithCacheReplayTiming sets the response timing mode for cache-hit
+// responses. Defaults to ResponseTimingInstant() (no delay, preserving
+// pre-feature behavior).
+//
+// Timing composition: WithCacheReplayTiming composes ADDITIVELY with any
+// delays the caller adds after receiving the response. Pre-feature
+// fixtures (ElapsedMS == 0) incur no replay timing delay regardless
+// of mode. The delay is applied in tapeToResponse before returning the
+// *http.Response, so the caller of RoundTrip perceives the delay.
+func WithCacheReplayTiming(mode ResponseTimingMode) CachingOption {
+	return func(ct *CachingTransport) {
+		ct.replayTiming = mode
+	}
+}
+
+// withCacheNowFunc overrides the clock for elapsed-time measurement.
+// Unexported -- only used in tests.
+func withCacheNowFunc(fn func() time.Time) CachingOption {
+	return func(ct *CachingTransport) { ct.nowFunc = fn }
+}
+
+// withCacheSleepFunc overrides the sleep function for testing.
+// Unexported -- only used in tests.
+func withCacheSleepFunc(fn func(context.Context, time.Duration) error) CachingOption {
+	return func(ct *CachingTransport) { ct.sleepFunc = fn }
+}
+
 // defaultCacheMaxBodySize is the default maximum request body size for cache
 // participation: 10 MiB.
 const defaultCacheMaxBodySize = 10 * 1024 * 1024
@@ -229,6 +261,9 @@ func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...Cachin
 		singleFlight: true,
 		maxBodySize:  defaultCacheMaxBodySize,
 		sseRecording: true,
+		replayTiming: ResponseTimingInstant(),
+		nowFunc:      time.Now,
+		sleepFunc:    defaultSleepFunc,
 		cacheFilter: func(resp *http.Response) bool {
 			return resp.StatusCode >= 200 && resp.StatusCode < 300
 		},
@@ -290,7 +325,7 @@ func (ct *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 				if tape.Response.IsSSE() {
 					return ct.sseResponseFromTape(tape), nil
 				}
-				return ct.tapeToResponse(tape), nil
+				return ct.tapeToResponse(req.Context(), tape), nil
 			}
 		}
 	}
@@ -419,6 +454,7 @@ func (ct *CachingTransport) roundTripUpstream(req *http.Request, reqBody []byte,
 		req = req.WithContext(ctx)
 	}
 
+	startTime := ct.nowFunc()
 	resp, transportErr := ct.upstream.RoundTrip(req)
 	if transportErr != nil {
 		// Upstream error path.
@@ -439,7 +475,7 @@ func (ct *CachingTransport) roundTripUpstream(req *http.Request, reqBody []byte,
 
 	// SSE detection on miss path.
 	if ct.sseRecording && isSSEContentType(resp.Header.Get("Content-Type")) {
-		return ct.roundTripSSE(req, resp, reqBody)
+		return ct.roundTripSSE(req, resp, reqBody, startTime)
 	}
 
 	// Read response body into buffer.
@@ -472,6 +508,7 @@ func (ct *CachingTransport) roundTripUpstream(req *http.Request, reqBody []byte,
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Header.Clone(),
 		Body:       respBody,
+		ElapsedMS:  elapsedMS(startTime, ct.nowFunc),
 	}
 
 	tape := NewTape(ct.route, recordedReq, recordedResp)
@@ -492,8 +529,8 @@ func (ct *CachingTransport) roundTripUpstream(req *http.Request, reqBody []byte,
 // while a background goroutine parses SSE events. When the stream
 // completes cleanly, the tape is persisted. If the stream is truncated
 // (client disconnect), the partial tape is discarded.
-func (ct *CachingTransport) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte) (*http.Response, error) {
-	startTime := time.Now()
+func (ct *CachingTransport) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte, startTime time.Time) (*http.Response, error) {
+	nowFunc := ct.nowFunc // capture for closure
 	respHeaders := resp.Header.Clone()
 
 	recordedReq := RecordedReq{
@@ -542,6 +579,7 @@ func (ct *CachingTransport) roundTripSSE(req *http.Request, resp *http.Response,
 			Headers:    respHeaders,
 			Body:       nil,
 			SSEEvents:  collectedEvents,
+			ElapsedMS:  elapsedMS(startTime, nowFunc),
 		}
 
 		tape := NewTape(ct.route, recordedReq, recordedResp)
@@ -647,14 +685,23 @@ func (ct *CachingTransport) serveStaleFallback(req *http.Request) (*http.Respons
 	if tape.Response.IsSSE() {
 		resp = ct.sseResponseFromTape(tape)
 	} else {
-		resp = ct.tapeToResponse(tape)
+		resp = ct.tapeToResponse(context.Background(), tape)
 	}
 	resp.Header.Set("X-Httptape-Stale", "true")
 	return resp, nil
 }
 
 // tapeToResponse synthesizes an *http.Response from a non-SSE Tape.
-func (ct *CachingTransport) tapeToResponse(tape Tape) *http.Response {
+// The replay timing delay (opt-in via WithCacheReplayTiming) is applied
+// before returning, so the caller of RoundTrip perceives the delay.
+// This composes ADDITIVELY with any caller-side delays. Pre-feature
+// fixtures (ElapsedMS == 0) incur no delay regardless of mode.
+func (ct *CachingTransport) tapeToResponse(ctx context.Context, tape Tape) *http.Response {
+	// Apply replay timing delay before building the response.
+	if replayDelay := ct.replayTiming.responseDelay(tape.Response.ElapsedMS); replayDelay > 0 {
+		_ = ct.sleepFunc(ctx, replayDelay) //nolint:errcheck // context cancellation is non-fatal here
+	}
+
 	header := make(http.Header)
 	if tape.Response.Headers != nil {
 		header = tape.Response.Headers.Clone()
@@ -732,7 +779,7 @@ func (ct *CachingTransport) reQueryStoreForSSE(req *http.Request, reqBody []byte
 		return ct.sseResponseFromTape(tape), nil
 	}
 	if ok {
-		return ct.tapeToResponse(tape), nil
+		return ct.tapeToResponse(req.Context(), tape), nil
 	}
 
 	// Tape not found -- leader's store write may have failed.

--- a/caching_transport_test.go
+++ b/caching_transport_test.go
@@ -1581,3 +1581,202 @@ func TestCachingTransport_LookupDisabledSkipsStoreList(t *testing.T) {
 		t.Errorf("Store.List was called %d times, want 0 (lookup disabled should skip store query)", calls)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ElapsedMS recording on cache miss (non-SSE)
+// ---------------------------------------------------------------------------
+
+func TestCachingTransport_ElapsedMS_NonSSE(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore()
+	callCount := 0
+	fakeNow := func() time.Time {
+		callCount++
+		if callCount == 1 {
+			return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		}
+		return time.Date(2026, 1, 1, 0, 0, 0, 200*int(time.Millisecond), time.UTC)
+	}
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheSingleFlight(false),
+		withCacheNowFunc(fakeNow),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+	if tapes[0].Response.ElapsedMS != 200 {
+		t.Errorf("ElapsedMS = %d, want 200", tapes[0].Response.ElapsedMS)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ElapsedMS recording on cache miss (SSE)
+// ---------------------------------------------------------------------------
+
+func TestCachingTransport_ElapsedMS_SSE(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore()
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var callCount atomic.Int64
+	fakeNow := func() time.Time {
+		n := callCount.Add(1)
+		if n == 1 {
+			return baseTime
+		}
+		return baseTime.Add(750 * time.Millisecond)
+	}
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		body := "data: event1\n\ndata: event2\n\n"
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheSingleFlight(false),
+		withCacheNowFunc(fakeNow),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Consume body to trigger SSE recording completion.
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+	if !tapes[0].Response.IsSSE() {
+		t.Fatal("expected SSE tape")
+	}
+	if tapes[0].Response.ElapsedMS != 750 {
+		t.Errorf("ElapsedMS = %d, want 750", tapes[0].Response.ElapsedMS)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WithCacheReplayTiming on cache hit
+// ---------------------------------------------------------------------------
+
+func TestCachingTransport_WithCacheReplayTiming_Recorded(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("cached"),
+		ElapsedMS:  300,
+	})
+	store.Save(context.Background(), tape)
+
+	var sleepCalled bool
+	var sleepDuration time.Duration
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		t.Error("upstream should not be called on cache hit")
+		return nil, fmt.Errorf("unreachable")
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheReplayTiming(ResponseTimingRecorded()),
+		withCacheSleepFunc(func(_ context.Context, d time.Duration) error {
+			sleepCalled = true
+			sleepDuration = d
+			return nil
+		}),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if string(body) != "cached" {
+		t.Errorf("body = %q, want %q", string(body), "cached")
+	}
+	if !sleepCalled {
+		t.Error("sleepFunc was not called for recorded timing")
+	}
+	if sleepDuration != 300*time.Millisecond {
+		t.Errorf("sleepDuration = %v, want 300ms", sleepDuration)
+	}
+}
+
+func TestCachingTransport_WithCacheReplayTiming_PreFeatureNoDelay(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method:   "GET",
+		URL:      "http://example.com/api",
+		Headers:  http.Header{},
+		BodyHash: "",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{},
+		Body:       []byte("cached"),
+		ElapsedMS:  0, // pre-feature
+	})
+	store.Save(context.Background(), tape)
+
+	var sleepCalled bool
+
+	upstream := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("unreachable")
+	})
+
+	ct := NewCachingTransport(upstream, store,
+		WithCacheReplayTiming(ResponseTimingRecorded()),
+		withCacheSleepFunc(func(_ context.Context, d time.Duration) error {
+			sleepCalled = true
+			return nil
+		}),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if sleepCalled {
+		t.Error("sleepFunc was called for pre-feature fixture (ElapsedMS=0)")
+	}
+}

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -184,6 +184,25 @@ Each event's `Data` field is treated as an independent JSON body, so the same pa
 
 See [Redaction](sanitization.md) for more on SSE redaction and faking.
 
+## Response elapsed time
+
+Every recorded tape automatically captures the total response time in the `elapsed_ms` field of `RecordedResp`. This measures the wall-clock time from when the request was sent to when the response body was fully received (non-SSE) or when the SSE stream completed (SSE).
+
+```json
+{
+  "response": {
+    "status_code": 200,
+    "headers": {"Content-Type": ["application/json"]},
+    "body": {"result": "ok"},
+    "elapsed_ms": 142
+  }
+}
+```
+
+Elapsed time recording is always-on -- there is no flag to disable it. The `elapsed_ms` field uses `omitempty`, so pre-feature fixtures (created before this feature existed) remain byte-identical on round-trip.
+
+The recorded elapsed time is used by the replay timing feature. See [Replay](replay.md#response-timing) for details on how to use `WithReplayTiming` and `WithCacheReplayTiming` to replay responses with realistic timing.
+
 ## Thread safety
 
 `Recorder` is safe for concurrent use. Multiple goroutines can call `RoundTrip` simultaneously. `Close` must be called exactly once when recording is complete (though calling it multiple times is safe due to `sync.Once`).

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -97,6 +97,35 @@ Adds a fixed delay before every response. The delay is applied after matching bu
 srv := httptape.NewServer(store, httptape.WithDelay(200*time.Millisecond))
 ```
 
+### WithReplayTiming
+
+```go
+func WithReplayTiming(mode ResponseTimingMode) ServerOption
+```
+
+Controls whether the server delays responses based on their recorded elapsed time (`RecordedResp.ElapsedMS`). Defaults to `ResponseTimingInstant()` (no delay, preserving pre-feature behavior).
+
+Three modes are available:
+
+| Mode | Behavior | Use case |
+|------|----------|----------|
+| `ResponseTimingInstant()` | No delay (default) | Unit tests, CI |
+| `ResponseTimingRecorded()` | Delay = recorded elapsed time | Realistic replay, back-pressure testing |
+| `ResponseTimingAccelerated(factor)` | Delay = elapsed * factor | Fast but proportional; factor < 1 = faster, > 1 = slower |
+
+```go
+// Replay with recorded timing -- each response takes as long as the original.
+srv, _ := httptape.NewServer(store, httptape.WithReplayTiming(httptape.ResponseTimingRecorded()))
+
+// Replay 10x faster than recorded.
+mode, _ := httptape.ResponseTimingAccelerated(0.1)
+srv, _ := httptape.NewServer(store, httptape.WithReplayTiming(mode))
+```
+
+**Backward compatibility:** Pre-feature fixtures (missing `elapsed_ms` field, or `elapsed_ms: 0`) incur no delay regardless of mode.
+
+**Additive composition with WithDelay:** `WithReplayTiming` composes additively with `WithDelay` and per-fixture `metadata.delay`. The existing delay (user-authored "simulate slow API") runs first, then the replay timing delay runs second. The total delay is their sum. For example, if `WithDelay` is 100ms and the recorded elapsed time is 200ms with `ResponseTimingRecorded()`, the total delay before the response is written is 300ms.
+
 ### WithErrorRate
 
 ```go
@@ -247,6 +276,22 @@ func TestMyAPI(t *testing.T) {
     // assert on user...
 }
 ```
+
+## Response timing
+
+Response timing allows you to replay responses with realistic delays based on the recorded `elapsed_ms` field. This is controlled by `WithReplayTiming` (for the Server) and `WithCacheReplayTiming` (for CachingTransport).
+
+See [WithReplayTiming](#withreplaytiming) above for configuration details.
+
+For CachingTransport, use `WithCacheReplayTiming`:
+
+```go
+ct := httptape.NewCachingTransport(upstream, store,
+    httptape.WithCacheReplayTiming(httptape.ResponseTimingRecorded()),
+)
+```
+
+The delay is applied before returning the `*http.Response`, so the caller of `RoundTrip` perceives the delay as if the upstream had taken that long to respond.
 
 ## Using as a standalone server
 

--- a/proxy.go
+++ b/proxy.go
@@ -121,6 +121,7 @@ type l1RecordingTransport struct {
 	onError    func(error)
 	health     *HealthMonitor
 	isFallback func(err error, resp *http.Response) bool
+	nowFunc    func() time.Time // clock for elapsed-time measurement; injectable for testing
 }
 
 // RoundTrip forwards the request to the real upstream and saves the raw
@@ -130,6 +131,7 @@ type l1RecordingTransport struct {
 // its own SSE tee recording reader for L2. Returns the upstream response
 // (possibly with a wrapped body for SSE).
 func (t *l1RecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	startTime := t.nowFunc()
 	resp, err := t.inner.RoundTrip(req)
 	if err != nil {
 		return nil, err
@@ -159,7 +161,7 @@ func (t *l1RecordingTransport) RoundTrip(req *http.Request) (*http.Response, err
 	// SSE responses: wrap body with an sseRecordingReader for L1 recording.
 	// CachingTransport will wrap the returned body again for L2 recording.
 	if isSSEContentType(resp.Header.Get("Content-Type")) {
-		return t.roundTripSSE(req, resp, reqBody), nil
+		return t.roundTripSSE(req, resp, reqBody, startTime), nil
 	}
 
 	// Non-SSE: read response body, build raw tape, save to L1, restore body.
@@ -188,6 +190,7 @@ func (t *l1RecordingTransport) RoundTrip(req *http.Request) (*http.Response, err
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Header.Clone(),
 		Body:       respBody,
+		ElapsedMS:  elapsedMS(startTime, t.nowFunc),
 	}
 
 	rawTape := NewTape(t.route, recordedReq, recordedResp)
@@ -205,8 +208,8 @@ func (t *l1RecordingTransport) RoundTrip(req *http.Request) (*http.Response, err
 // roundTripSSE handles SSE responses in the L1 recording path. The body
 // is wrapped in an sseRecordingReader that accumulates events and saves a
 // raw tape to L1 when the stream completes.
-func (t *l1RecordingTransport) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte) *http.Response {
-	startTime := time.Now()
+func (t *l1RecordingTransport) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte, startTime time.Time) *http.Response {
+	nowFunc := t.nowFunc // capture for closure
 	respHeaders := resp.Header.Clone()
 
 	recordedReq := RecordedReq{
@@ -243,6 +246,7 @@ func (t *l1RecordingTransport) roundTripSSE(req *http.Request, resp *http.Respon
 			Body:       nil,
 			SSEEvents:  collectedEvents,
 			Truncated:  truncated,
+			ElapsedMS:  elapsedMS(startTime, nowFunc),
 		}
 
 		rawTape := NewTape(t.route, recordedReq, recordedResp)
@@ -529,6 +533,7 @@ func NewProxy(l1, l2 Store, opts ...ProxyOption) (*Proxy, error) {
 		onError:    p.onError,
 		health:     p.health,
 		isFallback: p.isFallback,
+		nowFunc:    time.Now,
 	}
 
 	// Construct CachingTransport with l1RecordingTransport as upstream.

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1135,6 +1135,7 @@ func TestL1RecordingTransport_ResponseBodyReadError(t *testing.T) {
 		l1:      l1,
 		route:   "test",
 		onError: func(err error) { capturedErr = err },
+		nowFunc: time.Now,
 		isFallback: func(err error, _ *http.Response) bool {
 			return err != nil
 		},
@@ -1181,6 +1182,7 @@ func TestL1RecordingTransport_SaveError(t *testing.T) {
 		l1:      l1,
 		route:   "test",
 		onError: func(err error) { capturedErr = err },
+		nowFunc: time.Now,
 		isFallback: func(err error, _ *http.Response) bool {
 			return err != nil
 		},
@@ -1685,6 +1687,7 @@ func TestL1RecordingTransport_SSETruncation(t *testing.T) {
 			capturedErrors = append(capturedErrors, err.Error())
 			mu.Unlock()
 		},
+		nowFunc: time.Now,
 		isFallback: func(err error, _ *http.Response) bool {
 			return err != nil
 		},
@@ -1753,6 +1756,7 @@ func TestL1RecordingTransport_SSESaveError(t *testing.T) {
 			capturedErrors = append(capturedErrors, err.Error())
 			mu.Unlock()
 		},
+		nowFunc: time.Now,
 		isFallback: func(err error, _ *http.Response) bool {
 			return err != nil
 		},
@@ -1843,5 +1847,145 @@ func TestProxy_SSEResponseFromTape_WithTiming(t *testing.T) {
 	// The 80ms inter-event delay should be applied (within tolerance).
 	if elapsed < 50*time.Millisecond {
 		t.Errorf("elapsed %v, expected >= 50ms for 80ms timing delay", elapsed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// l1RecordingTransport: ElapsedMS is recorded (non-SSE)
+// ---------------------------------------------------------------------------
+
+func TestL1RecordingTransport_ElapsedMS_NonSSE(t *testing.T) {
+	l1 := NewMemoryStore()
+
+	callCount := 0
+	fakeNow := func() time.Time {
+		callCount++
+		if callCount == 1 {
+			return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		}
+		return time.Date(2026, 1, 1, 0, 0, 0, 120*int(time.Millisecond), time.UTC)
+	}
+
+	transport := successTransport(200, "ok")
+
+	l1rt := &l1RecordingTransport{
+		inner:   transport,
+		l1:      l1,
+		route:   "test",
+		nowFunc: fakeNow,
+		isFallback: func(err error, _ *http.Response) bool {
+			return err != nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := l1rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tapes, _ := l1.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 L1 tape, got %d", len(tapes))
+	}
+	if tapes[0].Response.ElapsedMS != 120 {
+		t.Errorf("ElapsedMS = %d, want 120", tapes[0].Response.ElapsedMS)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// l1RecordingTransport: ElapsedMS is recorded (SSE)
+// ---------------------------------------------------------------------------
+
+func TestL1RecordingTransport_ElapsedMS_SSE(t *testing.T) {
+	l1 := NewMemoryStore()
+
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var callCount atomic.Int64
+	fakeNow := func() time.Time {
+		n := callCount.Add(1)
+		if n == 1 {
+			return baseTime
+		}
+		return baseTime.Add(400 * time.Millisecond)
+	}
+
+	body := "data: hello\n\ndata: world\n\n"
+	transport := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})
+
+	l1rt := &l1RecordingTransport{
+		inner:   transport,
+		l1:      l1,
+		route:   "test",
+		nowFunc: fakeNow,
+		isFallback: func(err error, _ *http.Response) bool {
+			return err != nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	resp, err := l1rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tapes, _ := l1.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 L1 tape, got %d", len(tapes))
+	}
+	if !tapes[0].Response.IsSSE() {
+		t.Fatal("expected SSE tape")
+	}
+	if tapes[0].Response.ElapsedMS != 400 {
+		t.Errorf("ElapsedMS = %d, want 400", tapes[0].Response.ElapsedMS)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proxy: ElapsedMS is recorded in both L1 and L2
+// ---------------------------------------------------------------------------
+
+func TestProxy_ElapsedMS_Recorded(t *testing.T) {
+	l1 := NewMemoryStore()
+	l2 := NewMemoryStore()
+
+	proxy, err := NewProxy(l1, l2,
+		WithProxyTransport(successTransport(200, "ok")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/api", nil)
+	resp, err := proxy.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	l1Tapes, _ := l1.List(context.Background(), Filter{})
+	l2Tapes, _ := l2.List(context.Background(), Filter{})
+	if len(l1Tapes) != 1 || len(l2Tapes) != 1 {
+		t.Fatalf("expected 1 tape in each store, got L1=%d, L2=%d", len(l1Tapes), len(l2Tapes))
+	}
+
+	// Both tapes should have a positive ElapsedMS (actual HTTP round-trip
+	// happened, so elapsed > 0 unless the machine is impossibly fast).
+	if l1Tapes[0].Response.ElapsedMS < 0 {
+		t.Errorf("L1 ElapsedMS = %d, want >= 0", l1Tapes[0].Response.ElapsedMS)
+	}
+	if l2Tapes[0].Response.ElapsedMS < 0 {
+		t.Errorf("L2 ElapsedMS = %d, want >= 0", l2Tapes[0].Response.ElapsedMS)
 	}
 }

--- a/recorder.go
+++ b/recorder.go
@@ -46,6 +46,7 @@ type Recorder struct {
 	maxBodySize   int               // max body size in bytes; 0 = no limit
 	skipRedirects bool              // when true, skip recording 3xx responses
 	sseRecording  bool              // true = detect and record SSE streams (default true)
+	nowFunc       func() time.Time  // clock for elapsed-time measurement; injectable for testing
 
 	// async internals
 	sendMu    sync.Mutex    // coordinates closed-check-then-send with close-channel
@@ -190,6 +191,13 @@ func WithRecorderTLSConfig(cfg *tls.Config) RecorderOption {
 	}
 }
 
+// withRecorderNowFunc overrides the clock for elapsed-time measurement.
+// This is unexported -- only used in tests to make elapsed-time
+// deterministic without real sleeping.
+func withRecorderNowFunc(fn func() time.Time) RecorderOption {
+	return func(r *Recorder) { r.nowFunc = fn }
+}
+
 // NewRecorder creates a new Recorder wrapping the given store.
 // If transport is nil, http.DefaultTransport is used.
 //
@@ -215,6 +223,7 @@ func NewRecorder(store Store, opts ...RecorderOption) *Recorder {
 		randFloat:    rand.Float64,
 		bufSize:      1024,
 		sseRecording: true,
+		nowFunc:      time.Now,
 	}
 
 	for _, opt := range opts {
@@ -274,6 +283,7 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	// Execute the actual HTTP call.
+	startTime := r.nowFunc()
 	resp, err := r.transport.RoundTrip(req)
 	if err != nil {
 		return nil, err
@@ -287,7 +297,7 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	// SSE detection: if the response is text/event-stream and SSE recording
 	// is enabled, use the streaming recording path instead of buffering.
 	if r.sseRecording && isSSEContentType(resp.Header.Get("Content-Type")) {
-		return r.roundTripSSE(req, resp, reqBody)
+		return r.roundTripSSE(req, resp, reqBody, startTime)
 	}
 
 	// Capture response body.
@@ -343,6 +353,7 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 		Body:             respBody,
 		Truncated:        respTruncated,
 		OriginalBodySize: respOrigSize,
+		ElapsedMS:        elapsedMS(startTime, r.nowFunc),
 	}
 
 	tape := NewTape(r.route, recordedReq, recordedResp)
@@ -360,8 +371,8 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 // in an sseRecordingReader that delivers bytes to the caller unchanged while
 // parsing SSE events in a background goroutine. Tape persistence is deferred
 // until the caller finishes consuming the body (Close or EOF).
-func (r *Recorder) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte) (*http.Response, error) {
-	startTime := time.Now()
+func (r *Recorder) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte, startTime time.Time) (*http.Response, error) {
+	nowFunc := r.nowFunc // capture for closure
 	respHeaders := resp.Header.Clone()
 
 	var mu sync.Mutex
@@ -416,6 +427,7 @@ func (r *Recorder) roundTripSSE(req *http.Request, resp *http.Response, reqBody 
 			Body:       nil,
 			SSEEvents:  collectedEvents,
 			Truncated:  truncated,
+			ElapsedMS:  elapsedMS(startTime, nowFunc),
 		}
 
 		tape := NewTape(r.route, recordedReq, recordedResp)

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1823,5 +1824,103 @@ func TestRecorder_MalformedJSON(t *testing.T) {
 	}
 	if !bytes.Equal(tapes[0].Request.Body, malformed) {
 		t.Error("malformed JSON request body was unexpectedly modified")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ElapsedMS recording
+// ---------------------------------------------------------------------------
+
+func TestRecorder_ElapsedMS_NonSSE(t *testing.T) {
+	store := NewMemoryStore()
+
+	callCount := 0
+	fakeNow := func() time.Time {
+		callCount++
+		// First call: start time. Second call: after response body read.
+		if callCount == 1 {
+			return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		}
+		return time.Date(2026, 1, 1, 0, 0, 0, 150*int(time.Millisecond), time.UTC)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("hello"))
+	}))
+	defer upstream.Close()
+
+	rec := NewRecorder(store,
+		WithAsync(false),
+		withRecorderNowFunc(fakeNow),
+	)
+	defer rec.Close()
+
+	client := &http.Client{Transport: rec}
+	resp, err := client.Get(upstream.URL + "/api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+	if tapes[0].Response.ElapsedMS != 150 {
+		t.Errorf("ElapsedMS = %d, want 150", tapes[0].Response.ElapsedMS)
+	}
+}
+
+func TestRecorder_ElapsedMS_SSE(t *testing.T) {
+	store := NewMemoryStore()
+
+	// The nowFunc is called twice: once for startTime (callCount=1) and once
+	// in elapsedMS at onDone time (callCount=2). We use a monotonic sequence.
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var callCount atomic.Int64
+	fakeNow := func() time.Time {
+		n := callCount.Add(1)
+		if n == 1 {
+			return baseTime
+		}
+		return baseTime.Add(500 * time.Millisecond)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		fmt.Fprint(w, "data: hello\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "data: world\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	rec := NewRecorder(store,
+		WithAsync(false),
+		withRecorderNowFunc(fakeNow),
+	)
+	defer rec.Close()
+
+	client := &http.Client{Transport: rec}
+	resp, err := client.Get(upstream.URL + "/stream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must consume the body for the SSE recording to complete.
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	tapes, _ := store.List(context.Background(), Filter{})
+	if len(tapes) != 1 {
+		t.Fatalf("expected 1 tape, got %d", len(tapes))
+	}
+	if !tapes[0].Response.IsSSE() {
+		t.Fatal("expected SSE tape")
+	}
+	if tapes[0].Response.ElapsedMS != 500 {
+		t.Errorf("ElapsedMS = %d, want 500", tapes[0].Response.ElapsedMS)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package httptape
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -20,20 +21,22 @@ import (
 type Server struct {
 	store            Store
 	matcher          Matcher
-	fallbackStatus   int                 // HTTP status when no tape matches
-	fallbackBody     []byte              // response body when no tape matches
-	onNoMatch        func(*http.Request) // optional callback when no tape matches
-	cors             bool                // if true, add CORS headers to all responses
-	delay            time.Duration       // fixed delay before every response; zero means no delay
-	errorRate        float64             // fraction of requests that return 500 (0.0-1.0)
-	randFloat        func() float64      // random number generator (injectable for testing)
-	replayHeaders    map[string]string   // headers injected into every replayed response
-	templating       bool                // if true, resolve {{...}} in responses
-	strictTemplating bool                // if true, unresolvable expressions produce 500
-	sseTiming        SSETimingMode       // controls SSE replay inter-event timing
-	counters         *counterState       // per-server counter state for {{counter}}
-	randSource       io.Reader           // randomness source for template helpers
-	synthesis        bool                // if true, exemplar tapes are consulted on miss
+	fallbackStatus   int                                        // HTTP status when no tape matches
+	fallbackBody     []byte                                     // response body when no tape matches
+	onNoMatch        func(*http.Request)                        // optional callback when no tape matches
+	cors             bool                                       // if true, add CORS headers to all responses
+	delay            time.Duration                              // fixed delay before every response; zero means no delay
+	errorRate        float64                                    // fraction of requests that return 500 (0.0-1.0)
+	randFloat        func() float64                             // random number generator (injectable for testing)
+	replayHeaders    map[string]string                          // headers injected into every replayed response
+	templating       bool                                       // if true, resolve {{...}} in responses
+	strictTemplating bool                                       // if true, unresolvable expressions produce 500
+	sseTiming        SSETimingMode                              // controls SSE replay inter-event timing
+	replayTiming     ResponseTimingMode                         // controls response elapsed-time replay delay
+	sleepFunc        func(context.Context, time.Duration) error // injectable sleep for testing
+	counters         *counterState                              // per-server counter state for {{counter}}
+	randSource       io.Reader                                  // randomness source for template helpers
+	synthesis        bool                                       // if true, exemplar tapes are consulted on miss
 }
 
 // ServerOption configures a Server.
@@ -193,6 +196,117 @@ func withRandSource(r io.Reader) ServerOption {
 	return func(s *Server) { s.randSource = r }
 }
 
+// ResponseTimingMode controls how the recorded response elapsed time is
+// applied during replay. It is a sealed interface implemented by three
+// unexported types, mirroring SSETimingMode.
+type ResponseTimingMode interface {
+	// responseDelay returns the duration to sleep before sending the
+	// response, given the recorded elapsed time in milliseconds.
+	// Returns zero for unknown elapsed time (elapsedMS <= 0).
+	responseDelay(elapsedMS int64) time.Duration
+	responseTimingMode() // seal
+}
+
+// responseTimingInstant replays responses immediately with no delay.
+// This is the default and preserves pre-feature behavior.
+type responseTimingInstant struct{}
+
+func (responseTimingInstant) responseTimingMode() {}
+func (responseTimingInstant) responseDelay(_ int64) time.Duration {
+	return 0
+}
+
+// responseTimingRecorded replays responses with the original recorded
+// elapsed time as a delay.
+type responseTimingRecorded struct{}
+
+func (responseTimingRecorded) responseTimingMode() {}
+func (responseTimingRecorded) responseDelay(elapsedMS int64) time.Duration {
+	if elapsedMS <= 0 {
+		return 0
+	}
+	return time.Duration(elapsedMS) * time.Millisecond
+}
+
+// responseTimingAccelerated divides the recorded elapsed time by the
+// given factor. Factor > 1 means slower than recorded; factor < 1 means
+// faster than recorded.
+type responseTimingAccelerated struct {
+	factor float64
+}
+
+func (responseTimingAccelerated) responseTimingMode() {}
+func (a responseTimingAccelerated) responseDelay(elapsedMS int64) time.Duration {
+	if elapsedMS <= 0 {
+		return 0
+	}
+	return time.Duration(float64(elapsedMS)*a.factor) * time.Millisecond
+}
+
+// ResponseTimingInstant returns a ResponseTimingMode that replays responses
+// immediately with no delay. This is the default mode and preserves
+// pre-feature behavior.
+func ResponseTimingInstant() ResponseTimingMode {
+	return responseTimingInstant{}
+}
+
+// ResponseTimingRecorded returns a ResponseTimingMode that replays responses
+// with the original recorded elapsed time as a delay. Pre-feature fixtures
+// (ElapsedMS == 0) are replayed instantly regardless of this setting.
+func ResponseTimingRecorded() ResponseTimingMode {
+	return responseTimingRecorded{}
+}
+
+// ResponseTimingAccelerated returns a ResponseTimingMode that scales the
+// recorded elapsed time by the given factor. A factor > 1 makes responses
+// slower than recorded; a factor < 1 makes them faster. Factor must be > 0;
+// returns an error otherwise.
+func ResponseTimingAccelerated(factor float64) (ResponseTimingMode, error) {
+	if factor <= 0 {
+		return nil, fmt.Errorf("httptape: ResponseTimingAccelerated factor must be > 0, got %g", factor)
+	}
+	return responseTimingAccelerated{factor: factor}, nil
+}
+
+// WithReplayTiming sets the response timing mode for replayed responses.
+// Defaults to ResponseTimingInstant() (no delay, preserving pre-feature
+// behavior).
+//
+// Timing composition: WithReplayTiming composes ADDITIVELY with
+// WithDelay / metadata.delay. The existing effectiveDelay (user-authored
+// "simulate slow API" delay) runs first, then the replay timing delay
+// runs second, before the response is written. This means if WithDelay
+// is 100ms and the recorded elapsed time is 200ms with
+// ResponseTimingRecorded(), the total delay is 300ms. Pre-feature
+// fixtures (ElapsedMS == 0) incur no replay timing delay regardless
+// of mode.
+func WithReplayTiming(mode ResponseTimingMode) ServerOption {
+	return func(s *Server) { s.replayTiming = mode }
+}
+
+// withSleepFunc overrides the sleep function for testing. This is
+// unexported -- only used in tests to avoid real sleeping.
+func withSleepFunc(fn func(context.Context, time.Duration) error) ServerOption {
+	return func(s *Server) { s.sleepFunc = fn }
+}
+
+// defaultSleepFunc sleeps for the given duration, respecting context
+// cancellation. Returns nil on successful sleep, or the context error
+// if the context is cancelled during the sleep.
+func defaultSleepFunc(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // NewServer creates a new Server that replays tapes from the given store.
 //
 // By default:
@@ -222,6 +336,8 @@ func NewServer(store Store, opts ...ServerOption) (*Server, error) {
 		fallbackBody:   []byte("httptape: no matching tape found"),
 		templating:     true,
 		sseTiming:      SSETimingRealtime(),
+		replayTiming:   ResponseTimingInstant(),
+		sleepFunc:      defaultSleepFunc,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -374,6 +490,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// delay elapsed, proceed to write response
 		case <-r.Context().Done():
 			// client disconnected during delay, bail out
+			return
+		}
+	}
+
+	// 9b. Replay timing delay (opt-in via WithReplayTiming). This composes
+	// ADDITIVELY with the effectiveDelay above: WithDelay / metadata.delay
+	// is a user-authored "simulate slow API" delay, while WithReplayTiming
+	// is replay-fidelity. Both run sequentially so the total delay is their
+	// sum. Pre-feature fixtures (ElapsedMS == 0) incur no replay timing
+	// delay regardless of mode.
+	if replayDelay := s.replayTiming.responseDelay(tape.Response.ElapsedMS); replayDelay > 0 {
+		if err := s.sleepFunc(r.Context(), replayDelay); err != nil {
+			// Context cancelled during replay timing delay.
 			return
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1958,3 +1958,347 @@ func TestServer_SynthesisEnabled_PatternWithNoParams(t *testing.T) {
 		t.Errorf("body = %s, want %s", got, want)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ResponseTimingMode
+// ---------------------------------------------------------------------------
+
+func TestResponseTimingInstant(t *testing.T) {
+	mode := ResponseTimingInstant()
+
+	tests := []struct {
+		name      string
+		elapsedMS int64
+		want      time.Duration
+	}{
+		{"zero elapsed", 0, 0},
+		{"positive elapsed", 500, 0},
+		{"negative elapsed", -1, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mode.responseDelay(tt.elapsedMS)
+			if got != tt.want {
+				t.Errorf("responseDelay(%d) = %v, want %v", tt.elapsedMS, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResponseTimingRecorded(t *testing.T) {
+	mode := ResponseTimingRecorded()
+
+	tests := []struct {
+		name      string
+		elapsedMS int64
+		want      time.Duration
+	}{
+		{"zero elapsed returns no delay", 0, 0},
+		{"positive elapsed returns that duration", 250, 250 * time.Millisecond},
+		{"negative elapsed returns no delay", -1, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mode.responseDelay(tt.elapsedMS)
+			if got != tt.want {
+				t.Errorf("responseDelay(%d) = %v, want %v", tt.elapsedMS, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResponseTimingAccelerated(t *testing.T) {
+	t.Run("factor 2 doubles elapsed time", func(t *testing.T) {
+		mode, err := ResponseTimingAccelerated(2.0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := mode.responseDelay(100)
+		if got != 200*time.Millisecond {
+			t.Errorf("responseDelay(100) with factor 2 = %v, want 200ms", got)
+		}
+	})
+
+	t.Run("factor 0.5 halves elapsed time", func(t *testing.T) {
+		mode, err := ResponseTimingAccelerated(0.5)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := mode.responseDelay(100)
+		if got != 50*time.Millisecond {
+			t.Errorf("responseDelay(100) with factor 0.5 = %v, want 50ms", got)
+		}
+	})
+
+	t.Run("zero elapsed returns no delay regardless of factor", func(t *testing.T) {
+		mode, err := ResponseTimingAccelerated(2.0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := mode.responseDelay(0)
+		if got != 0 {
+			t.Errorf("responseDelay(0) = %v, want 0", got)
+		}
+	})
+
+	t.Run("negative factor returns error", func(t *testing.T) {
+		_, err := ResponseTimingAccelerated(-1.0)
+		if err == nil {
+			t.Error("expected error for negative factor")
+		}
+	})
+
+	t.Run("zero factor returns error", func(t *testing.T) {
+		_, err := ResponseTimingAccelerated(0.0)
+		if err == nil {
+			t.Error("expected error for zero factor")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// WithReplayTiming on Server
+// ---------------------------------------------------------------------------
+
+func TestServer_WithReplayTiming_Recorded(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/data",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/plain"}},
+		Body:       []byte("ok"),
+		ElapsedMS:  300,
+	})
+	store.Save(context.Background(), tape)
+
+	var sleepCalled bool
+	var sleepDuration time.Duration
+
+	srv, err := NewServer(store,
+		WithReplayTiming(ResponseTimingRecorded()),
+		withSleepFunc(func(_ context.Context, d time.Duration) error {
+			sleepCalled = true
+			sleepDuration = d
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !sleepCalled {
+		t.Error("sleepFunc was not called for recorded timing mode")
+	}
+	if sleepDuration != 300*time.Millisecond {
+		t.Errorf("sleepDuration = %v, want 300ms", sleepDuration)
+	}
+}
+
+func TestServer_WithReplayTiming_Instant(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/data",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/plain"}},
+		Body:       []byte("ok"),
+		ElapsedMS:  300,
+	})
+	store.Save(context.Background(), tape)
+
+	var sleepCalled bool
+
+	srv, err := NewServer(store,
+		WithReplayTiming(ResponseTimingInstant()),
+		withSleepFunc(func(_ context.Context, d time.Duration) error {
+			sleepCalled = true
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if sleepCalled {
+		t.Error("sleepFunc was called with instant timing mode (should not be)")
+	}
+}
+
+func TestServer_WithReplayTiming_PreFeatureFixtureNoDelay(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/data",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/plain"}},
+		Body:       []byte("ok"),
+		ElapsedMS:  0, // pre-feature fixture
+	})
+	store.Save(context.Background(), tape)
+
+	var sleepCalled bool
+
+	srv, err := NewServer(store,
+		WithReplayTiming(ResponseTimingRecorded()),
+		withSleepFunc(func(_ context.Context, d time.Duration) error {
+			sleepCalled = true
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if sleepCalled {
+		t.Error("sleepFunc was called for pre-feature fixture (ElapsedMS=0)")
+	}
+}
+
+func TestServer_WithReplayTiming_AdditiveWithDelay(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/data",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/plain"}},
+		Body:       []byte("ok"),
+		ElapsedMS:  200,
+	})
+	store.Save(context.Background(), tape)
+
+	var sleepDurations []time.Duration
+
+	srv, err := NewServer(store,
+		WithDelay(100*time.Millisecond),
+		WithReplayTiming(ResponseTimingRecorded()),
+		withSleepFunc(func(_ context.Context, d time.Duration) error {
+			sleepDurations = append(sleepDurations, d)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	// The replay timing delay should be 200ms (recorded elapsed).
+	// WithDelay uses its own timer/select, not sleepFunc. The sleepFunc
+	// only captures the replay timing delay.
+	if len(sleepDurations) != 1 {
+		t.Fatalf("sleepFunc called %d times, want 1", len(sleepDurations))
+	}
+	if sleepDurations[0] != 200*time.Millisecond {
+		t.Errorf("replay timing sleep = %v, want 200ms", sleepDurations[0])
+	}
+}
+
+func TestServer_WithReplayTiming_ContextCancelled(t *testing.T) {
+	store := NewMemoryStore()
+	tape := NewTape("", RecordedReq{
+		Method: "GET",
+		URL:    "/api/data",
+	}, RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"text/plain"}},
+		Body:       []byte("ok"),
+		ElapsedMS:  1000,
+	})
+	store.Save(context.Background(), tape)
+
+	sleepCalled := false
+	srv, err := NewServer(store,
+		WithReplayTiming(ResponseTimingRecorded()),
+		withSleepFunc(func(ctx context.Context, _ time.Duration) error {
+			sleepCalled = true
+			return ctx.Err()
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a valid context for the store.List call, but cancel before
+	// the sleep runs.
+	rec := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/api/data", nil).WithContext(ctx)
+	cancel() // cancel after request is built but before ServeHTTP
+
+	srv.ServeHTTP(rec, req)
+
+	// When context is cancelled, store.List may fail (returning 500
+	// "store error") or the sleepFunc may return early. Either path
+	// means the normal 200 body is NOT returned.
+	if sleepCalled {
+		// If sleep was reached, it returned ctx.Err() and the server
+		// bailed out without writing the normal response body.
+		if rec.Body.String() == "ok" {
+			t.Error("expected response body != 'ok' when context was cancelled during sleep")
+		}
+	}
+	// If store.List failed due to the cancelled context, the server
+	// returns 500 "store error" -- that's also acceptable.
+}
+
+// ---------------------------------------------------------------------------
+// defaultSleepFunc
+// ---------------------------------------------------------------------------
+
+func TestDefaultSleepFunc_ZeroDuration(t *testing.T) {
+	err := defaultSleepFunc(context.Background(), 0)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDefaultSleepFunc_NegativeDuration(t *testing.T) {
+	err := defaultSleepFunc(context.Background(), -1*time.Millisecond)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDefaultSleepFunc_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := defaultSleepFunc(ctx, 10*time.Second)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+}

--- a/tape.go
+++ b/tape.go
@@ -126,6 +126,13 @@ type RecordedResp struct {
 	// When nil or empty (including for tapes created before SSE support was
 	// added), the tape is treated as a regular HTTP response.
 	SSEEvents []SSEEvent `json:"sse_events,omitempty"`
+
+	// ElapsedMS is the total response time in milliseconds, measured from
+	// when the request was sent to when the response body was fully received
+	// (non-SSE) or when the SSE stream completed (SSE). Zero means unknown
+	// (pre-feature fixtures or measurement failure). Always recorded; replay
+	// delay is opt-in via WithReplayTiming / WithCacheReplayTiming.
+	ElapsedMS int64 `json:"elapsed_ms,omitempty"`
 }
 
 // IsSSE reports whether this response represents an SSE stream.
@@ -216,6 +223,7 @@ func (r RecordedResp) MarshalJSON() ([]byte, error) {
 		Truncated        bool        `json:"truncated,omitempty"`
 		OriginalBodySize int64       `json:"original_body_size,omitempty"`
 		SSEEvents        []SSEEvent  `json:"sse_events,omitempty"`
+		ElapsedMS        int64       `json:"elapsed_ms,omitempty"`
 	}
 
 	a := alias{
@@ -225,6 +233,7 @@ func (r RecordedResp) MarshalJSON() ([]byte, error) {
 		Truncated:        r.Truncated,
 		OriginalBodySize: r.OriginalBodySize,
 		SSEEvents:        r.SSEEvents,
+		ElapsedMS:        r.ElapsedMS,
 	}
 
 	a.Body = marshalBody(r.Body, r.Headers)
@@ -242,6 +251,7 @@ func (r *RecordedResp) UnmarshalJSON(data []byte) error {
 		Truncated        bool            `json:"truncated,omitempty"`
 		OriginalBodySize int64           `json:"original_body_size,omitempty"`
 		SSEEvents        []SSEEvent      `json:"sse_events,omitempty"`
+		ElapsedMS        int64           `json:"elapsed_ms,omitempty"`
 	}
 
 	var a alias
@@ -254,6 +264,7 @@ func (r *RecordedResp) UnmarshalJSON(data []byte) error {
 	r.Truncated = a.Truncated
 	r.OriginalBodySize = a.OriginalBodySize
 	r.SSEEvents = a.SSEEvents
+	r.ElapsedMS = a.ElapsedMS
 
 	body, err := unmarshalBody(a.Body, a.Headers)
 	if err != nil {
@@ -435,6 +446,14 @@ func BodyHashFromBytes(b []byte) string {
 	}
 	h := sha256.Sum256(b)
 	return hex.EncodeToString(h[:])
+}
+
+// elapsedMS returns the elapsed milliseconds since start using the provided
+// now function. This helper is used by all 6 recording sites (Recorder,
+// CachingTransport, l1RecordingTransport -- each non-SSE and SSE paths)
+// to populate RecordedResp.ElapsedMS.
+func elapsedMS(start time.Time, now func() time.Time) int64 {
+	return now().Sub(start).Milliseconds()
 }
 
 // newUUID generates a UUID v4 string using crypto/rand.

--- a/tape_test.go
+++ b/tape_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewTape(t *testing.T) {
@@ -889,5 +890,128 @@ func TestTape_MarshalJSON_RoundTrip_Exemplar(t *testing.T) {
 	}
 	if string(data) != string(data2) {
 		t.Errorf("round-trip mismatch:\n  first:  %s\n  second: %s", data, data2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ElapsedMS serialization
+// ---------------------------------------------------------------------------
+
+func TestRecordedResp_MarshalJSON_ElapsedMSOmitempty(t *testing.T) {
+	r := RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{}`),
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if strings.Contains(string(data), "elapsed_ms") {
+		t.Errorf("elapsed_ms should be omitted when zero, got: %s", data)
+	}
+}
+
+func TestRecordedResp_MarshalJSON_ElapsedMSPresent(t *testing.T) {
+	r := RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{}`),
+		ElapsedMS:  142,
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"elapsed_ms":142`) {
+		t.Errorf("expected elapsed_ms:142 in output, got: %s", data)
+	}
+}
+
+func TestRecordedResp_UnmarshalJSON_ElapsedMS(t *testing.T) {
+	input := `{
+		"status_code": 200,
+		"headers": {"Content-Type": ["text/plain"]},
+		"body": "hello",
+		"elapsed_ms": 350
+	}`
+
+	var r RecordedResp
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if r.ElapsedMS != 350 {
+		t.Errorf("ElapsedMS = %d, want 350", r.ElapsedMS)
+	}
+}
+
+func TestRecordedResp_UnmarshalJSON_ElapsedMSAbsent(t *testing.T) {
+	input := `{
+		"status_code": 200,
+		"headers": {"Content-Type": ["text/plain"]},
+		"body": "hello"
+	}`
+
+	var r RecordedResp
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if r.ElapsedMS != 0 {
+		t.Errorf("ElapsedMS = %d, want 0 for pre-feature fixture", r.ElapsedMS)
+	}
+}
+
+func TestRecordedResp_JSON_RoundTrip_WithElapsedMS(t *testing.T) {
+	original := RecordedResp{
+		StatusCode: 200,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"key":"value"}`),
+		ElapsedMS:  500,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var roundTripped RecordedResp
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if roundTripped.ElapsedMS != original.ElapsedMS {
+		t.Errorf("ElapsedMS = %d, want %d", roundTripped.ElapsedMS, original.ElapsedMS)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// elapsedMS helper
+// ---------------------------------------------------------------------------
+
+func TestElapsedMS(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	nowFunc := func() time.Time {
+		return start.Add(250 * time.Millisecond)
+	}
+
+	got := elapsedMS(start, nowFunc)
+	if got != 250 {
+		t.Errorf("elapsedMS = %d, want 250", got)
+	}
+}
+
+func TestElapsedMS_Zero(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	nowFunc := func() time.Time { return start }
+
+	got := elapsedMS(start, nowFunc)
+	if got != 0 {
+		t.Errorf("elapsedMS = %d, want 0", got)
 	}
 }


### PR DESCRIPTION
Closes #240

## Summary

- **`RecordedResp.ElapsedMS int64`** (`omitempty`): records total response elapsed time in milliseconds. Always-on recording, no opt-out. Both `MarshalJSON` and `UnmarshalJSON` alias structs updated.
- **`elapsedMS(start, nowFunc)` helper** in `tape.go`: used by all 6 recording sites.
- **`ResponseTimingMode` sealed interface** (mirrors `SSETimingMode` shape) with 3 constructors:
  - `ResponseTimingInstant()` -- no delay (default)
  - `ResponseTimingRecorded()` -- replay with recorded elapsed time
  - `ResponseTimingAccelerated(factor)` -- scale elapsed time by factor (>0 required)
- **`WithReplayTiming(mode)`** `ServerOption` on `Server`
- **`WithCacheReplayTiming(mode)`** `CachingOption` on `CachingTransport`
- **`defaultSleepFunc`**: timer + select on ctx.Done, same pattern as existing `effectiveDelay`

### Six recording sites (ElapsedMS populated)

1. `recorder.go` -- `Recorder.RoundTrip` non-SSE path
2. `recorder.go` -- `Recorder.roundTripSSE` SSE path
3. `caching_transport.go` -- `roundTripUpstream` non-SSE path
4. `caching_transport.go` -- `roundTripSSE` SSE path
5. `proxy.go` -- `l1RecordingTransport.RoundTrip` non-SSE path
6. `proxy.go` -- `l1RecordingTransport.roundTripSSE` SSE path

### Additive composition with WithDelay / metadata.delay

Replay timing runs AFTER the existing `effectiveDelay` block (step 9) and BEFORE writing the response (step 10). The total delay is their sum:

- `WithDelay(100ms)` + `ResponseTimingRecorded()` with `ElapsedMS=200` = 300ms total
- Documented in code comment at the apply site + godoc on `WithReplayTiming`

### Clock and sleep injection

- Each recording struct gains `nowFunc func() time.Time` (mirrors `randFloat` pattern)
- Server and CachingTransport gain `sleepFunc func(context.Context, time.Duration) error`
- All unexported `withNowFunc` / `withSleepFunc` test options prevent real sleeping

### Backward compatibility

- `elapsed_ms` uses `omitempty`: pre-feature fixtures remain byte-identical
- Default mode is `Instant` (no delay): pre-feature behavior preserved
- Pre-feature fixtures (`ElapsedMS == 0`) incur no delay regardless of mode

## Test plan

- [x] `RecordedResp` marshal/unmarshal round-trip with `ElapsedMS`
- [x] `ElapsedMS` omitted when zero (pre-feature compat)
- [x] `elapsedMS()` helper unit test
- [x] `ResponseTimingInstant` returns zero for all inputs
- [x] `ResponseTimingRecorded` returns recorded duration, zero for 0/negative
- [x] `ResponseTimingAccelerated` scales correctly, rejects factor <= 0
- [x] `WithReplayTiming(Recorded)` invokes sleepFunc with correct duration
- [x] `WithReplayTiming(Instant)` does not invoke sleepFunc
- [x] Pre-feature fixture (ElapsedMS=0) does not delay with `Recorded` mode
- [x] Additive composition: WithDelay + WithReplayTiming both apply
- [x] Context cancellation during replay timing aborts response
- [x] `defaultSleepFunc` zero/negative duration returns immediately
- [x] `defaultSleepFunc` cancelled context returns error
- [x] Recorder non-SSE records ElapsedMS via injected clock
- [x] Recorder SSE records ElapsedMS via injected clock
- [x] CachingTransport non-SSE records ElapsedMS via injected clock
- [x] CachingTransport SSE records ElapsedMS via injected clock
- [x] CachingTransport cache-hit with `WithCacheReplayTiming(Recorded)` sleeps
- [x] CachingTransport cache-hit pre-feature fixture does not sleep
- [x] l1RecordingTransport non-SSE records ElapsedMS
- [x] l1RecordingTransport SSE records ElapsedMS
- [x] Proxy records ElapsedMS in both L1 and L2
- [x] All tests race-clean (`go test -race`)
- [x] No real sleeping in tests (all use `sleepFunc` injection)
- [x] `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` all clean