### PR TITLE
chore(#249): flip docs site to httptape.dev/docs (phase 2)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy docs to vibewarden.dev
+name: Deploy docs to httptape.dev
 
 on:
   push:
@@ -24,9 +24,9 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
-          external_repository: vibewarden/vibewarden.dev
+          external_repository: httptape/httptape.dev
           publish_branch: main
           publish_dir: ./_site/docs
-          destination_dir: docs/httptape
+          destination_dir: docs
           keep_files: true
-          commit_message: "docs: sync from vibewarden/httptape@${{ github.sha }}"
+          commit_message: "docs: sync from httptape/httptape@${{ github.sha }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ LABEL org.opencontainers.image.title="httptape" \
       org.opencontainers.image.description="HTTP traffic recording, redaction, and replay — embeddable Go library, CLI, and 3 MB Docker image." \
       org.opencontainers.image.source="https://github.com/httptape/httptape" \
       org.opencontainers.image.url="https://github.com/httptape/httptape" \
-      org.opencontainers.image.documentation="https://vibewarden.dev/docs/httptape/" \
+      org.opencontainers.image.documentation="https://httptape.dev/docs/" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.version="${VERSION}"
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sensitive data on write, and replays them as a mock server. Think WireMock, but
 with a 3 MB Docker image, an embeddable Go library, SSE record/replay with
 per-event timing, and a redaction pipeline built into the core.
 
-**Docs**: [vibewarden.dev/docs/httptape](https://vibewarden.dev/docs/httptape/) · **From**: [VibeWarden](https://vibewarden.dev)
+**Docs**: [httptape.dev/docs](https://httptape.dev/docs/) · **From**: [VibeWarden](https://vibewarden.dev)
 
 **The 3 Rs:**
 
@@ -92,7 +92,7 @@ httptape proxy --upstream https://api.example.com \
     --fixtures ./cache --config redact.json
 ```
 
-When the upstream is reachable, requests are forwarded and responses are cached in two tiers (L1 in-memory, L2 on disk). When the upstream is down, httptape transparently serves cached responses. See [Proxy Mode](https://vibewarden.dev/docs/httptape/proxy/) for details.
+When the upstream is reachable, requests are forwarded and responses are cached in two tiers (L1 in-memory, L2 on disk). When the upstream is down, httptape transparently serves cached responses. See [Proxy Mode](https://httptape.dev/docs/proxy/) for details.
 
 ### Recording LLM streaming responses
 Record SSE streams from OpenAI, Anthropic, or any SSE-based API. Each event is stored individually with timing metadata, so replay can simulate the original streaming behavior.
@@ -128,7 +128,7 @@ defer ts.Close()
 // Point your code at ts.URL -- streaming responses replay instantly.
 ```
 
-See [Recording](https://vibewarden.dev/docs/httptape/recording/) and [Replay](https://vibewarden.dev/docs/httptape/replay/) for details on SSE support.
+See [Recording](https://httptape.dev/docs/recording/) and [Replay](https://httptape.dev/docs/replay/) for details on SSE support.
 
 ## Install
 
@@ -383,14 +383,14 @@ More examples coming. See [`examples/README.md`](examples/README.md) for the ind
 
 ## Documentation
 
-Full docs at **[vibewarden.dev/docs/httptape](https://vibewarden.dev/docs/httptape/)**.
+Full docs at **[httptape.dev/docs](https://httptape.dev/docs/)**.
 
-- [Getting Started](https://vibewarden.dev/docs/httptape/getting-started/)
-- [Recording](https://vibewarden.dev/docs/httptape/recording/) · [Replay](https://vibewarden.dev/docs/httptape/replay/) · [Redaction](https://vibewarden.dev/docs/httptape/sanitization/)
-- [Proxy Mode](https://vibewarden.dev/docs/httptape/proxy/) · [Matching](https://vibewarden.dev/docs/httptape/matching/) · [Storage](https://vibewarden.dev/docs/httptape/storage/)
-- [Import/Export](https://vibewarden.dev/docs/httptape/import-export/) · [JSON Config](https://vibewarden.dev/docs/httptape/config/)
-- [CLI Reference](https://vibewarden.dev/docs/httptape/cli/) · [Docker](https://vibewarden.dev/docs/httptape/docker/) · [Testcontainers](https://vibewarden.dev/docs/httptape/testcontainers/)
-- [API Reference](https://vibewarden.dev/docs/httptape/api-reference/)
+- [Getting Started](https://httptape.dev/docs/getting-started/)
+- [Recording](https://httptape.dev/docs/recording/) · [Replay](https://httptape.dev/docs/replay/) · [Redaction](https://httptape.dev/docs/sanitization/)
+- [Proxy Mode](https://httptape.dev/docs/proxy/) · [Matching](https://httptape.dev/docs/matching/) · [Storage](https://httptape.dev/docs/storage/)
+- [Import/Export](https://httptape.dev/docs/import-export/) · [JSON Config](https://httptape.dev/docs/config/)
+- [CLI Reference](https://httptape.dev/docs/cli/) · [Docker](https://httptape.dev/docs/docker/) · [Testcontainers](https://httptape.dev/docs/testcontainers/)
+- [API Reference](https://httptape.dev/docs/api-reference/)
 
 ## About
 

--- a/doc.go
+++ b/doc.go
@@ -92,6 +92,6 @@
 // # Documentation
 //
 // Full documentation, guides, and examples live at
-// https://vibewarden.dev/docs/httptape/. httptape is developed as part of
+// https://httptape.dev/docs/. httptape is developed as part of
 // VibeWarden — see https://vibewarden.dev/.
 package httptape

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -67,7 +67,7 @@ The `GenerateSelfSignedCert` function generates a self-signed certificate
 for programmatic use in tests:
 
 ```go
-import "github.com/VibeWarden/httptape"
+import "github.com/httptape/httptape"
 
 sc, err := httptape.GenerateSelfSignedCert("localhost", "127.0.0.1")
 if err != nil {

--- a/examples/java-spring-boot/README.md
+++ b/examples/java-spring-boot/README.md
@@ -50,7 +50,7 @@ Tests spin up an httptape container via Testcontainers, run assertions against b
 
 Drop a JSON file anywhere under `src/test/resources/fixtures/` — the test container auto-discovers it via classpath scan. No code changes needed.
 
-The httptape Tape JSON schema (and how to record real upstream traffic into one) is documented at [vibewarden.dev/docs/httptape](https://vibewarden.dev/docs/httptape/).
+The httptape Tape JSON schema (and how to record real upstream traffic into one) is documented at [httptape.dev/docs](https://httptape.dev/docs/).
 
 ## Development workflow — run with the same Testcontainers setup
 

--- a/examples/kotlin-ktor-koog/README.md
+++ b/examples/kotlin-ktor-koog/README.md
@@ -76,7 +76,7 @@ Tests spin up an httptape container via Testcontainers, run the Koog agent again
 
 Drop a JSON file anywhere under `src/test/resources/fixtures/` -- the SDK's classpath scanner auto-discovers it. No code changes needed.
 
-The httptape Tape JSON schema (and how to record real upstream traffic into one) is documented at [vibewarden.dev/docs/httptape](https://vibewarden.dev/docs/httptape/).
+The httptape Tape JSON schema (and how to record real upstream traffic into one) is documented at [httptape.dev/docs](https://httptape.dev/docs/).
 
 ## Development workflow -- run with the same Testcontainers setup
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -251,7 +251,7 @@ func FakeSSEEventData(seed string, paths ...string) SanitizeFunc
 ## Links
 
 - Repo: https://github.com/httptape/httptape
-- Docs: https://vibewarden.dev/docs/httptape
+- Docs: https://httptape.dev/docs
 - Go pkg: https://pkg.go.dev/github.com/httptape/httptape
 - Docker: ghcr.io/httptape/httptape
 # httptape

--- a/llms.txt
+++ b/llms.txt
@@ -235,6 +235,6 @@ func FakeSSEEventData(seed string, paths ...string) SanitizeFunc
 ## Links
 
 - Repo: https://github.com/httptape/httptape
-- Docs: https://vibewarden.dev/docs/httptape
+- Docs: https://httptape.dev/docs
 - Go pkg: https://pkg.go.dev/github.com/httptape/httptape
 - Docker: ghcr.io/httptape/httptape

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: httptape
 site_description: "Record, Redact, Replay -- HTTP traffic recording, redaction, and replay."
-site_url: https://vibewarden.dev/docs/httptape
+site_url: https://httptape.dev/docs
 repo_url: https://github.com/httptape/httptape
 repo_name: httptape/httptape
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Phase 2 of the GitHub org migration (issue #249, follow-up to PR #250 + #253).

Moves the documentation site URL from `vibewarden.dev/docs/httptape` to **`httptape.dev/docs`** (subpath under the unified `httptape.dev` site, per the 2026-04-28 decision).

## Changes (10 files)

| File | Change |
|---|---|
| `mkdocs.yml` | `site_url` |
| `.github/workflows/docs.yml` | `external_repository`, `destination_dir`, `commit_message`, workflow display name |
| `Dockerfile` | `org.opencontainers.image.documentation` OCI label |
| `doc.go` | Package-level godoc URL |
| `README.md` | Header docs link, body refs, Documentation section ToC |
| `llms.txt`, `llms-full.txt` | `Docs:` line |
| `examples/{java-spring-boot,kotlin-ktor-koog}/README.md` | Docs URL refs |
| `docs/tls.md` | Stale Go import path leftover from phase 1 (`github.com/VibeWarden/httptape` → `github.com/httptape/httptape`) |

`VibeWarden` company attribution links in `README.md:27,397` and `doc.go:96` are intentionally preserved per the migration plan ("stays as 'built and maintained by' credit").

## :warning: Required user-side infrastructure (after merge)

Until these are in place, `docs.yml` will fail on the next docs change:

1. **Repo setup**: `httptape/httptape.dev` exists but is empty. The workflow expects to push to its `main` branch under `docs/` (with `keep_files: true` so the future landing page coexists).
2. **Deploy key**: `DOCS_DEPLOY_KEY` is currently configured for `vibewarden/vibewarden.dev`. It needs to be replaced with a new keypair whose public half is added as a deploy key (with write access) on `httptape/httptape.dev`.
3. **DNS**: `A`/`CNAME` records for `httptape.dev` (apex) pointing at GitHub Pages, plus a `CNAME` file in the deploy target repo.
4. **(Optional)**: Redirects from `vibewarden.dev/docs/httptape/*` → `httptape.dev/docs/*` to preserve inbound links. Lives in the VibeWarden site repo, not here.

The currently-live docs at `vibewarden.dev/docs/httptape` stay at last-deployed state during the gap (the workflow won't push to it anymore, but no one removes the existing files either).

## Test plan

- [ ] Internal docs links rendered by mkdocs build still resolve correctly (relative paths work regardless of `site_url`)
- [ ] After infra setup: `docs.yml` workflow runs green on push to main, `httptape.dev/docs/` serves the site
- [ ] After infra setup: pkg.go.dev shows the new documentation URL link from the OCI label is irrelevant (Docker), and from `doc.go` is consumed by godoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)