### PR TITLE
chore: launch-prep doc cleanup — VibeWarden attribution + CLAUDE.md drift

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,7 +29,7 @@ License: Apache 2.0
 | Matching | Progressive | Exact match first, fuzzy/regex as opt-in |
 | Recording | Async by default | Non-blocking, minimal hot-path overhead |
 | Body handling | Store hash + full body | Hash for matching, full body for replay |
-| Distribution | Go module only (v1) | CLI wrapper is a future goal, not v1 |
+| Distribution | Go module (primary); standalone CLI binary and Docker image for non-Go callers | Embeddable as a Go module first; CLI/Docker added for non-Go consumers |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,13 @@ success is unchanged.
   (none found in surviving content; prose references to the VibeWarden parent
   project retained). (#246)
 
+- **README/godoc attribution**: reframed VibeWarden mention in README and
+  `doc.go` to "httptape originated at VibeWarden and is now a standalone
+  project". Reflects post-spinout reality after the GitHub org migration.
+
+- **CLAUDE.md Distribution row**: refreshed to reflect that the CLI and
+  Docker image now ship; the "CLI is a future goal" note was stale.
+
 ## [0.13.1] - 2026-04-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Full docs at **[httptape.dev/docs](https://httptape.dev/docs/)**.
 
 ## About
 
-httptape is developed as part of [VibeWarden](https://vibewarden.dev). For the full docs, guides, and other projects from the VibeWarden team, visit [vibewarden.dev](https://vibewarden.dev).
+httptape originated at [VibeWarden](https://vibewarden.dev) and is now a standalone project. Full docs and guides live at [httptape.dev/docs](https://httptape.dev/docs/).
 
 ## License
 

--- a/doc.go
+++ b/doc.go
@@ -92,6 +92,6 @@
 // # Documentation
 //
 // Full documentation, guides, and examples live at
-// https://httptape.dev/docs/. httptape is developed as part of VibeWarden —
-// see https://vibewarden.dev/.
+// https://httptape.dev/docs/. httptape originated at VibeWarden
+// (https://vibewarden.dev/) and is now a standalone project.
 package httptape


### PR DESCRIPTION
## Summary

Three small doc-drift fixes flagged in the 2026-05-10 project audit. No behavior change.

- **README.md & doc.go**: Reframe the VibeWarden mention from "developed as part of VibeWarden" (implies ongoing parent ownership) to "originated at VibeWarden and is now a standalone project" — reflects post-org-migration reality.
- **CLAUDE.md "Locked decisions"**: Refresh the Distribution row. The previous text said "Go module only (v1); CLI wrapper is a future goal, not v1", but `cmd/httptape` and the Docker image both ship. Updated to "Go module (primary); standalone CLI binary and Docker image for non-Go callers".
- **CHANGELOG**: Document all three under Unreleased.

## Context

Follows the 2026-05-10 audit and the #246 decisions.md cleanup (#259, #260). These items were called out as separate doc-drift not in scope of the ADR audit.

## Test plan

- [x] `go test ./... -short` passes locally
- [ ] CI green