### PR TITLE
chore: upgrade sub-agent models (bookend split)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Software architect agent. Invoke after PM sets status READY_FOR_ARCH. Reads the PM spec, validates against locked decisions, produces a concrete technical design (interfaces, types, file layout, sequence diagrams in text), writes a full ADR to decisions.md, posts a short status comment to the GitHub issue, and sets issue status to READY_FOR_DEV.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 ---
 
 You are the httptape Software Architect. You own technical correctness, architectural

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -2,7 +2,7 @@
 name: dev
 description: Senior Go developer agent. Invoke after architect sets status READY_FOR_DEV. Reads the architectural design from the issue comments, implements it precisely following the project's flat package structure, writes tests, commits, and opens a PR. Sets issue status to READY_FOR_REVIEW.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-sonnet-4-6
 ---
 
 You are the httptape Senior Go Developer. You implement exactly what the architect

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -2,7 +2,7 @@
 name: pm
 description: Product manager agent. Invoke when you need to turn a feature idea or GitHub issue into a detailed spec ready for the architect. Use for: writing acceptance criteria, breaking epics into stories, creating GitHub issues via gh CLI, setting issue status to READY_FOR_ARCH.
 tools: Read, Write, Edit, Bash
-model: claude-opus-4-6
+model: claude-sonnet-4-6
 ---
 
 You are the httptape Product Manager. You translate product ideas and rough GitHub issues

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Code reviewer agent. Invoke after dev sets status READY_FOR_REVIEW. Reads the PR diff, checks against architectural design and code quality rules, writes inline review comments via gh CLI, and either approves or requests changes. Sets issue status to CHANGES_REQUESTED or APPROVED.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 ---
 
 You are the httptape Code Reviewer. You are the last automated gate before the human


### PR DESCRIPTION
## Summary

Upgrade the four sub-agent model pins from `claude-opus-4-6` to a role-differentiated split.

| Agent | Was | Now | Why |
|---|---|---|---|
| `pm` | Opus 4.6 | **Sonnet 4.6** | Spec writing is well within Sonnet's range |
| `architect` | Opus 4.6 | **Opus 4.7** | Architectural reasoning + ADRs benefit most from Opus |
| `dev` | Opus 4.6 | **Sonnet 4.6** | Long-running implementation from a clear spec — biggest cost win |
| `reviewer` | Opus 4.6 | **Opus 4.7** | Review quality compounds; missed issues cost more than the model |

Opus on the thinking-heavy bookends (architect designs, reviewer guards); Sonnet on the high-token middle (pm specs, dev implementation).

## Test plan

- [ ] First post-merge issue dispatched end-to-end exercises all four agents — sanity-check that none of them lose meaningful quality on the new model
- [x] No code changes; nothing to test in CI