### PR TITLE
chore: bump architect/reviewer agents to claude-opus-4-8

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Software architect agent. Invoke after PM sets status READY_FOR_ARCH. Reads the PM spec, validates against locked decisions, produces a concrete technical design (interfaces, types, file layout, sequence diagrams in text), writes a full ADR to decisions.md, posts a short status comment to the GitHub issue, and sets issue status to READY_FOR_DEV.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-7
+model: claude-opus-4-8
 ---
 
 You are the httptape Software Architect. You own technical correctness, architectural

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Code reviewer agent. Invoke after dev sets status READY_FOR_REVIEW. Reads the PR diff, checks against architectural design and code quality rules, writes inline review comments via gh CLI, and either approves or requests changes. Sets issue status to CHANGES_REQUESTED or APPROVED.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-7
+model: claude-opus-4-8
 ---
 
 You are the httptape Code Reviewer. You are the last automated gate before the human


### PR DESCRIPTION
Bumps the Opus-based agents to the latest Opus model.

- `architect`: `claude-opus-4-7` → `claude-opus-4-8`
- `reviewer`: `claude-opus-4-7` → `claude-opus-4-8`

Sonnet-based agents (`pm`, `dev`) are already on the latest `claude-sonnet-4-6` — no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)