### PR TITLE
chore: teach pm/architect/dev agents about examples/

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -97,6 +97,8 @@ agent can implement without ambiguity.
 
 ## Design principles to enforce
 
+These apply to **library code** at the repo root. For `examples/<demo>/` work see the next section.
+
 - **Single flat package**: httptape is one Go package, not a multi-package project.
   All files live at the package root. No `internal/`, `cmd/`, or sub-packages.
 - **Hexagonal by convention**: interfaces (ports) defined at the top of their files
@@ -105,6 +107,16 @@ agent can implement without ambiguity.
 - **stdlib only**: no external dependencies in v1.
 - **No global state**: dependency injection via functional options everywhere.
 - **No panics**: this is a library — always return errors.
+
+## Designing for example issues (`examples/<demo>/`)
+
+When the issue scope is entirely under `examples/<demo>/`, switch rulesets:
+
+- **CLAUDE.md locked decisions are library-only** — do not enforce stdlib-only, single-flat-package, "no panics", or "no global state" against demo code. Each demo follows its language ecosystem's idioms (Spring Boot, Ktor + Koog, React/TS, etc.).
+- **The "design" is mostly file layout within the demo** plus naming conventions appropriate to the stack. Skip the Types/Functions/Sequence/Error-cases template above unless the change genuinely warrants it.
+- **Most example issues do NOT warrant an ADR** (per the tightened ADR bar in `decisions.md` — a Dependabot bump, a new demo file, or a framework upgrade is not a locked architectural decision). Produce only the short issue comment; skip the `decisions.md` append.
+- **Verify build commands match `.github/workflows/examples.yml`** — that workflow is the source of truth for how each demo is built/tested in CI. Your design's verification steps should match exactly (e.g. `./mvnw -B test`, `./gradlew test --no-daemon`, `npm run build`).
+- **JVM demos consume the `httptape-jvm` SDK** via composite build locally and `mavenLocal()` in CI. Account for this if the issue touches dependency wiring.
 
 ## What you must NOT do
 

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -119,11 +119,25 @@ func TestNewTape(t *testing.T) {
 }
 ```
 
+## Examples mode (`examples/<demo>/`)
+
+When the architect's design targets `examples/<demo>/` rather than the library root, **switch rulesets**:
+
+- The Code quality rules and Go patterns above are **library-only** — they do not apply to example code. Each demo follows its language ecosystem's idioms (Spring Boot, Ktor + Koog, React/TS, etc.).
+- **Use the demo's toolchain** for build and test verification, not `go build`/`go test`. The authoritative commands per demo are in `.github/workflows/examples.yml`:
+  - `examples/ts-frontend-first` → `npm ci && npm run build`
+  - `examples/java-spring-boot` → `./mvnw -B test`
+  - `examples/kotlin-ktor-koog` → `./gradlew test --no-daemon`
+- **Stdlib-only and single-flat-package rules are library-only.** Add third-party deps via the demo's package manager (npm/Maven/Gradle) as the design calls for. Never import demo code from the library root.
+- **Run the demo's verification command from inside its directory** (cd into `examples/<demo>/`). Do not skip this — the examples CI matrix uses the same commands, so a clean local run is your pre-PR gate.
+- **JVM demos**: locally consume `httptape-jvm` via composite build (path: `../../../httptape-jvm` relative to the demo). In CI, `examples.yml` publishes the SDK to `mavenLocal()`. If your change touches dependency wiring, verify both paths.
+- Branch naming, conventional commit style, and the PR workflow stay the same as library work.
+
 ## What you must NOT do
 
 - Do not implement anything not in the architect's design
-- Do not add external dependencies — v1 is stdlib only
-- Do not create sub-packages — httptape is a single flat package
-- Do not skip tests — 90% coverage target
+- Do not add external dependencies to the **library** — v1 is stdlib only (examples may use any reasonable deps)
+- Do not create sub-packages in the **library** — httptape is a single flat package (examples follow their own ecosystem layout)
+- Do not skip tests — 90% coverage target (library); for examples, verify the demo's build/test command passes
 - Do not push to main — always use a feature branch
-- Do not open a PR if `go test ./...` fails
+- Do not open a PR if the verification command for the affected scope fails (`go test ./...` for library, the demo's build command for examples)

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -37,6 +37,16 @@ coming back to ask questions.
    gh issue comment <number> --repo httptape/httptape --body "Status: READY_FOR_ARCH"
    ```
 
+## Library issues vs example issues
+
+Issues fall into two shapes; the spec template above is for **library** work. **Example** issues (anything under `examples/<demo>/`) follow a lighter ruleset:
+
+- The "As a Go developer" user story doesn't fit — frame it as "As a httptape user evaluating the [Spring Boot / Ktor / TS frontend] integration".
+- Locked decisions in `.claude/CLAUDE.md` (stdlib-only, single flat package, hexagonal, etc.) are **library-only**. Do not propagate them into example specs.
+- Acceptance criteria should name the demo's toolchain so dev/reviewer know how to verify: e.g. "build succeeds with `npm run build`", "`./mvnw test` passes", "`./gradlew test --no-daemon` passes". The `.github/workflows/examples.yml` matrix is the authoritative source of build commands.
+- Always include the demo's path (e.g. `examples/kotlin-ktor-koog`) in the spec so dev opens the right working directory.
+- Example issues rarely warrant an ADR — flag this in the spec so the architect skips straight to the design comment.
+
 ## Spec quality rules
 
 - Acceptance criteria must be testable by a developer without talking to you


### PR DESCRIPTION
## Summary

Closes the gap surfaced in today's audit: the reviewer agent already had a `library vs examples` scope split with per-language idiom checks (Go/TS/Java/Kotlin/Python), but the upstream agents (pm, architect, dev) were pinned to Go library work. Any issue scoped to `examples/<demo>/` — including the open #160 and #161 (port kotlin demos) — would have been mis-executed: pm would write Go-shaped acceptance criteria, architect would design for the package root, and dev would try to add Go files in the library.

Each agent now has a short examples-mode section. Key rules:

- Locked decisions in CLAUDE.md (stdlib-only, single flat package, no panics, no global state) are **library-only** and do not propagate into example specs/designs/code.
- Build/test verification uses the demo's toolchain, not `go build`/`go test`:
  - `examples/ts-frontend-first` → `npm ci && npm run build`
  - `examples/java-spring-boot` → `./mvnw -B test`
  - `examples/kotlin-ktor-koog` → `./gradlew test --no-daemon`
- `.github/workflows/examples.yml` is the source of truth for build commands.
- JVM demos consume `httptape-jvm` via composite build locally and `mavenLocal()` in CI.
- Most example issues do **not** warrant an ADR (per the tightened ADR bar from #246).

Total: +40 / -4 across three frontmatter files. No code changes.

## Test plan

- [ ] Next time an `examples/*` issue is dispatched end-to-end (e.g. #160 or #161), verify each agent uses the example's toolchain and does not try to apply library rules to demo code
- [x] No code changes; nothing to test in CI