### PR TITLE
chore(#249): rename module + image namespace to httptape org (phase 1)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -14,13 +14,13 @@ agent can implement without ambiguity.
 1. **Read context first** — always read:
    - `CLAUDE.md` (locked decisions, architecture principles, package structure)
    - `decisions.md` (previous ADRs — never contradict a closed decision)
-   - The GitHub issue assigned to you (`gh issue view <number> --repo VibeWarden/httptape --comments`)
+   - The GitHub issue assigned to you (`gh issue view <number> --repo httptape/httptape --comments`)
    - Relevant existing code (`Glob`, `Grep` to understand current state)
 
 2. **Validate the spec** — if the PM spec is missing information or contradicts locked
    decisions, post a short comment on the issue and set status back to `NEEDS_CLARIFICATION`:
    ```bash
-   gh issue comment <number> --repo VibeWarden/httptape \
+   gh issue comment <number> --repo httptape/httptape \
      --body "Status: NEEDS_CLARIFICATION\n\nBlocking questions:\n- <question>"
    ```
    Do not design around incomplete specs.
@@ -77,7 +77,7 @@ agent can implement without ambiguity.
 
 6. **Post a short comment to the GitHub issue** — keep this brief:
    ```bash
-   gh issue comment <number> --repo VibeWarden/httptape --body "Status: READY_FOR_DEV
+   gh issue comment <number> --repo httptape/httptape --body "Status: READY_FOR_DEV
 
    Design: ADR-<N> in decisions.md
 

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -16,7 +16,7 @@ single-package layout and hexagonal-by-convention architecture.
    - `decisions.md` — all ADRs, especially the one for this issue
    - The GitHub issue and all its comments:
      ```bash
-     gh issue view <number> --repo VibeWarden/httptape --comments
+     gh issue view <number> --repo httptape/httptape --comments
      ```
    - Existing code in the package (`Glob`, `Grep`)
 
@@ -57,7 +57,7 @@ single-package layout and hexagonal-by-convention architecture.
    ```bash
    git push origin feat/<issue-number>-<short-slug>
    gh pr create \
-     --repo VibeWarden/httptape \
+     --repo httptape/httptape \
      --title "feat(#<number>): <description>" \
      --body "Closes #<number>\n\n## Summary\n<what you built>\n\n## Test plan\n<how to verify>" \
      --label "status:review"
@@ -65,7 +65,7 @@ single-package layout and hexagonal-by-convention architecture.
 
 8. **Set issue status**:
    ```bash
-   gh issue comment <number> --repo VibeWarden/httptape --body "Status: READY_FOR_REVIEW\nPR: <pr-url>"
+   gh issue comment <number> --repo httptape/httptape --body "Status: READY_FOR_REVIEW\nPR: <pr-url>"
    ```
 
 ## Code quality rules

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -21,12 +21,12 @@ coming back to ask questions.
    - Out of scope (explicit list of what this story does NOT cover)
    - Open questions (if any — flag these, do not guess)
 
-3. **Create GitHub issues** — use `gh` CLI to create issues in `VibeWarden/httptape`
+3. **Create GitHub issues** — use `gh` CLI to create issues in `httptape/httptape`
    with the correct milestone label and body. Use this format:
 
    ```bash
    gh issue create \
-     --repo VibeWarden/httptape \
+     --repo httptape/httptape \
      --title "..." \
      --body "..." \
      --label "milestone:..."
@@ -34,7 +34,7 @@ coming back to ask questions.
 
 4. **Set status** — after creating or updating an issue, add a comment:
    ```bash
-   gh issue comment <number> --repo VibeWarden/httptape --body "Status: READY_FOR_ARCH"
+   gh issue comment <number> --repo httptape/httptape --body "Status: READY_FOR_ARCH"
    ```
 
 ## Spec quality rules

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -17,12 +17,12 @@ become technical debt.
    - `decisions.md` — ADRs for this issue
    - The PR details:
      ```bash
-     gh pr view <number> --repo VibeWarden/httptape --comments
-     gh pr diff <number> --repo VibeWarden/httptape
+     gh pr view <number> --repo httptape/httptape --comments
+     gh pr diff <number> --repo httptape/httptape
      ```
    - The linked issue:
      ```bash
-     gh issue view <issue-number> --repo VibeWarden/httptape --comments
+     gh issue view <issue-number> --repo httptape/httptape --comments
      ```
 
 2. **Review the diff** systematically against this checklist.
@@ -31,7 +31,7 @@ become technical debt.
    ```bash
    gh api \
      --method POST \
-     /repos/VibeWarden/httptape/pulls/<pr-number>/comments \
+     /repos/httptape/httptape/pulls/<pr-number>/comments \
      -f body="<comment>" \
      -f commit_id="<commit-sha>" \
      -f path="<file-path>" \
@@ -41,12 +41,12 @@ become technical debt.
 4. **Submit review** — approve or request changes:
    ```bash
    # Request changes
-   gh pr review <number> --repo VibeWarden/httptape \
+   gh pr review <number> --repo httptape/httptape \
      --request-changes \
      --body "<summary of issues found>"
 
    # Approve
-   gh pr review <number> --repo VibeWarden/httptape \
+   gh pr review <number> --repo httptape/httptape \
      --approve \
      --body "LGTM. <brief summary of what was reviewed>"
    ```
@@ -54,11 +54,11 @@ become technical debt.
 5. **Set issue status**:
    ```bash
    # If changes requested
-   gh issue comment <issue-number> --repo VibeWarden/httptape \
+   gh issue comment <issue-number> --repo httptape/httptape \
      --body "Status: CHANGES_REQUESTED\n<summary>"
 
    # If approved
-   gh issue comment <issue-number> --repo VibeWarden/httptape \
+   gh issue comment <issue-number> --repo httptape/httptape \
      --body "Status: APPROVED — ready for human review"
    ```
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or how-to
-    url: https://github.com/VibeWarden/httptape/discussions
+    url: https://github.com/httptape/httptape/discussions
     about: For "how do I do X with httptape?" questions, please use Discussions.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME_GHCR: ghcr.io/vibewarden/httptape
+  IMAGE_NAME_GHCR: ghcr.io/httptape/httptape
   IMAGE_NAME_DOCKERHUB: tibtof/httptape
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ PM Agent → Architect Agent → Dev Agent → Reviewer Agent → (your PR revie
 
 ## GitHub conventions
 
-- Org: `VibeWarden`
+- Org: `httptape`
 - Repo: `httptape`
 - Branch naming: `feat/<issue-number>-<short-slug>`, `fix/<issue-number>-<short-slug>`
 - Commit style: conventional commits (`feat:`, `fix:`, `chore:`, `docs:`, `test:`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ USER 65534
 # `docker build .` and on downstream re-builds.
 LABEL org.opencontainers.image.title="httptape" \
       org.opencontainers.image.description="HTTP traffic recording, redaction, and replay — embeddable Go library, CLI, and 3 MB Docker image." \
-      org.opencontainers.image.source="https://github.com/VibeWarden/httptape" \
-      org.opencontainers.image.url="https://github.com/VibeWarden/httptape" \
+      org.opencontainers.image.source="https://github.com/httptape/httptape" \
+      org.opencontainers.image.url="https://github.com/httptape/httptape" \
       org.opencontainers.image.documentation="https://vibewarden.dev/docs/httptape/" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.version="${VERSION}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/VibeWarden/httptape/main/assets/logo.png" alt="httptape logo" width="300">
+  <img src="https://raw.githubusercontent.com/httptape/httptape/main/assets/logo.png" alt="httptape logo" width="300">
 </p>
 
 <h3 align="center">Record, Redact, Replay</h3>
@@ -10,9 +10,9 @@
 </p>
 
 <p align="center">
-  <a href="https://pkg.go.dev/github.com/VibeWarden/httptape"><img src="https://pkg.go.dev/badge/github.com/VibeWarden/httptape.svg" alt="Go Reference"></a>
-  <a href="https://github.com/VibeWarden/httptape/actions/workflows/test.yml"><img src="https://github.com/VibeWarden/httptape/actions/workflows/test.yml/badge.svg?branch=main" alt="Tests"></a>
-  <a href="https://scorecard.dev/viewer/?uri=github.com/VibeWarden/httptape"><img src="https://api.scorecard.dev/projects/github.com/VibeWarden/httptape/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://pkg.go.dev/github.com/httptape/httptape"><img src="https://pkg.go.dev/badge/github.com/httptape/httptape.svg" alt="Go Reference"></a>
+  <a href="https://github.com/httptape/httptape/actions/workflows/test.yml"><img src="https://github.com/httptape/httptape/actions/workflows/test.yml/badge.svg?branch=main" alt="Tests"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/httptape/httptape"><img src="https://api.scorecard.dev/projects/github.com/httptape/httptape/badge" alt="OpenSSF Scorecard"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://hub.docker.com/r/tibtof/httptape"><img src="https://img.shields.io/docker/image-size/tibtof/httptape/latest?label=docker" alt="Docker Image Size"></a>
 </p>
@@ -134,12 +134,12 @@ See [Recording](https://vibewarden.dev/docs/httptape/recording/) and [Replay](ht
 
 **Go library:**
 ```bash
-go get github.com/VibeWarden/httptape
+go get github.com/httptape/httptape
 ```
 
 **CLI:**
 ```bash
-go install github.com/VibeWarden/httptape/cmd/httptape@latest
+go install github.com/httptape/httptape/cmd/httptape@latest
 ```
 
 **Docker** (~3 MB, multi-arch):
@@ -309,10 +309,10 @@ release:
 
 ```bash
 docker pull tibtof/httptape           # Docker Hub
-docker pull ghcr.io/vibewarden/httptape   # GHCR
+docker pull ghcr.io/httptape/httptape   # GHCR
 ```
 
-Examples below use `tibtof/httptape`; substitute `ghcr.io/vibewarden/httptape`
+Examples below use `tibtof/httptape`; substitute `ghcr.io/httptape/httptape`
 freely.
 
 ```bash
@@ -333,7 +333,7 @@ docker run -v ./cache:/fixtures -v ./config.json:/config/config.json -p 8081:808
 ## Testcontainers
 
 ```go
-import httptapetest "github.com/VibeWarden/httptape/testcontainers"
+import httptapetest "github.com/httptape/httptape/testcontainers"
 
 container, err := httptapetest.RunContainer(ctx,
     httptapetest.WithFixturesDir("./testdata/fixtures"),

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ This policy will be revisited at 1.0.
 ## Reporting a vulnerability
 
 **Preferred**: open a GitHub Private Vulnerability Report at
-<https://github.com/VibeWarden/httptape/security/advisories/new>.
+<https://github.com/httptape/httptape/security/advisories/new>.
 This keeps the report private until a fix is ready and lets us coordinate a
 CVE if applicable.
 

--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -33,7 +33,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/VibeWarden/httptape"
+	"github.com/httptape/httptape"
 )
 
 // usageError wraps an error to indicate a usage/flag-parsing problem (exit code 1)

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/VibeWarden/httptape"
+	"github.com/httptape/httptape"
 )
 
 func TestSubcommandDispatch(t *testing.T) {

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/VibeWarden/httptape/config.schema.json",
+  "$id": "https://github.com/httptape/httptape/config.schema.json",
   "title": "httptape config",
   "description": "Declarative configuration for httptape's sanitization pipeline and matcher composition. Maps to the Go API: RedactHeaders, RedactBodyPaths, FakeFields, CompositeMatcher.",
   "type": "object",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 
 services:
   serve:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     profiles: [serve]
     command:
       - serve
@@ -19,7 +19,7 @@ services:
       - ./config.json:/config/config.json:ro
 
   record:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     profiles: [record]
     command:
       - record

--- a/docs/caching-transport.md
+++ b/docs/caching-transport.md
@@ -328,7 +328,7 @@ import (
     "net/http"
     "time"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,7 +5,7 @@ httptape includes a standalone CLI binary for HTTP traffic recording, redaction,
 ## Install
 
 ```bash
-go install github.com/VibeWarden/httptape/cmd/httptape@latest
+go install github.com/httptape/httptape/cmd/httptape@latest
 ```
 
 Or use the [Docker image](docker.md).

--- a/docs/config.md
+++ b/docs/config.md
@@ -268,13 +268,13 @@ Additional rules for `matcher`:
 
 ## JSON Schema
 
-A JSON Schema is available at [`config.schema.json`](https://github.com/VibeWarden/httptape/blob/main/config.schema.json) for IDE autocompletion and CI validation.
+A JSON Schema is available at [`config.schema.json`](https://github.com/httptape/httptape/blob/main/config.schema.json) for IDE autocompletion and CI validation.
 
 Reference it in your config file:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/VibeWarden/httptape/main/config.schema.json",
+  "$schema": "https://raw.githubusercontent.com/httptape/httptape/main/config.schema.json",
   "version": "1",
   "rules": [...]
 }

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,7 +5,7 @@ httptape is available as a minimal Docker image built from scratch (no OS, no sh
 ## Pull
 
 ```bash
-docker pull ghcr.io/vibewarden/httptape:latest
+docker pull ghcr.io/httptape/httptape:latest
 ```
 
 ## Serve mode
@@ -16,7 +16,7 @@ Replay recorded fixtures:
 docker run --rm \
   -v ./fixtures:/fixtures:ro \
   -p 8081:8081 \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   serve --fixtures /fixtures --port 8081
 ```
 
@@ -31,7 +31,7 @@ docker run --rm \
   -v ./fixtures:/fixtures \
   -v ./redact.json:/config/config.json:ro \
   -p 8081:8081 \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   record --upstream https://api.example.com \
          --fixtures /fixtures \
          --config /config/config.json \
@@ -49,7 +49,7 @@ docker run --rm \
   -v ./cache:/fixtures \
   -v ./redact.json:/config/config.json:ro \
   -p 8081:8081 \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   proxy --upstream https://api.example.com \
         --fixtures /fixtures \
         --config /config/config.json \
@@ -85,7 +85,7 @@ Both are declared as `VOLUME` in the Dockerfile and pre-exist in the image.
 ```yaml
 services:
   mock-api:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["serve", "--fixtures", "/fixtures", "--port", "8081"]
     ports:
       - "8081:8081"
@@ -105,7 +105,7 @@ services:
 ```yaml
 services:
   recorder:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command:
       - record
       - --upstream
@@ -128,7 +128,7 @@ services:
 ```yaml
 services:
   api-proxy:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command:
       - proxy
       - --upstream
@@ -162,13 +162,13 @@ services:
 ```yaml
 services:
   recorder:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["record", "--upstream", "https://api.example.com", "--fixtures", "/fixtures", "--port", "8081"]
     volumes:
       - fixture-data:/fixtures
 
   exporter:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["export", "--fixtures", "/fixtures", "--output", "/output/bundle.tar.gz"]
     volumes:
       - fixture-data:/fixtures:ro
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mock-api:
-        image: ghcr.io/vibewarden/httptape:latest
+        image: ghcr.io/httptape/httptape:latest
         options: >-
           -v ${{ github.workspace }}/fixtures:/fixtures:ro
         ports:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ Record, Redact, and Replay HTTP traffic in 5 minutes.
 
 - Go 1.26 or later (for the Go library)
 - Or: Docker (for CLI/Docker usage with any language)
-- `go get github.com/VibeWarden/httptape`
+- `go get github.com/httptape/httptape`
 
 ## Step 1: Record HTTP traffic
 
@@ -19,7 +19,7 @@ import (
     "fmt"
     "net/http"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {
@@ -62,7 +62,7 @@ import (
     "net/http"
     "net/http/httptest"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {
@@ -97,7 +97,7 @@ import (
     "net/http"
     "strings"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {
@@ -144,7 +144,7 @@ import (
     "net/http/httptest"
     "testing"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func TestUserAPI(t *testing.T) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,19 +35,19 @@ httptape captures HTTP request/response pairs, redacts sensitive data on write, 
 === "Go library"
 
     ```bash
-    go get github.com/VibeWarden/httptape
+    go get github.com/httptape/httptape
     ```
 
 === "CLI"
 
     ```bash
-    go install github.com/VibeWarden/httptape/cmd/httptape@latest
+    go install github.com/httptape/httptape/cmd/httptape@latest
     ```
 
 === "Docker"
 
     ```bash
-    docker pull ghcr.io/vibewarden/httptape:latest
+    docker pull ghcr.io/httptape/httptape:latest
     ```
 
 Requires Go 1.26 or later for the library/CLI. Docker works with any platform.
@@ -62,7 +62,7 @@ import (
     "net/http"
     "net/http/httptest"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {
@@ -117,4 +117,4 @@ httptape proxy --upstream https://api.github.com --fixtures ./cache
 
 ## License
 
-[Apache 2.0](https://github.com/VibeWarden/httptape/blob/main/LICENSE)
+[Apache 2.0](https://github.com/httptape/httptape/blob/main/LICENSE)

--- a/docs/other-languages.md
+++ b/docs/other-languages.md
@@ -1,6 +1,6 @@
 # Using httptape with Other Languages
 
-httptape ships as a Docker image (`ghcr.io/vibewarden/httptape:latest`), so any language with Docker or Testcontainers support can use it as a mock server. This guide shows how to start an httptape container, mount fixture files, make requests, and clean up in several popular languages.
+httptape ships as a Docker image (`ghcr.io/httptape/httptape:latest`), so any language with Docker or Testcontainers support can use it as a mock server. This guide shows how to start an httptape container, mount fixture files, make requests, and clean up in several popular languages.
 
 All examples assume you have a directory of recorded fixtures at `./testdata/fixtures` relative to the project root. The container exposes port **8081** by default.
 
@@ -31,7 +31,7 @@ class HttptapeTest {
 
     @BeforeAll
     static void startContainer() {
-        httptape = new GenericContainer<>("ghcr.io/vibewarden/httptape:latest")
+        httptape = new GenericContainer<>("ghcr.io/httptape/httptape:latest")
             .withCommand("serve", "--fixtures", "/fixtures")
             .withExposedPorts(8081)
             .withFileSystemBind("./testdata/fixtures", "/fixtures")
@@ -90,7 +90,7 @@ class HttptapeTest {
         @BeforeAll
         @JvmStatic
         fun startContainer() {
-            httptape = GenericContainer("ghcr.io/vibewarden/httptape:latest")
+            httptape = GenericContainer("ghcr.io/httptape/httptape:latest")
                 .withCommand("serve", "--fixtures", "/fixtures")
                 .withExposedPorts(8081)
                 .withFileSystemBind("./testdata/fixtures", "/fixtures")
@@ -134,7 +134,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 
 def test_replay_fixture():
-    with DockerContainer("ghcr.io/vibewarden/httptape:latest") \
+    with DockerContainer("ghcr.io/httptape/httptape:latest") \
         .with_command("serve --fixtures /fixtures") \
         .with_exposed_ports(8081) \
         .with_volume_mapping("./testdata/fixtures", "/fixtures") as container:
@@ -159,7 +159,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 @pytest.fixture(scope="module")
 def httptape_url():
-    container = DockerContainer("ghcr.io/vibewarden/httptape:latest") \
+    container = DockerContainer("ghcr.io/httptape/httptape:latest") \
         .with_command("serve --fixtures /fixtures") \
         .with_exposed_ports(8081) \
         .with_volume_mapping("./testdata/fixtures", "/fixtures")
@@ -198,7 +198,7 @@ describe("httptape replay", () => {
 
   before(async () => {
     container = await new GenericContainer(
-      "ghcr.io/vibewarden/httptape:latest"
+      "ghcr.io/httptape/httptape:latest"
     )
       .withCommand(["serve", "--fixtures", "/fixtures"])
       .withExposedPorts(8081)
@@ -238,7 +238,7 @@ describe("httptape replay", () => {
 
   beforeAll(async () => {
     container = await new GenericContainer(
-      "ghcr.io/vibewarden/httptape:latest"
+      "ghcr.io/httptape/httptape:latest"
     )
       .withCommand(["serve", "--fixtures", "/fixtures"])
       .withExposedPorts(8081)
@@ -277,7 +277,7 @@ docker run -d \
   --name httptape-mock \
   -p 8081:8081 \
   -v "$PWD/testdata/fixtures:/fixtures" \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   serve --fixtures /fixtures
 ```
 
@@ -295,7 +295,7 @@ docker run -d \
   --name httptape-mock \
   -p 8081:8081 \
   -v "$PWD/testdata/fixtures:/fixtures" \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   serve --fixtures /fixtures \
   --replay-header "Authorization=Bearer test-token" \
   --replay-header "X-Request-Id=integration-test-001"
@@ -313,7 +313,7 @@ docker stop httptape-mock && docker rm httptape-mock
 # docker-compose.test.yml
 services:
   httptape:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["serve", "--fixtures", "/fixtures"]
     ports:
       - "8081:8081"

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -159,7 +159,7 @@ docker run --rm \
   -v ./cache:/fixtures \
   -v ./redact.json:/config/config.json:ro \
   -p 8081:8081 \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   proxy --upstream https://api.example.com \
         --fixtures /fixtures \
         --config /config/config.json \
@@ -171,7 +171,7 @@ docker run --rm \
 ```yaml
 services:
   api-proxy:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command:
       - proxy
       - --upstream

--- a/docs/testcontainers.md
+++ b/docs/testcontainers.md
@@ -5,7 +5,7 @@ httptape provides a Go [Testcontainers](https://golang.testcontainers.org/) modu
 ## Install
 
 ```bash
-go get github.com/VibeWarden/httptape/testcontainers
+go get github.com/httptape/httptape/testcontainers
 ```
 
 This module has external dependencies (testcontainers-go, Docker client libraries) unlike the core httptape library which is stdlib-only.
@@ -13,7 +13,7 @@ This module has external dependencies (testcontainers-go, Docker client librarie
 ## Import
 
 ```go
-import httptapecontainer "github.com/VibeWarden/httptape/testcontainers"
+import httptapecontainer "github.com/httptape/httptape/testcontainers"
 ```
 
 The package name is `httptape` (under the `testcontainers` directory), so most users alias it to avoid collision with the main `httptape` package.
@@ -113,10 +113,10 @@ Bind-mounts a host JSON config file to `/config/config.json`. Mutually exclusive
 ### WithImage
 
 ```go
-httptapecontainer.WithImage("ghcr.io/vibewarden/httptape:v1.0.0")
+httptapecontainer.WithImage("ghcr.io/httptape/httptape:v1.0.0")
 ```
 
-Overrides the Docker image. Defaults to `ghcr.io/vibewarden/httptape:latest`.
+Overrides the Docker image. Defaults to `ghcr.io/httptape/httptape:latest`.
 
 ### WithPort
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -60,7 +60,7 @@ httptape record \
 The `BuildTLSConfig` function converts file paths into a `*tls.Config`:
 
 ```go
-import "github.com/VibeWarden/httptape"
+import "github.com/httptape/httptape"
 
 // Custom CA only
 tlsCfg, err := httptape.BuildTLSConfig("", "", "/path/to/ca.pem", false)

--- a/docs/ui-first-dev.md
+++ b/docs/ui-first-dev.md
@@ -60,7 +60,7 @@ A typical setup with a React/Vue/Svelte dev server calling httptape as the API b
 # docker-compose.yml
 services:
   mock-api:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["serve", "--fixtures", "/fixtures", "--port", "3001", "--cors"]
     ports:
       - "3001:3001"
@@ -323,7 +323,7 @@ Docker Compose for this setup:
 ```yaml
 services:
   mock-api:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["serve", "--fixtures", "/fixtures", "--port", "3001", "--cors"]
     ports:
       - "3001:3001"

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ Each subdirectory is a self-contained, runnable example of httptape used in a re
 ## Conventions
 
 - Each example owns its own dependencies — Go examples have their own `go.mod` so they don't pollute the library's stdlib-only constraint.
-- `docker-compose.yml`, where present, pins to a published httptape image (`ghcr.io/vibewarden/httptape:<version>`) so examples Just Run on a fresh clone — no local build of httptape required. Bumped per release.
+- `docker-compose.yml`, where present, pins to a published httptape image (`ghcr.io/httptape/httptape:<version>`) so examples Just Run on a fresh clone — no local build of httptape required. Bumped per release.
 - Examples are kept opinionated and minimal — they showcase httptape behavior, not framework taste.
 
 ## CI smoke tests

--- a/examples/java-spring-boot/README.md
+++ b/examples/java-spring-boot/README.md
@@ -1,6 +1,6 @@
 # Test your Spring AI agents deterministically
 
-Working example of [httptape](https://github.com/VibeWarden/httptape) used to test a **Spring AI streaming chat completion** and a classic REST integration — both served from pre-recorded fixtures via [Testcontainers](https://testcontainers.com/), with zero real API calls.
+Working example of [httptape](https://github.com/httptape/httptape) used to test a **Spring AI streaming chat completion** and a classic REST integration — both served from pre-recorded fixtures via [Testcontainers](https://testcontainers.com/), with zero real API calls.
 
 ## What this demo shows
 

--- a/examples/java-spring-boot/docker-compose.yml
+++ b/examples/java-spring-boot/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   httptape:
-    image: ghcr.io/vibewarden/httptape:0.13.0
+    image: ghcr.io/httptape/httptape:0.13.0
     command: ["serve", "--fixtures", "/fixtures", "--sse-timing=realtime"]
     volumes:
       # All fixtures must be in a single flat directory for FileStore.

--- a/examples/kotlin-ktor-koog/README.md
+++ b/examples/kotlin-ktor-koog/README.md
@@ -1,6 +1,6 @@
 # Test your Koog AI agents deterministically
 
-Working example of [httptape](https://github.com/VibeWarden/httptape) used to test a **Koog single-tool AI agent** with a weather REST integration -- both served from pre-recorded fixtures via [Testcontainers](https://testcontainers.com/), with zero real API calls.
+Working example of [httptape](https://github.com/httptape/httptape) used to test a **Koog single-tool AI agent** with a weather REST integration -- both served from pre-recorded fixtures via [Testcontainers](https://testcontainers.com/), with zero real API calls.
 
 ## What this demo shows
 
@@ -37,7 +37,7 @@ This demo exercises the matcher composition stack from #178, #179, and #180:
 
 ## httptape version requirement
 
-This demo requires **httptape v0.13.0** or later. v0.13.0 adds `CachingTransport` as a library primitive. v0.12.0 introduced Content-Type-driven body shape in fixtures (PR [#191](https://github.com/VibeWarden/httptape/pull/191)) and includes `--config` support for declarative matcher composition (first shipped in v0.11.0, PR [#184](https://github.com/VibeWarden/httptape/pull/184)). Earlier releases cannot read the migrated fixture format or the matcher config.
+This demo requires **httptape v0.13.0** or later. v0.13.0 adds `CachingTransport` as a library primitive. v0.12.0 introduced Content-Type-driven body shape in fixtures (PR [#191](https://github.com/httptape/httptape/pull/191)) and includes `--config` support for declarative matcher composition (first shipped in v0.11.0, PR [#184](https://github.com/httptape/httptape/pull/184)). Earlier releases cannot read the migrated fixture format or the matcher config.
 
 ## Prerequisites
 
@@ -134,7 +134,7 @@ IDE users: open [`api.http`](./api.http) -- IntelliJ's HTTP Client and VS Code's
 | httptape-jvm SDK | 0.1.0-SNAPSHOT (Testcontainers + Kotest extension) |
 | Testcontainers | 2.0.4 (via SDK transitive dependency) |
 | Gradle | 9.4.1 (wrapper committed) |
-| httptape | v0.13.1 (ghcr.io/vibewarden/httptape:0.13.1, SDK default) |
+| httptape | v0.13.1 (ghcr.io/httptape/httptape:0.13.1, SDK default) |
 
 ## Why not...?
 

--- a/examples/kotlin-ktor-koog/docker-compose.yml
+++ b/examples/kotlin-ktor-koog/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   httptape:
-    image: ghcr.io/vibewarden/httptape:0.13.0
+    image: ghcr.io/httptape/httptape:0.13.0
     command: ["serve", "--fixtures", "/fixtures", "--config", "/config/httptape.config.json"]
     volumes:
       - ./src/test/resources/fixtures/openai/chat-1.json:/fixtures/chat-1.json:ro

--- a/examples/ts-frontend-first/README.md
+++ b/examples/ts-frontend-first/README.md
@@ -1,6 +1,6 @@
 # Frontend-first development with httptape proxy mode
 
-Working example of [httptape](https://github.com/VibeWarden/httptape) used as a fallback proxy in front of a backend API. The frontend never breaks, even when the backend goes down — it transparently falls back to cached data, and the UI reflects the current source **live, without any user action**.
+Working example of [httptape](https://github.com/httptape/httptape) used as a fallback proxy in front of a backend API. The frontend never breaks, even when the backend goes down — it transparently falls back to cached data, and the UI reflects the current source **live, without any user action**.
 
 ## Architecture
 
@@ -85,11 +85,11 @@ httptape's `RedactSSEEventData` and `FakeSSEEventData` sanitization functions op
 docker compose up
 ```
 
-Pulls `ghcr.io/vibewarden/httptape:0.13.0` (v0.13.0 adds CachingTransport; v0.12.0 introduced Content-Type-driven body shape, ContentNegotiationCriterion, and the `migrate-fixtures` CLI subcommand). Also builds the React frontend. No local Go build needed.
+Pulls `ghcr.io/httptape/httptape:0.13.0` (v0.13.0 adds CachingTransport; v0.12.0 introduced Content-Type-driven body shape, ContentNegotiationCriterion, and the `migrate-fixtures` CLI subcommand). Also builds the React frontend. No local Go build needed.
 
 Open [http://localhost:3000](http://localhost:3000).
 
-> Pinned to `0.13.0` for reproducibility. To track latest, change the image to `ghcr.io/vibewarden/httptape:latest`.
+> Pinned to `0.13.0` for reproducibility. To track latest, change the image to `ghcr.io/httptape/httptape:latest`.
 
 ## Try it
 

--- a/examples/ts-frontend-first/docker-compose.yml
+++ b/examples/ts-frontend-first/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   upstream:
-    image: ghcr.io/vibewarden/httptape:0.13.0
+    image: ghcr.io/httptape/httptape:0.13.0
     command: ["serve", "--fixtures", "/fixtures"]
     volumes:
       - ./mocks/upstream-fixtures:/fixtures:ro
 
   proxy:
-    image: ghcr.io/vibewarden/httptape:0.13.0
+    image: ghcr.io/httptape/httptape:0.13.0
     command:
       - proxy
       - --upstream

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/VibeWarden/httptape
+module github.com/httptape/httptape
 
 go 1.26

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -194,7 +194,7 @@ to v0.12 format (Content-Type-driven body shape). Idempotent. Skips non-tape fil
 ## Docker
 
 ```
-docker pull ghcr.io/vibewarden/httptape:latest
+docker pull ghcr.io/httptape/httptape:latest
 # ~3 MB scratch image, runs as non-root (65534)
 ```
 
@@ -250,10 +250,10 @@ func FakeSSEEventData(seed string, paths ...string) SanitizeFunc
 
 ## Links
 
-- Repo: https://github.com/VibeWarden/httptape
+- Repo: https://github.com/httptape/httptape
 - Docs: https://vibewarden.dev/docs/httptape
-- Go pkg: https://pkg.go.dev/github.com/VibeWarden/httptape
-- Docker: ghcr.io/vibewarden/httptape
+- Go pkg: https://pkg.go.dev/github.com/httptape/httptape
+- Docker: ghcr.io/httptape/httptape
 # httptape
 
 **Record, Redact, Replay** -- HTTP traffic recording, redaction, and replay.
@@ -291,19 +291,19 @@ httptape captures HTTP request/response pairs, redacts sensitive data on write, 
 === "Go library"
 
     ```bash
-    go get github.com/VibeWarden/httptape
+    go get github.com/httptape/httptape
     ```
 
 === "CLI"
 
     ```bash
-    go install github.com/VibeWarden/httptape/cmd/httptape@latest
+    go install github.com/httptape/httptape/cmd/httptape@latest
     ```
 
 === "Docker"
 
     ```bash
-    docker pull ghcr.io/vibewarden/httptape:latest
+    docker pull ghcr.io/httptape/httptape:latest
     ```
 
 Requires Go 1.26 or later for the library/CLI. Docker works with any platform.
@@ -318,7 +318,7 @@ import (
     "net/http"
     "net/http/httptest"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {
@@ -373,7 +373,7 @@ httptape proxy --upstream https://api.github.com --fixtures ./cache
 
 ## License
 
-[Apache 2.0](https://github.com/VibeWarden/httptape/blob/main/LICENSE)
+[Apache 2.0](https://github.com/httptape/httptape/blob/main/LICENSE)
 # Getting Started
 
 Record, Redact, and Replay HTTP traffic in 5 minutes.
@@ -382,7 +382,7 @@ Record, Redact, and Replay HTTP traffic in 5 minutes.
 
 - Go 1.26 or later (for the Go library)
 - Or: Docker (for CLI/Docker usage with any language)
-- `go get github.com/VibeWarden/httptape`
+- `go get github.com/httptape/httptape`
 
 ## Step 1: Record HTTP traffic
 
@@ -395,7 +395,7 @@ import (
     "fmt"
     "net/http"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {
@@ -438,7 +438,7 @@ import (
     "net/http"
     "net/http/httptest"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {
@@ -473,7 +473,7 @@ import (
     "net/http"
     "strings"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func main() {
@@ -520,7 +520,7 @@ import (
     "net/http/httptest"
     "testing"
 
-    "github.com/VibeWarden/httptape"
+    "github.com/httptape/httptape"
 )
 
 func TestUserAPI(t *testing.T) {
@@ -1785,7 +1785,7 @@ docker run --rm \
   -v ./cache:/fixtures \
   -v ./redact.json:/config/config.json:ro \
   -p 8081:8081 \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   proxy --upstream https://api.example.com \
         --fixtures /fixtures \
         --config /config/config.json \
@@ -1797,7 +1797,7 @@ docker run --rm \
 ```yaml
 services:
   api-proxy:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command:
       - proxy
       - --upstream
@@ -3124,7 +3124,7 @@ A typical setup with a React/Vue/Svelte dev server calling httptape as the API b
 # docker-compose.yml
 services:
   mock-api:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["serve", "--fixtures", "/fixtures", "--port", "3001", "--cors"]
     ports:
       - "3001:3001"
@@ -3387,7 +3387,7 @@ Docker Compose for this setup:
 ```yaml
 services:
   mock-api:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["serve", "--fixtures", "/fixtures", "--port", "3001", "--cors"]
     ports:
       - "3001:3001"
@@ -3457,7 +3457,7 @@ services:
 - [Matching](matching.md) -- customizing request-to-tape matching
 # Using httptape with Other Languages
 
-httptape ships as a Docker image (`ghcr.io/vibewarden/httptape:latest`), so any language with Docker or Testcontainers support can use it as a mock server. This guide shows how to start an httptape container, mount fixture files, make requests, and clean up in several popular languages.
+httptape ships as a Docker image (`ghcr.io/httptape/httptape:latest`), so any language with Docker or Testcontainers support can use it as a mock server. This guide shows how to start an httptape container, mount fixture files, make requests, and clean up in several popular languages.
 
 All examples assume you have a directory of recorded fixtures at `./testdata/fixtures` relative to the project root. The container exposes port **8081** by default.
 
@@ -3488,7 +3488,7 @@ class HttptapeTest {
 
     @BeforeAll
     static void startContainer() {
-        httptape = new GenericContainer<>("ghcr.io/vibewarden/httptape:latest")
+        httptape = new GenericContainer<>("ghcr.io/httptape/httptape:latest")
             .withCommand("serve", "--fixtures", "/fixtures")
             .withExposedPorts(8081)
             .withFileSystemBind("./testdata/fixtures", "/fixtures")
@@ -3547,7 +3547,7 @@ class HttptapeTest {
         @BeforeAll
         @JvmStatic
         fun startContainer() {
-            httptape = GenericContainer("ghcr.io/vibewarden/httptape:latest")
+            httptape = GenericContainer("ghcr.io/httptape/httptape:latest")
                 .withCommand("serve", "--fixtures", "/fixtures")
                 .withExposedPorts(8081)
                 .withFileSystemBind("./testdata/fixtures", "/fixtures")
@@ -3591,7 +3591,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 
 def test_replay_fixture():
-    with DockerContainer("ghcr.io/vibewarden/httptape:latest") \
+    with DockerContainer("ghcr.io/httptape/httptape:latest") \
         .with_command("serve --fixtures /fixtures") \
         .with_exposed_ports(8081) \
         .with_volume_mapping("./testdata/fixtures", "/fixtures") as container:
@@ -3616,7 +3616,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 @pytest.fixture(scope="module")
 def httptape_url():
-    container = DockerContainer("ghcr.io/vibewarden/httptape:latest") \
+    container = DockerContainer("ghcr.io/httptape/httptape:latest") \
         .with_command("serve --fixtures /fixtures") \
         .with_exposed_ports(8081) \
         .with_volume_mapping("./testdata/fixtures", "/fixtures")
@@ -3655,7 +3655,7 @@ describe("httptape replay", () => {
 
   before(async () => {
     container = await new GenericContainer(
-      "ghcr.io/vibewarden/httptape:latest"
+      "ghcr.io/httptape/httptape:latest"
     )
       .withCommand(["serve", "--fixtures", "/fixtures"])
       .withExposedPorts(8081)
@@ -3695,7 +3695,7 @@ describe("httptape replay", () => {
 
   beforeAll(async () => {
     container = await new GenericContainer(
-      "ghcr.io/vibewarden/httptape:latest"
+      "ghcr.io/httptape/httptape:latest"
     )
       .withCommand(["serve", "--fixtures", "/fixtures"])
       .withExposedPorts(8081)
@@ -3734,7 +3734,7 @@ docker run -d \
   --name httptape-mock \
   -p 8081:8081 \
   -v "$PWD/testdata/fixtures:/fixtures" \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   serve --fixtures /fixtures
 ```
 
@@ -3752,7 +3752,7 @@ docker run -d \
   --name httptape-mock \
   -p 8081:8081 \
   -v "$PWD/testdata/fixtures:/fixtures" \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   serve --fixtures /fixtures \
   --replay-header "Authorization=Bearer test-token" \
   --replay-header "X-Request-Id=integration-test-001"
@@ -3770,7 +3770,7 @@ docker stop httptape-mock && docker rm httptape-mock
 # docker-compose.test.yml
 services:
   httptape:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["serve", "--fixtures", "/fixtures"]
     ports:
       - "8081:8081"
@@ -4070,13 +4070,13 @@ Additional rules for `matcher`:
 
 ## JSON Schema
 
-A JSON Schema is available at [`config.schema.json`](https://github.com/VibeWarden/httptape/blob/main/config.schema.json) for IDE autocompletion and CI validation.
+A JSON Schema is available at [`config.schema.json`](https://github.com/httptape/httptape/blob/main/config.schema.json) for IDE autocompletion and CI validation.
 
 Reference it in your config file:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/VibeWarden/httptape/main/config.schema.json",
+  "$schema": "https://raw.githubusercontent.com/httptape/httptape/main/config.schema.json",
   "version": "1",
   "rules": [...]
 }
@@ -4191,7 +4191,7 @@ httptape includes a standalone CLI binary for HTTP traffic recording, redaction,
 ## Install
 
 ```bash
-go install github.com/VibeWarden/httptape/cmd/httptape@latest
+go install github.com/httptape/httptape/cmd/httptape@latest
 ```
 
 Or use the [Docker image](docker.md).
@@ -4446,7 +4446,7 @@ httptape is available as a minimal Docker image built from scratch (no OS, no sh
 ## Pull
 
 ```bash
-docker pull ghcr.io/vibewarden/httptape:latest
+docker pull ghcr.io/httptape/httptape:latest
 ```
 
 ## Serve mode
@@ -4457,7 +4457,7 @@ Replay recorded fixtures:
 docker run --rm \
   -v ./fixtures:/fixtures:ro \
   -p 8081:8081 \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   serve --fixtures /fixtures --port 8081
 ```
 
@@ -4472,7 +4472,7 @@ docker run --rm \
   -v ./fixtures:/fixtures \
   -v ./redact.json:/config/config.json:ro \
   -p 8081:8081 \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   record --upstream https://api.example.com \
          --fixtures /fixtures \
          --config /config/config.json \
@@ -4490,7 +4490,7 @@ docker run --rm \
   -v ./cache:/fixtures \
   -v ./redact.json:/config/config.json:ro \
   -p 8081:8081 \
-  ghcr.io/vibewarden/httptape:latest \
+  ghcr.io/httptape/httptape:latest \
   proxy --upstream https://api.example.com \
         --fixtures /fixtures \
         --config /config/config.json \
@@ -4526,7 +4526,7 @@ Both are declared as `VOLUME` in the Dockerfile and pre-exist in the image.
 ```yaml
 services:
   mock-api:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["serve", "--fixtures", "/fixtures", "--port", "8081"]
     ports:
       - "8081:8081"
@@ -4546,7 +4546,7 @@ services:
 ```yaml
 services:
   recorder:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command:
       - record
       - --upstream
@@ -4569,7 +4569,7 @@ services:
 ```yaml
 services:
   api-proxy:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command:
       - proxy
       - --upstream
@@ -4603,13 +4603,13 @@ services:
 ```yaml
 services:
   recorder:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["record", "--upstream", "https://api.example.com", "--fixtures", "/fixtures", "--port", "8081"]
     volumes:
       - fixture-data:/fixtures
 
   exporter:
-    image: ghcr.io/vibewarden/httptape:latest
+    image: ghcr.io/httptape/httptape:latest
     command: ["export", "--fixtures", "/fixtures", "--output", "/output/bundle.tar.gz"]
     volumes:
       - fixture-data:/fixtures:ro
@@ -4632,7 +4632,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mock-api:
-        image: ghcr.io/vibewarden/httptape:latest
+        image: ghcr.io/httptape/httptape:latest
         options: >-
           -v ${{ github.workspace }}/fixtures:/fixtures:ro
         ports:
@@ -4669,7 +4669,7 @@ httptape provides a Go [Testcontainers](https://golang.testcontainers.org/) modu
 ## Install
 
 ```bash
-go get github.com/VibeWarden/httptape/testcontainers
+go get github.com/httptape/httptape/testcontainers
 ```
 
 This module has external dependencies (testcontainers-go, Docker client libraries) unlike the core httptape library which is stdlib-only.
@@ -4677,7 +4677,7 @@ This module has external dependencies (testcontainers-go, Docker client librarie
 ## Import
 
 ```go
-import httptapecontainer "github.com/VibeWarden/httptape/testcontainers"
+import httptapecontainer "github.com/httptape/httptape/testcontainers"
 ```
 
 The package name is `httptape` (under the `testcontainers` directory), so most users alias it to avoid collision with the main `httptape` package.
@@ -4777,10 +4777,10 @@ Bind-mounts a host JSON config file to `/config/config.json`. Mutually exclusive
 ### WithImage
 
 ```go
-httptapecontainer.WithImage("ghcr.io/vibewarden/httptape:v1.0.0")
+httptapecontainer.WithImage("ghcr.io/httptape/httptape:v1.0.0")
 ```
 
-Overrides the Docker image. Defaults to `ghcr.io/vibewarden/httptape:latest`.
+Overrides the Docker image. Defaults to `ghcr.io/httptape/httptape:latest`.
 
 ### WithPort
 
@@ -4929,7 +4929,7 @@ httptape record \
 The `BuildTLSConfig` function converts file paths into a `*tls.Config`:
 
 ```go
-import "github.com/VibeWarden/httptape"
+import "github.com/httptape/httptape"
 
 // Custom CA only
 tlsCfg, err := httptape.BuildTLSConfig("", "", "/path/to/ca.pem", false)

--- a/llms.txt
+++ b/llms.txt
@@ -178,7 +178,7 @@ to v0.12 format (Content-Type-driven body shape). Idempotent. Skips non-tape fil
 ## Docker
 
 ```
-docker pull ghcr.io/vibewarden/httptape:latest
+docker pull ghcr.io/httptape/httptape:latest
 # ~3 MB scratch image, runs as non-root (65534)
 ```
 
@@ -234,7 +234,7 @@ func FakeSSEEventData(seed string, paths ...string) SanitizeFunc
 
 ## Links
 
-- Repo: https://github.com/VibeWarden/httptape
+- Repo: https://github.com/httptape/httptape
 - Docs: https://vibewarden.dev/docs/httptape
-- Go pkg: https://pkg.go.dev/github.com/VibeWarden/httptape
-- Docker: ghcr.io/vibewarden/httptape
+- Go pkg: https://pkg.go.dev/github.com/httptape/httptape
+- Docker: ghcr.io/httptape/httptape

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: httptape
 site_description: "Record, Redact, Replay -- HTTP traffic recording, redaction, and replay."
 site_url: https://vibewarden.dev/docs/httptape
-repo_url: https://github.com/VibeWarden/httptape
-repo_name: VibeWarden/httptape
+repo_url: https://github.com/httptape/httptape
+repo_name: httptape/httptape
 edit_uri: edit/main/docs/
 
 theme:
@@ -84,4 +84,4 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/VibeWarden/httptape
+      link: https://github.com/httptape/httptape

--- a/testcontainers/README.md
+++ b/testcontainers/README.md
@@ -11,7 +11,7 @@ import (
     "net/http"
     "testing"
 
-    httptape "github.com/VibeWarden/httptape/testcontainers"
+    httptape "github.com/httptape/httptape/testcontainers"
 )
 
 func TestAPI(t *testing.T) {
@@ -43,7 +43,7 @@ func TestAPI(t *testing.T) {
 | `WithMode`          | Set the mode: `"serve"` (default) or `"record"`.         |
 | `WithTarget`        | Set the upstream URL for record mode.                     |
 | `WithPort`          | Override the exposed port (default `"8081/tcp"`).         |
-| `WithImage`         | Override the Docker image (default `ghcr.io/vibewarden/httptape:latest`). |
+| `WithImage`         | Override the Docker image (default `ghcr.io/httptape/httptape:latest`). |
 
 `WithConfig` and `WithConfigFile` are mutually exclusive.
 

--- a/testcontainers/doc.go
+++ b/testcontainers/doc.go
@@ -1,7 +1,7 @@
 // Package httptape provides a Testcontainers module for running an httptape
 // Docker container in integration tests.
 //
-// This module wraps the ghcr.io/vibewarden/httptape Docker image and exposes
+// This module wraps the ghcr.io/httptape/httptape Docker image and exposes
 // a functional-options API consistent with the main httptape library. It
 // enables Go developers to spin up an isolated httptape container directly
 // from go test, without manual Docker orchestration.

--- a/testcontainers/go.mod
+++ b/testcontainers/go.mod
@@ -1,4 +1,4 @@
-module github.com/VibeWarden/httptape/testcontainers
+module github.com/httptape/httptape/testcontainers
 
 go 1.26.1
 

--- a/testcontainers/httptape.go
+++ b/testcontainers/httptape.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultImage is the default Docker image used for the httptape container.
-	DefaultImage = "ghcr.io/vibewarden/httptape:latest"
+	DefaultImage = "ghcr.io/httptape/httptape:latest"
 
 	// DefaultPort is the default exposed port inside the container.
 	DefaultPort = "8081/tcp"

--- a/testcontainers/httptape_test.go
+++ b/testcontainers/httptape_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	httptape "github.com/VibeWarden/httptape/testcontainers"
+	httptape "github.com/httptape/httptape/testcontainers"
 )
 
 func TestRunContainer_ServeMode(t *testing.T) {
@@ -94,7 +94,7 @@ func TestRunContainer_WithImage(t *testing.T) {
 
 	ctr, err := httptape.RunContainer(ctx,
 		httptape.WithFixturesDir("./testdata/fixtures"),
-		httptape.WithImage("ghcr.io/vibewarden/httptape:latest"),
+		httptape.WithImage("ghcr.io/httptape/httptape:latest"),
 	)
 	if err != nil {
 		t.Fatalf("RunContainer: %v", err)

--- a/testcontainers/options.go
+++ b/testcontainers/options.go
@@ -92,7 +92,7 @@ func WithPort(port string) Option {
 }
 
 // WithImage overrides the Docker image reference. Defaults to
-// "ghcr.io/vibewarden/httptape:latest".
+// "ghcr.io/httptape/httptape:latest".
 func WithImage(image string) Option {
 	return func(o *options) {
 		o.image = image


### PR DESCRIPTION
Phase 1 of the GitHub org migration from `VibeWarden` to `httptape` (issue #249, plan in `~/notes/httptape/org-migration.md`).

## Summary

Mechanical rename across 42 files:

- **Go module path**: `github.com/VibeWarden/httptape` → `github.com/httptape/httptape` (parent `go.mod` + `testcontainers/go.mod` submodule)
- **Import sites**: `cmd/httptape/main.go`, `cmd/httptape/main_test.go`, `testcontainers/httptape_test.go`
- **GHCR image namespace**: `ghcr.io/vibewarden/httptape` → `ghcr.io/httptape/httptape` (`docker.yml` env, `docker-compose.yml`, examples compose files, docs, `testcontainers.DefaultImage`)
- **Repo URL refs**: README badges (Go Reference, Tests, Scorecard), `mkdocs.yml` repo_url + repo_name + footer, `CLAUDE.md` Org line, ISSUE_TEMPLATE, `SECURITY.md`, `config.schema.json` `$id`, `Dockerfile` OCI labels, `.claude/agents/*.md` prompts, `llms*.txt`

`go build ./... && go test ./...` are green under the new module path.

## Intentionally preserved (out of scope for phase 1)

| Reference | Reason |
|---|---|
| `vibewarden.dev/docs/httptape` (mkdocs `site_url`, README docs links, `doc.go`, `Dockerfile` documentation label, `llms*.txt` Docs: line, two example READMEs) | Phase 2: needs new GitHub Pages target repo + DNS for `docs.httptape.dev` first |
| `.github/workflows/docs.yml` deploy target (`vibewarden/vibewarden.dev`) | Phase 2: docs deploy target follows the docs URL flip |
| `VibeWarden` company attribution in README + `doc.go` | Per migration plan: "stays as 'built and maintained by' credit" |
| `VibeWarden/httptape-jvm` (in `examples.yml` workflow + two example READMEs) | Sibling phase 1 PR lives in the `httptape-jvm` repo |
| `decisions.md` historical ADR refs | ADRs document point-in-time decisions; not retroactively rewritten |
| `tibtof/httptape` Docker Hub namespace | Locked decision 2026-04-28: keep personal namespace |

## Order of operations

1. Merge this PR → references point to new org (no breakage yet because module path is new and unused)
2. **User**: `gh repo transfer VibeWarden/httptape httptape` (manual; not delegated)
3. Sibling phase 1 PR in `httptape-jvm` + transfer
4. PR in `vibewarden` repo: bump `go.mod` import path + image refs
5. Phase 2 PR (this repo): flip docs site URL to `docs.httptape.dev`, update `docs.yml` deploy target, set up redirects from `vibewarden.dev/docs/httptape/*`

## Test plan

- [x] `go build ./...` passes under new module path
- [x] `go test ./...` passes (all packages, no test changes needed)
- [ ] CI green on this branch (Tests + Examples + Docker workflow PR-mode)
- [ ] After merge + transfer: confirm `pkg.go.dev/github.com/httptape/httptape` resolves and Go Reference badge renders
- [ ] After merge + transfer: confirm `ghcr.io/httptape/httptape:latest` is publishable on next tag

Closes #249 (when phase 2 also lands; tracking issue can stay open until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)