### PR TITLE
fix(#300): upstream timeout no longer cancels live SSE streams

### DIFF
--- a/caching_transport.go
+++ b/caching_transport.go
@@ -196,9 +196,15 @@ func WithCacheUpstreamDownFallback(enabled bool) CachingOption {
 }
 
 // WithCacheUpstreamTimeout sets a timeout for upstream requests on cache
-// miss. When set, the request context is wrapped with a deadline before
-// forwarding. Default: 0 (no timeout; the caller's http.Client timeout
-// dominates).
+// miss. Default: 0 (no timeout; the caller's http.Client timeout dominates).
+//
+// For buffered responses the timeout covers the entire upstream interaction:
+// headers and body read. A stalled body read is aborted with a deadline error.
+//
+// For SSE responses the timeout bounds only the header (time-to-first-byte)
+// phase. Once SSE headers are received the timer is disarmed and the stream
+// runs for its natural lifetime under the caller's own context. Closing the
+// SSE response body releases the upstream context created for this timeout.
 func WithCacheUpstreamTimeout(d time.Duration) CachingOption {
 	return func(ct *CachingTransport) {
 		ct.upstreamTimeout = d
@@ -527,11 +533,37 @@ func (ct *CachingTransport) roundTripWithSingleFlight(req *http.Request, reqBody
 // roundTripUpstream handles the actual upstream call and optional recording.
 func (ct *CachingTransport) roundTripUpstream(req *http.Request, reqBody []byte, bodyHash string) (*http.Response, error) {
 	// Apply upstream timeout if configured.
+	// We use context.WithCancelCause + time.AfterFunc rather than
+	// context.WithTimeout so that the timer can be stopped (disarmed) for the
+	// SSE path. A WithTimeout deadline cannot be disarmed after creation, which
+	// would cancel a live SSE body when roundTripUpstream returns.
+	var (
+		cancel context.CancelCauseFunc
+		timer  *time.Timer
+	)
 	if ct.upstreamTimeout > 0 {
-		ctx, cancel := context.WithTimeout(req.Context(), ct.upstreamTimeout)
-		defer cancel()
+		var ctx context.Context
+		ctx, cancel = context.WithCancelCause(req.Context())
+		timer = time.AfterFunc(ct.upstreamTimeout, func() {
+			cancel(context.DeadlineExceeded)
+		})
 		req = req.WithContext(ctx)
 	}
+
+	// transferred is set to true when the SSE path takes ownership of cancel.
+	// The deferred cleanup must not fire cancel in that case.
+	transferred := false
+	defer func() {
+		if transferred {
+			return
+		}
+		if timer != nil {
+			timer.Stop()
+		}
+		if cancel != nil {
+			cancel(nil)
+		}
+	}()
 
 	startTime := ct.nowFunc()
 	resp, transportErr := ct.upstream.RoundTrip(req)
@@ -554,7 +586,13 @@ func (ct *CachingTransport) roundTripUpstream(req *http.Request, reqBody []byte,
 
 	// SSE detection on miss path.
 	if ct.sseRecording && isSSEContentType(resp.Header.Get("Content-Type")) {
-		return ct.roundTripSSE(req, resp, reqBody, startTime)
+		// Stop the timer: the SSE stream must not be bounded by upstreamTimeout.
+		// The stream now owns the cancel function and will call it on body Close.
+		if timer != nil {
+			timer.Stop()
+		}
+		transferred = true
+		return ct.roundTripSSE(req, resp, reqBody, startTime, cancel)
 	}
 
 	// Read response body into buffer.
@@ -608,7 +646,13 @@ func (ct *CachingTransport) roundTripUpstream(req *http.Request, reqBody []byte,
 // while a background goroutine parses SSE events. When the stream
 // completes cleanly, the tape is persisted. If the stream is truncated
 // (client disconnect), the partial tape is discarded.
-func (ct *CachingTransport) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte, startTime time.Time) (*http.Response, error) {
+//
+// cancel is the context.CancelCauseFunc from roundTripUpstream's disarmable
+// timer. When non-nil, cancel ownership transfers to this function: it will be
+// called exactly once when the caller closes the response body, releasing the
+// upstream context. When nil (upstreamTimeout == 0), no cancellation wrapper
+// is added and the stream runs purely under the caller's context.
+func (ct *CachingTransport) roundTripSSE(req *http.Request, resp *http.Response, reqBody []byte, startTime time.Time, cancel context.CancelCauseFunc) (*http.Response, error) {
 	nowFunc := ct.nowFunc // capture for closure
 	respHeaders := resp.Header.Clone()
 
@@ -679,8 +723,31 @@ func (ct *CachingTransport) roundTripSSE(req *http.Request, resp *http.Response,
 
 	wrapper := newSSERecordingReader(trackedBody, startTime, onEvent, onDone)
 	resp.Body = wrapper
+	if cancel != nil {
+		// Wrap with cancelOnCloseReadCloser so the upstream context is released
+		// when the caller closes the body, not when roundTripUpstream returns.
+		resp.Body = &cancelOnCloseReadCloser{inner: wrapper, cancel: cancel}
+	}
 
 	return resp, nil
+}
+
+// cancelOnCloseReadCloser transfers upstream-timeout cancellation to the SSE
+// stream lifecycle: it invokes cancel exactly once after the wrapped body is
+// closed, so the deadline context is released when the caller is done reading
+// rather than when roundTripUpstream returns.
+type cancelOnCloseReadCloser struct {
+	inner  io.ReadCloser
+	cancel context.CancelCauseFunc
+	once   sync.Once
+}
+
+func (c *cancelOnCloseReadCloser) Read(p []byte) (int, error) { return c.inner.Read(p) }
+
+func (c *cancelOnCloseReadCloser) Close() error {
+	err := c.inner.Close()
+	c.once.Do(func() { c.cancel(nil) })
+	return err
 }
 
 // eofTrackingReadCloser wraps an io.ReadCloser and tracks whether the

--- a/caching_transport_test.go
+++ b/caching_transport_test.go
@@ -2175,3 +2175,244 @@ func TestSingleFlightKey(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Upstream timeout: SSE vs buffered path correctness (#300)
+// ---------------------------------------------------------------------------
+
+// TestCachingTransport_UpstreamTimeoutSSEvsBuffered verifies that the
+// disarmable-timer approach (context.WithCancelCause + time.AfterFunc) behaves
+// correctly for both SSE and buffered responses.
+func TestCachingTransport_UpstreamTimeoutSSEvsBuffered(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			// Core regression: the SSE stream must stay readable past the timeout.
+			// Previously, defer cancel() fired on return from roundTripUpstream,
+			// tearing down the body immediately.
+			name: "SSE stream stays open past upstream timeout while streaming",
+			run: func(t *testing.T) {
+				t.Parallel()
+				store := NewMemoryStore()
+
+				const timeout = 60 * time.Millisecond
+				const eventInterval = 40 * time.Millisecond
+				const numEvents = 4 // span = 4 * 40ms = 160ms >> timeout
+
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "text/event-stream")
+					w.WriteHeader(200)
+					flusher, ok := w.(http.Flusher)
+					if !ok {
+						t.Error("httptest server does not support Flusher")
+						return
+					}
+					for i := 0; i < numEvents; i++ {
+						fmt.Fprintf(w, "data: event-%d\n\n", i)
+						flusher.Flush()
+						if i < numEvents-1 {
+							time.Sleep(eventInterval)
+						}
+					}
+				}))
+				defer srv.Close()
+
+				ct := NewCachingTransport(http.DefaultTransport, store,
+					WithCacheUpstreamTimeout(timeout),
+					WithCacheSingleFlight(false),
+				)
+
+				req, _ := http.NewRequest("GET", srv.URL+"/stream", nil)
+				resp, err := ct.RoundTrip(req)
+				if err != nil {
+					t.Fatalf("RoundTrip error: %v", err)
+				}
+
+				body, readErr := io.ReadAll(resp.Body)
+				resp.Body.Close()
+
+				if readErr != nil {
+					t.Fatalf("SSE body read error after timeout window: %v", readErr)
+				}
+
+				for i := 0; i < numEvents; i++ {
+					want := fmt.Sprintf("event-%d", i)
+					if !strings.Contains(string(body), want) {
+						t.Errorf("SSE body missing %q; got %q", want, string(body))
+					}
+				}
+
+				// Wait for the async onDone callback to persist the tape.
+				time.Sleep(150 * time.Millisecond)
+
+				tapes, _ := store.List(context.Background(), Filter{})
+				if len(tapes) != 1 {
+					t.Fatalf("store has %d tapes after SSE stream, want 1", len(tapes))
+				}
+				if !tapes[0].Response.IsSSE() {
+					t.Error("stored tape is not SSE")
+				}
+				if len(tapes[0].Response.SSEEvents) != numEvents {
+					t.Errorf("stored tape has %d SSE events, want %d", len(tapes[0].Response.SSEEvents), numEvents)
+				}
+			},
+		},
+		{
+			// The header phase must still be bounded: an SSE request that never
+			// sends headers should time out.
+			name: "upstream timeout aborts an SSE request that stalls before sending headers",
+			run: func(t *testing.T) {
+				t.Parallel()
+				store := NewMemoryStore()
+
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Block until the client disconnects (timeout fires).
+					<-r.Context().Done()
+				}))
+				defer srv.Close()
+
+				ct := NewCachingTransport(http.DefaultTransport, store,
+					WithCacheUpstreamTimeout(50*time.Millisecond),
+					WithCacheSingleFlight(false),
+				)
+
+				req, _ := http.NewRequest("GET", srv.URL+"/stream", nil)
+				resp, err := ct.RoundTrip(req)
+				if err == nil {
+					resp.Body.Close()
+					t.Fatal("expected error when upstream stalls before headers, got nil")
+				}
+				if !errors.Is(err, context.DeadlineExceeded) {
+					t.Errorf("expected context.DeadlineExceeded, got %v", err)
+				}
+			},
+		},
+		{
+			// Buffered semantics must be unchanged: the timer stays armed during
+			// the body read, so a stalled buffered body read aborts with a
+			// deadline error. roundTripUpstream catches the error, calls onError,
+			// and still returns the (empty) response — so we verify via the
+			// onError callback rather than the test's own io.ReadAll.
+			// Uses a mock transport with io.Pipe to give deterministic stall
+			// behavior without any server-side race.
+			name: "upstream timeout still bounds a buffered response whose body stalls",
+			run: func(t *testing.T) {
+				t.Parallel()
+				store := NewMemoryStore()
+
+				var (
+					capturedErr error
+					errMu       sync.Mutex
+				)
+
+				upstream := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					pr, pw := io.Pipe()
+					// Close the pipe with context.Cause so io.ReadAll inside
+					// roundTripUpstream gets context.DeadlineExceeded.
+					go func() {
+						<-req.Context().Done()
+						pw.CloseWithError(context.Cause(req.Context()))
+					}()
+					return &http.Response{
+						StatusCode: 200,
+						Header:     http.Header{"Content-Type": {"application/json"}},
+						Body:       pr,
+					}, nil
+				})
+
+				ct := NewCachingTransport(upstream, store,
+					WithCacheUpstreamTimeout(60*time.Millisecond),
+					WithCacheSingleFlight(false),
+					WithCacheOnError(func(err error) {
+						errMu.Lock()
+						capturedErr = err
+						errMu.Unlock()
+					}),
+				)
+
+				req, _ := http.NewRequest("GET", "http://example.com/data", nil)
+				resp, err := ct.RoundTrip(req)
+				if err != nil {
+					t.Fatalf("expected headers to arrive before timeout, got: %v", err)
+				}
+				resp.Body.Close()
+
+				// The body read inside roundTripUpstream should have timed out,
+				// triggering onError with context.DeadlineExceeded.
+				errMu.Lock()
+				bodyErr := capturedErr
+				errMu.Unlock()
+				if bodyErr == nil {
+					t.Fatal("onError not called; expected deadline exceeded on stalled body read")
+				}
+				if !errors.Is(bodyErr, context.DeadlineExceeded) {
+					t.Errorf("expected context.DeadlineExceeded in onError, got %v", bodyErr)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, tt.run)
+	}
+}
+
+// TestCachingTransport_ClosingSSEBodyReleasesUpstreamContext verifies that
+// closing a recorded SSE response body cancels the upstream-timeout context,
+// proving that cancel ownership transferred to the stream lifecycle and does not
+// leak the context.
+func TestCachingTransport_ClosingSSEBodyReleasesUpstreamContext(t *testing.T) {
+	t.Parallel()
+
+	var capturedCtx context.Context
+	var ctxMu sync.Mutex
+
+	upstream := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		ctxMu.Lock()
+		capturedCtx = req.Context()
+		ctxMu.Unlock()
+
+		body := "data: hello\n\ndata: world\n\n"
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})
+
+	store := NewMemoryStore()
+	ct := NewCachingTransport(upstream, store,
+		WithCacheUpstreamTimeout(500*time.Millisecond),
+		WithCacheSingleFlight(false),
+	)
+
+	req, _ := http.NewRequest("GET", "http://example.com/stream", nil)
+	resp, err := ct.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+
+	// Read stream to completion.
+	io.ReadAll(resp.Body) //nolint:errcheck
+
+	// Before Close: context should still be live (timer has not fired).
+	ctxMu.Lock()
+	ctx := capturedCtx
+	ctxMu.Unlock()
+	if ctx.Err() != nil {
+		t.Errorf("context cancelled before body Close: %v", ctx.Err())
+	}
+
+	// Close triggers cancelOnCloseReadCloser.cancel(nil).
+	resp.Body.Close()
+
+	// After Close: context must be cancelled.
+	if ctx.Err() == nil {
+		t.Error("context still live after body Close; cancel ownership transfer failed")
+	}
+}


