### PR TITLE
chore(#249): update httptape-jvm refs to new org (post-transfer)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -118,7 +118,7 @@ jobs:
         if: matrix.example.java-version
         uses: actions/checkout@v6
         with:
-          repository: VibeWarden/httptape-jvm
+          repository: httptape/httptape-jvm
           path: httptape-jvm-sibling
           ref: main
 

--- a/examples/java-spring-boot/README.md
+++ b/examples/java-spring-boot/README.md
@@ -30,7 +30,7 @@ This demo uses the `httptape-testcontainers` SDK (`dev.httptape:httptape-testcon
 
 ```bash
 # From the parent directory of this httptape checkout
-git clone https://github.com/VibeWarden/httptape-jvm.git
+git clone https://github.com/httptape/httptape-jvm.git
 cd httptape-jvm
 ./gradlew publishToMavenLocal
 ```

--- a/examples/kotlin-ktor-koog/README.md
+++ b/examples/kotlin-ktor-koog/README.md
@@ -51,7 +51,7 @@ This demo uses the `httptape-testcontainers-kotest` SDK (`dev.httptape:httptape-
 
 ```bash
 # From the parent directory of this httptape checkout
-git clone https://github.com/VibeWarden/httptape-jvm.git
+git clone https://github.com/httptape/httptape-jvm.git
 ```
 
 With the sibling repo present, `./gradlew test` resolves the SDK modules directly from source via composite build -- no publishing step needed.


### PR DESCRIPTION
Follow-up to PR #250.

Both `httptape` and `httptape-jvm` have been transferred to the `httptape` GitHub org. PR #250 deliberately left `VibeWarden/httptape-jvm` references in place, expecting a sibling phase 1 PR in `httptape-jvm` to coordinate. Since the transfer already happened, this PR completes the cleanup.

## Changes

- `examples/java-spring-boot/README.md`: clone URL
- `examples/kotlin-ktor-koog/README.md`: clone URL
- `.github/workflows/examples.yml`: `actions/checkout` repository for the JVM SDK build

Three lines, one substitution each.

## Test plan

- [ ] `Examples` workflow stays green (the SDK checkout uses the new repo path)
- [ ] No remaining `VibeWarden/httptape-jvm` refs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)