### PR TITLE
chore(release): dispatch httptape-js after tag publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,18 @@
 # .github/workflows/release.yml
 #
-# Run tests and publish a GitHub Release with auto-generated notes.
-# httptape is a Go library — no binaries needed.
+# Run tests, publish a GitHub Release with auto-generated notes, and notify
+# httptape/httptape-js (the npm-distribution sibling repo) so it can build
+# and publish per-platform binary packages plus vite-plugin-httptape.
+#
 # Triggers: semver tags (v*).
+#
+# Required secrets:
+#   HTTPTAPE_JS_DISPATCH_TOKEN — fine-grained PAT (or GitHub App token) with
+#     "Actions: write" on httptape/httptape-js. Used by the final step to
+#     fire a repository_dispatch event.
+#     If missing, the dispatch step fails loudly and the rest of the release
+#     still ships; npm packages will not be published automatically until
+#     the secret is added.
 
 name: Release
 
@@ -32,3 +42,22 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+
+      - name: Resolve version from tag
+        id: version
+        run: |
+          # Strip leading "v" so the payload version matches the npm
+          # version (e.g. tag v0.13.2 → version 0.13.2).
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify httptape-js (binary build + npm publish)
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HTTPTAPE_JS_DISPATCH_TOKEN }}
+          repository: httptape/httptape-js
+          event-type: httptape-release
+          client-payload: |
+            {
+              "version": "${{ steps.version.outputs.version }}",
+              "sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
## Summary

Append a final step to \`release.yml\` that fires a \`repository_dispatch\` event on \`httptape/httptape-js\` after the GitHub Release is created. The receiver workflow there (shipped in [httptape-js#3](https://github.com/httptape/httptape-js/pull/3)) builds the Go binary for 5 platforms, sets the matching version on every workspace package, and publishes the binary packages + \`vite-plugin-httptape\` to npm.

Closes the dispatcher half of the cross-repo release pipeline locked in [httptape-js ADR-1](https://github.com/httptape/httptape-js/issues/1#issuecomment-4537030867).

## Manual prerequisites (you, before the next release)

| | |
|---|---|
| 1. **Claim \`@httptape\` npm scope** | \`npm org create httptape\` (or via npmjs.com UI) so \`@httptape/binary-*\` can be published. |
| 2. **Reserve \`vite-plugin-httptape\` name** | One-time \`npm publish\` of a placeholder, OR rely on the workflow's first run to claim it. |
| 3. **Mint \`NPM_TOKEN\`** | Automation token with publish rights on \`@httptape/*\` and \`vite-plugin-httptape\`. Add as secret on \`httptape/httptape-js\`. |
| 4. **Mint \`HTTPTAPE_JS_DISPATCH_TOKEN\`** | Fine-grained PAT with \`Actions: write\` on \`httptape/httptape-js\`. Add as secret **on this repo**. |

Until secret #4 is added, the new dispatch step fails loudly but the GitHub Release itself still ships normally — so this PR is safe to merge before the secret is wired.

## Test plan

- [x] YAML parses (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] Step uses \`GITHUB_REF_NAME#v\` to strip the leading \`v\` so payload version matches npm version
- [x] Receiver workflow in httptape-js has the matching \`event-type: httptape-release\` and reads \`client_payload.version\`
- [ ] First real release after secrets are added fires the dispatch successfully (validated end-to-end by cutting v0.13.2 or a v0.13.2-rc.0)