### PR DESCRIPTION
Closes #300

## Root cause

`roundTripUpstream` in `caching_transport.go` wrapped the request with
`context.WithTimeout` and `defer cancel()`. Two bugs for the SSE path:

1. `defer cancel()` fires when `roundTripUpstream` returns. For SSE,
   `roundTripSSE` returns a *live* streaming body, so the deferred cancel
   runs immediately, tearing the body down while the caller still reads it.
2. Even without the defer, a `WithTimeout` deadline attached to the transport
   context watches the entire body lifetime. A 60s SSE stream is aborted at 30s
   with a 30s timeout — **and a `WithTimeout` deadline cannot be disarmed after
   creation**, so just moving `cancel` to `Close()` is not sufficient on its own.

## Fix

Replace `context.WithTimeout` + `defer cancel()` with a disarmable timer:

```
ctx, cancel = context.WithCancelCause(req.Context())
timer = time.AfterFunc(ct.upstreamTimeout, func() { cancel(context.DeadlineExceeded) })
```

A top-level deferred cleanup stops the timer and calls `cancel(nil)` on return.

**Buffered path**: unchanged semantics. The timer stays armed through
`io.ReadAll`, so a stalled body read is still aborted as
`context.DeadlineExceeded` (net/http uses `context.Cause` in Go 1.21+, so the
cause passed to `cancel` surfaces to the caller correctly).

