### PR TITLE
docs: extract why-and-comparisons to docs/why.md; remove WireMock framing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,8 +4,7 @@
 
 httptape is an embeddable Go library for HTTP traffic recording, sanitization, and replay.
 It captures HTTP request/response pairs, sanitizes sensitive data on write, and replays
-them as a mock server. Think WireMock, but native Go, embeddable, and with sanitization
-built into the core.
+them as a mock server. Native Go, embeddable, with sanitization built into the core.
 
 Target: Go developers who need deterministic, safe API mocking without Java, external
 processes, or manual fixture management.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/httptape/httptape/main/assets/logo.png" alt="httptape logo" width="300">
 </p>
 
-<h3 align="center">Like WireMock, but a 3 MB embeddable Go library — with redaction, SSE, and recording built in.</h3>
+<h3 align="center">A 3 MB embeddable Go library for HTTP record / redact / replay — with SSE event-level support and sanitize-on-write built in.</h3>
 
 <p align="center">
   <a href="https://pkg.go.dev/github.com/httptape/httptape"><img src="https://pkg.go.dev/badge/github.com/httptape/httptape.svg" alt="Go Reference"></a>
@@ -33,11 +33,7 @@ transitive dependencies.
 
 ## Why httptape?
 
-- **WireMock requires Java** -- separate process, 200 MB+ memory, can't embed in a Go binary
-- **Go mocking libraries** (`gock`, `httpmock`) only work inside test code -- no standalone server, no recording, no fixture management
-- **json-server / Mockoon** -- no recording, no redaction, manual fixture writing only
-- **Nobody does redaction** -- existing tools record raw traffic including secrets and PII. httptape redacts on write -- sensitive data never hits disk
-- **SSE record and replay** -- record Server-Sent Event streams (LLM completions, real-time feeds) with per-event timing, replay them with configurable speed (realtime, accelerated, or instant), and redact PII from individual event payloads. No other Go mocking tool does this
+Standalone server + CLI, **sanitize-on-write by default**, SSE event-level replay, and embeddable as a Go library with zero deps. For the full story (extracted from VibeWarden's egress proxy) and side-by-side comparisons with WireMock, Hoverfly, go-vcr, and others, see [Why httptape](https://httptape.dev/docs/why/).
 
 ## Use cases
 
@@ -350,24 +346,6 @@ Runnable end-to-end examples live in [`examples/`](examples/):
 - [`ts-frontend-first`](examples/ts-frontend-first/) — Vite + React talking to an httptape proxy with **live** source-state updates over SSE. Demonstrates fallback-to-cache (live → L1 → L2), per-event redaction, and the `/__httptape/health` endpoint.
 
 More examples coming. See [`examples/README.md`](examples/README.md) for the index.
-
-## How it compares
-
-| Feature | httptape | WireMock | go-vcr | json-server | MSW | gock |
-|---|---|---|---|---|---|---|
-| Embeddable in Go | **yes** | no (Java) | yes (test-only) | no (Node) | no (browser) | yes |
-| Standalone server | **yes** | yes | no | yes | no | no |
-| Docker | **3 MB** | 200 MB+ | n/a | 50 MB+ | n/a | n/a |
-| Recording | **yes** | yes | yes | no | no | no |
-| Redaction on write | **yes** | no | manual hooks | no | no | no |
-| Deterministic faking | **yes** | no | no | no | no | no |
-| Proxy with fallback | **yes** | no | no | no | no | no |
-| SSE record/replay | **yes** | no | no | no | partial | no |
-| Frontend mock backend | **yes** | yes | no | yes | yes (browser) | no |
-| Fixture import/export | **yes** | partial | no | no | no | no |
-| Dependencies | **zero** | JVM | yaml.v3 | npm | npm | 1 |
-
-**vs. [go-vcr](https://github.com/dnaeon/go-vcr)** — go-vcr is the de-facto cassette library for Go tests. httptape covers a different surface: it can also run as a standalone mock server (Docker / CLI / Testcontainers), redacts on write through a declarative pipeline (go-vcr exposes `BeforeSaveHook` callbacks but no built-in rules), records SSE streams with per-event timing, and bundles a fallback-to-cache proxy. If your only need is replaying cassettes inside `*_test.go`, go-vcr is smaller and a perfectly good fit.
 
 ## Key design decisions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,7 @@ httptape captures HTTP request/response pairs, redacts sensitive data on write, 
 
 ## Why httptape?
 
-**WireMock requires Java.** Separate process, 200 MB+ memory, can't embed in a Go binary.
-
-**Go mocking libraries** (`gock`, `httpmock`) only work inside test code. No standalone server, no recording, no fixture management.
-
-**Nobody does redaction.** Existing tools record raw traffic including secrets and PII. Redaction is always an afterthought. httptape redacts on write -- sensitive data never hits disk.
+Standalone server + CLI, **sanitize-on-write by default**, SSE event-level replay, and embeddable as a Go library with zero deps. For the full story (extracted from VibeWarden's egress proxy) and side-by-side comparisons with WireMock, Hoverfly, go-vcr, and others, see [Why httptape](why.md).
 
 ## Key features
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,0 +1,58 @@
+# Why httptape
+
+httptape exists because building an LLM-powered product means handling HTTP traffic that's full of secrets, prompts, PII, and streaming responses — and no existing tool treated any of that as a first-class concern.
+
+## Origin
+
+httptape was extracted from [VibeWarden](https://vibewarden.dev/), where we needed an egress proxy that could:
+
+1. **Record** real LLM and API traffic for replay in tests and demos.
+2. **Strip secrets, prompts, and PII *before* anything hit disk** — not as an opt-in afterthought.
+3. **Replay Server-Sent Event streams** with per-event timing, so streaming UIs behaved the same in tests as in production.
+4. **Embed directly into a Go binary**, with no external service to deploy alongside.
+
+We tried WireMock (Java process, no SSE replay), go-vcr (test-time-only, redaction via user hooks), and a handful of intercept-the-client mocking libraries. None of them treated the safe path as the default. So we built httptape and shipped it as a Go library, a CLI, and a 3 MB Docker image.
+
+The locked decision: **there is no "raw" recording mode**. Sanitization happens on write, deterministically (HMAC-SHA256 for fakes), before any tape touches a store. The safe path is the only path.
+
+## How it compares to other tools
+
+### Standalone mock servers
+
+**[WireMock](https://wiremock.org/)** is the reference standalone mock server. It supports recording, advanced matching, and a rich extension ecosystem — but it runs as a Java process (200 MB+ resident), can't be embedded in a Go binary, has no built-in SSE record/replay, and treats redaction as a plugin concern rather than a default.
+
+**[Hoverfly](https://hoverfly.io/)** is the closest direct competitor in Go: a standalone HTTP proxy with record/replay modes. Where httptape differs: sanitize-on-write is built in (rather than user-written middleware), SSE is replayed event-by-event with timing preserved, and the same code is consumable as an `http.RoundTripper` / `http.Handler` so you don't *have* to run a separate process.
+
+**[smocker](https://smocker.dev/)** is a Go-based WireMock-alike with a strong dynamic-matching engine. No record mode, no redaction, no SSE.
+
+### Cassette-style recording libraries
+
+**[go-vcr](https://github.com/dnaeon/go-vcr)** is the de-facto cassette library for Go tests. It records real HTTP traffic to YAML/JSON cassettes and replays in tests. Redaction is supported via `BeforeSaveHook` callbacks (user-written) — there are no built-in rules, no SSE, no standalone server, and it stays inside `*_test.go`. If your only need is replaying cassettes inside tests, go-vcr is smaller and a perfectly good fit. httptape covers a broader surface.
+
+### Intercept-the-client libraries (test-time only)
+
+**[gock](https://github.com/h2non/gock)** and **[jarcoal/httpmock](https://github.com/jarcoal/httpmock)** intercept HTTP calls from the Go test process. They're great for unit tests, but they don't record, don't run standalone, don't redact, and the fixtures are hand-written Go code.
+
+### Frontend-first mocking
+
+**[json-server](https://github.com/typicode/json-server)** and **[Mockoon](https://mockoon.com/)** are great for hand-written REST stubs and have nice UIs. No recording, no redaction, no SSE event-level support.
+
+**[MSW](https://mswjs.io/)** intercepts inside the JS runtime (browser or Node) for test-time mocking. Different deployment model from httptape — runs *inside* the application rather than as a sibling proxy. No record-from-upstream, no Go embedding.
+
+### Feature matrix
+
+| Feature | httptape | WireMock | Hoverfly | go-vcr | gock | json-server | MSW |
+|---|---|---|---|---|---|---|---|
+| Embeddable in Go | **yes** | no (Java) | partial (Go API) | yes (test-only) | yes | no (Node) | no (browser/Node) |
+| Standalone server | **yes** | yes | yes | no | no | yes | no |
+| Docker | **3 MB** | 200 MB+ | 60 MB | n/a | n/a | 50 MB+ | n/a |
+| Recording | **yes** | yes | yes | yes | no | no | no |
+| Redaction on write | **yes, default** | plugin | manual middleware | manual hooks | no | no | no |
+| Deterministic faking | **yes (HMAC-SHA256)** | no | no | no | no | no | no |
+| Proxy with fallback | **yes (L1/L2)** | no | partial | no | no | no | no |
+| SSE record/replay | **yes (per-event)** | no | no | no | no | no | partial (mock-only) |
+| Frontend mock backend | **yes** | yes | yes | no | no | yes | yes (browser) |
+| Fixture import/export | **yes (tar.gz)** | partial | partial | no | no | no | no |
+| Dependencies | **zero** | JVM | Go deps | yaml.v3 | 1 | npm tree | npm tree |
+
+The matrix is a thumbnail. If you're choosing between two of these for a specific problem, read the linked projects' docs for the full picture.

--- a/examples/java-spring-boot/README.md
+++ b/examples/java-spring-boot/README.md
@@ -111,7 +111,6 @@ IDE users: open [`api.http`](./api.http) — IntelliJ's HTTP Client (and VS Code
 
 | Alternative | Limitation |
 |---|---|
-| **WireMock** | No native SSE record/replay. No sanitize-on-write. |
 | **Spring `MockRestServiceServer`** | Works for REST, no streaming SSE support for Spring AI. |
 | **Real OpenAI calls in tests** | Slow (network), flaky (rate limits / outages), costs money, leaks PII into CI logs. |
 | **Manual mocking (Mockito)** | Skips the HTTP layer — you're not testing the real integration. Breaks when the API contract changes. |

--- a/examples/kotlin-ktor-koog/README.md
+++ b/examples/kotlin-ktor-koog/README.md
@@ -140,7 +140,6 @@ IDE users: open [`api.http`](./api.http) -- IntelliJ's HTTP Client and VS Code's
 
 | Alternative | Limitation |
 |---|---|
-| **WireMock** | No native body-fuzzy matching. No sanitize-on-write. |
 | **Koog's built-in mocks (`getMockExecutor`, `mockTool`)** | Mocks the LLM at executor level, skipping the HTTP layer entirely. You are not testing that your agent works with a real OpenAI-compatible endpoint. httptape tests the full HTTP integration -- serialization, headers, content negotiation -- same as production. |
 | **Real OpenAI calls in tests** | Slow, flaky, costs money, leaks PII into CI logs. |
 | **Manual Ktor test stubs** | Skips the HTTP layer. Breaks when the API contract changes. |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -216,13 +216,7 @@ Matcher criterion types: method, path, body_fuzzy (requires paths), content_nego
 
 ## How it compares
 
-| Feature | httptape | WireMock | gock/httpmock | MSW |
-|---|---|---|---|---|
-| SSE record/replay | **yes** | no | no | partial (mock-only) |
-| Redaction on write | **yes** | no | no | no |
-| Embeddable in Go | **yes** | no (Java) | yes | no (browser) |
-| Proxy with fallback | **yes** | no | no | no |
-| Content negotiation | **yes** | yes | no | no |
+Standalone server + CLI, sanitize-on-write by default, SSE event-level replay, proxy with L1/L2 fallback, zero deps. Full comparison (WireMock, Hoverfly, go-vcr, gock/httpmock, json-server, MSW): https://httptape.dev/docs/why
 
 ## Key APIs
 
@@ -268,11 +262,7 @@ httptape captures HTTP request/response pairs, redacts sensitive data on write, 
 
 ## Why httptape?
 
-**WireMock requires Java.** Separate process, 200 MB+ memory, can't embed in a Go binary.
-
-**Go mocking libraries** (`gock`, `httpmock`) only work inside test code. No standalone server, no recording, no fixture management.
-
-**Nobody does redaction.** Existing tools record raw traffic including secrets and PII. Redaction is always an afterthought. httptape redacts on write -- sensitive data never hits disk.
+Standalone server + CLI, sanitize-on-write by default, SSE event-level replay, embeddable as a Go library with zero deps. Extracted from VibeWarden's egress proxy. Full story + comparisons: https://httptape.dev/docs/why
 
 ## Key features
 

--- a/llms.txt
+++ b/llms.txt
@@ -200,13 +200,7 @@ Matcher criterion types: method, path, body_fuzzy (requires paths), content_nego
 
 ## How it compares
 
-| Feature | httptape | WireMock | gock/httpmock | MSW |
-|---|---|---|---|---|
-| SSE record/replay | **yes** | no | no | partial (mock-only) |
-| Redaction on write | **yes** | no | no | no |
-| Embeddable in Go | **yes** | no (Java) | yes | no (browser) |
-| Proxy with fallback | **yes** | no | no | no |
-| Content negotiation | **yes** | yes | no | no |
+Standalone server + CLI, sanitize-on-write by default, SSE event-level replay, proxy with L1/L2 fallback, zero deps. Full comparison (WireMock, Hoverfly, go-vcr, gock/httpmock, json-server, MSW): https://httptape.dev/docs/why
 
 ## Key APIs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Why httptape: why.md
   - Getting Started: getting-started.md
   - Core Concepts:
       - Recording: recording.md


### PR DESCRIPTION
## Summary

Extracts the README "Why httptape?" bullets + "How it compares" matrix into a versioned docs page (\`docs/why.md\`) and replaces both with a single pointer line. Also strips the "Like WireMock, but" framing from the README header and CLAUDE.md.

## Why now

Two problems the old format had:

1. Inline bullets carried false claims (e.g. "Go mocking libraries — no recording" — go-vcr does exactly that)
2. The pitch leaned on "Like WireMock" as a mental shortcut. Useful when nobody knew what httptape was; now it frames it as a WireMock clone rather than what it actually is (extracted from VibeWarden's egress-proxy needs)

Comparisons rot fast as a static README bullet but stay maintainable as a versioned docs page.

## Changes

- **New \`docs/why.md\`** — founder note (VibeWarden lineage), per-tool comparison covering WireMock, Hoverfly, smocker, go-vcr, gock, httpmock, json-server, Mockoon, MSW, and a feature matrix
- **\`README.md\`** — removed the 5-bullet "Why httptape?" + the full feature matrix + the go-vcr paragraph; H3 tagline no longer references WireMock
- **\`docs/index.md\`** — same slim-down + link to \`why.md\`
- **\`llms.txt\` / \`llms-full.txt\`** — replaced the inline comparison table (and the WireMock paragraph in llms-full.txt) with a single line pointing at the canonical page
- **\`examples/java-spring-boot/README.md\`, \`examples/kotlin-ktor-koog/README.md\`** — removed the WireMock row from each demo's "Why not...?" table; ecosystem-specific rows stay
- **\`.claude/CLAUDE.md\`** — dropped "Think WireMock, but native Go" framing
- **\`mkdocs.yml\`** — added "Why httptape" to nav between Home and Getting Started

## Out of scope

\`decisions.md\` still has 3 WireMock mentions — historical context inside ADRs (SSE design history, fixture-encoding decision). Deliberately preserved per the ADR audit rule (KEEP if load-bearing historical reference).

## Test plan

- [x] \`go test ./... -short\` passes (no code changes; sanity check)
- [x] \`grep -ri wiremock\` shows only intentional pointer-to-docs-why mentions outside \`decisions.md\` and worktrees
- [ ] Docs site builds cleanly (will be validated by CI / docs deploy)