**SSE path**: when SSE headers arrive, the timer is stopped (`timer.Stop()`)
and cancel ownership transfers to the new `cancelOnCloseReadCloser` type
wrapping the response body. `cancelOnCloseReadCloser.Close()` calls
`cancel(nil)` exactly once (via `sync.Once`), releasing the upstream context
when the caller is done reading — not when `roundTripUpstream` returns.

## Files changed

- `caching_transport.go` — `roundTripUpstream`, `roundTripSSE` (new `cancel`
  parameter), `cancelOnCloseReadCloser`, `WithCacheUpstreamTimeout` godoc.
- `caching_transport_test.go` — four new behavior-named test cases.

## Test plan

New tests in `TestCachingTransport_UpstreamTimeoutSSEvsBuffered`:

- **"SSE stream stays open past upstream timeout while streaming"** — httptest
  server emits 4 events at 40ms intervals (160ms total) with a 60ms timeout.
  Asserts all events are readable with no error, and the persisted tape has all
  4 events. This is the core regression guard.

- **"upstream timeout aborts an SSE request that stalls before sending headers"**
  — server blocks before writing headers. Asserts `errors.Is(err, context.DeadlineExceeded)`.

- **"upstream timeout still bounds a buffered response whose body stalls"** — mock
  transport returns a pipe-backed body that stalls until the context is cancelled.
  Asserts `onError` is called with `context.DeadlineExceeded` (the internal body
  read fails; the response is still returned with empty body as before).

Plus **`TestCachingTransport_ClosingSSEBodyReleasesUpstreamContext`** — captures
the request context, drives a short SSE stream to completion, asserts context is
still live before `Close()` and cancelled after. Proves cancel ownership
transferred and the context does not leak.

All tests pass: `go test ./... -race -count=1` and `go test -run Timeout -race -count=5 ./...`.
