### PR TITLE
fix(#306): matcher-only --config no longer disables sanitization

### DIFF
--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -52,14 +52,28 @@ const (
 
 var logger = log.New(os.Stderr, "httptape: ", 0)
 
+// safeDefaultCoverage enumerates exactly what the safe default sanitizer
+// redacts — and, critically, what it does NOT (bodies). Shared by both
+// safe-default warnings so the disclosure cannot drift between them.
+const safeDefaultCoverage = "Redacted headers: Authorization, Cookie, Set-Cookie, X-Api-Key, Proxy-Authorization, X-Forwarded-For. " +
+	"Redacted query params: api_key, access_token, token, secret, password, sig, signature, X-Amz-Signature, X-Goog-Signature. " +
+	"URL userinfo (user:password@) always stripped. " +
+	"Request/response BODIES are NOT redacted by default -- use --config with redact_body/fake rules for secrets in bodies."
+
 // safeDefaultWarning is printed to stderr when neither --config nor --unsafe-raw
 // is supplied. It names every header and query param category from the library's
 // default sensitive lists so users know exactly what is being redacted.
 const safeDefaultWarning = "WARNING: no --config supplied; applying safe default sanitization. " +
-	"Redacted headers: Authorization, Cookie, Set-Cookie, X-Api-Key, Proxy-Authorization, X-Forwarded-For. " +
-	"Redacted query params: api_key, access_token, token, secret, password, sig, signature, X-Amz-Signature, X-Goog-Signature. " +
-	"URL userinfo (user:password@) always stripped. " +
-	"To customize, use --config. To disable all sanitization (not recommended), use --unsafe-raw."
+	safeDefaultCoverage +
+	" To customize, use --config. To disable all sanitization (not recommended), use --unsafe-raw."
+
+// emptyRulesConfigWarning is printed when a --config is supplied but contains
+// no sanitization rules (matcher-only or empty "rules"). record/proxy ignore the
+// matcher block, so with zero rules the pipeline would be a no-op; instead we fail
+// closed by applying the safe default, matching the no-config posture.
+const emptyRulesConfigWarning = "WARNING: --config supplied but it contains no sanitization rules (matcher-only or empty \"rules\"); applying safe default sanitization. " +
+	safeDefaultCoverage +
+	" To sanitize with custom rules, add a non-empty \"rules\" array. To disable all sanitization (not recommended), drop --config and use --unsafe-raw."
 
 // unsafeRawWarning is printed to stderr when --unsafe-raw is supplied. It is
 // intentionally loud to make clear that the fail-closed default has been
@@ -453,6 +467,11 @@ func runRecord(args []string) error {
 		return fmt.Errorf("upstream URL must include scheme and host, got %q", *upstream)
 	}
 
+	// Validate mutual exclusion before any disk access (store MkdirAll, TLS PEM reads).
+	if *configPath != "" && *unsafeRaw {
+		return &usageError{fmt.Errorf("--config and --unsafe-raw are mutually exclusive")}
+	}
+
 	store, err := httptape.NewFileStore(httptape.WithDirectory(*fixtures))
 	if err != nil {
 		return fmt.Errorf("create store: %w", err)
@@ -477,19 +496,20 @@ func runRecord(args []string) error {
 		recorderOpts = append(recorderOpts, httptape.WithRecorderTLSConfig(tlsCfg))
 	}
 
-	// Validate mutual exclusion after flag parse, before any file read.
-	if *configPath != "" && *unsafeRaw {
-		return &usageError{fmt.Errorf("--config and --unsafe-raw are mutually exclusive")}
-	}
-
 	switch {
 	case *configPath != "":
 		cfg, err := httptape.LoadConfigFile(*configPath)
 		if err != nil {
 			return fmt.Errorf("load config: %w", err)
 		}
-		pipeline := cfg.BuildPipeline()
-		recorderOpts = append(recorderOpts, httptape.WithSanitizer(pipeline))
+		if len(cfg.Rules) == 0 {
+			// Matcher-only or empty config: no sanitization rules. Fail closed
+			// by applying the safe default (record/proxy ignore the matcher block).
+			recorderOpts = append(recorderOpts, httptape.WithSanitizer(defaultCLISanitizer()))
+			logger.Println(emptyRulesConfigWarning)
+		} else {
+			recorderOpts = append(recorderOpts, httptape.WithSanitizer(cfg.BuildPipeline()))
+		}
 	case *unsafeRaw:
 		logger.Println(unsafeRawWarning)
 	default:
@@ -615,6 +635,11 @@ func runProxy(args []string) error {
 		return fmt.Errorf("upstream URL must include scheme and host, got %q", *upstream)
 	}
 
+	// Validate mutual exclusion before any disk access (store MkdirAll, TLS PEM reads).
+	if *configPath != "" && *unsafeRaw {
+		return &usageError{fmt.Errorf("--config and --unsafe-raw are mutually exclusive")}
+	}
+
 	l1 := httptape.NewMemoryStore()
 	l2, err := httptape.NewFileStore(httptape.WithDirectory(*fixtures))
 	if err != nil {
@@ -639,19 +664,20 @@ func runProxy(args []string) error {
 		proxyOpts = append(proxyOpts, httptape.WithProxyTLSConfig(tlsCfg))
 	}
 
-	// Validate mutual exclusion after flag parse, before any file read.
-	if *configPath != "" && *unsafeRaw {
-		return &usageError{fmt.Errorf("--config and --unsafe-raw are mutually exclusive")}
-	}
-
 	switch {
 	case *configPath != "":
 		cfg, err := httptape.LoadConfigFile(*configPath)
 		if err != nil {
 			return fmt.Errorf("load config: %w", err)
 		}
-		pipeline := cfg.BuildPipeline()
-		proxyOpts = append(proxyOpts, httptape.WithProxySanitizer(pipeline))
+		if len(cfg.Rules) == 0 {
+			// Matcher-only or empty config: no sanitization rules. Fail closed
+			// by applying the safe default (record/proxy ignore the matcher block).
+			proxyOpts = append(proxyOpts, httptape.WithProxySanitizer(defaultCLISanitizer()))
+			logger.Println(emptyRulesConfigWarning)
+		} else {
+			proxyOpts = append(proxyOpts, httptape.WithProxySanitizer(cfg.BuildPipeline()))
+		}
 	case *unsafeRaw:
 		logger.Println(unsafeRawWarning)
 	default:

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -1857,19 +1857,215 @@ func TestProxyHelpListsUnsafeRaw(t *testing.T) {
 	}
 }
 
-// TestSafeDefaultWarningDriftGuard asserts that safeDefaultWarning contains
-// every element from DefaultSensitiveHeaders() and DefaultSensitiveQueryParams().
-// This prevents silent drift between the hard-coded warning text and the
-// canonical default lists in the library.
+// TestSafeDefaultWarningDriftGuard asserts that both safe-default warning strings
+// contain every element from DefaultSensitiveHeaders() and DefaultSensitiveQueryParams().
+// This prevents silent drift between the hard-coded warning text and the canonical
+// default lists in the library. Both warnings share safeDefaultCoverage, so this
+// also guards that the shared coverage string never loses a token.
 func TestSafeDefaultWarningDriftGuard(t *testing.T) {
-	for _, h := range httptape.DefaultSensitiveHeaders() {
-		if !strings.Contains(safeDefaultWarning, h) {
-			t.Errorf("safeDefaultWarning does not contain default sensitive header %q", h)
+	warnings := []struct {
+		name    string
+		warning string
+	}{
+		{"safeDefaultWarning", safeDefaultWarning},
+		{"emptyRulesConfigWarning", emptyRulesConfigWarning},
+	}
+	for _, w := range warnings {
+		for _, h := range httptape.DefaultSensitiveHeaders() {
+			if !strings.Contains(w.warning, h) {
+				t.Errorf("%s does not contain default sensitive header %q", w.name, h)
+			}
+		}
+		for _, p := range httptape.DefaultSensitiveQueryParams() {
+			if !strings.Contains(w.warning, p) {
+				t.Errorf("%s does not contain default sensitive query param %q", w.name, p)
+			}
 		}
 	}
-	for _, p := range httptape.DefaultSensitiveQueryParams() {
-		if !strings.Contains(safeDefaultWarning, p) {
-			t.Errorf("safeDefaultWarning does not contain default sensitive query param %q", p)
+}
+
+// matcherOnlyConfigPath writes a matcher-only config JSON (no sanitization rules)
+// to a temp file and returns its path. This is a valid config for serve (matcher
+// block is used) but produces an empty rules pipeline for record/proxy.
+func matcherOnlyConfigPath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "matcher-only.json")
+	content := `{"version":"1","matcher":{"criteria":[{"type":"method"},{"type":"path"}]}}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write matcher-only config: %v", err)
+	}
+	return path
+}
+
+// TestRecordFailClosed_MatcherOnlyConfigRedactsAuthAndToken verifies that record,
+// when given a --config with no sanitization rules (matcher-only), still applies
+// the safe default sanitizer so Authorization headers and token query params are
+// redacted before reaching disk.
+func TestRecordFailClosed_MatcherOnlyConfigRedactsAuthAndToken(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	fixturesDir, _ := runLiveCommandAndCapture(t,
+		[]string{"record", "--upstream", upstream.URL, "--config", matcherOnlyConfigPath(t)},
+		makeProbeWithAuthAndToken(upstream),
+	)
+
+	tape := loadFirstTapeFromDir(t, fixturesDir)
+
+	authVals := tape.Request.Headers.Values("Authorization")
+	if len(authVals) == 0 {
+		t.Fatal("fixture missing Authorization header entirely")
+	}
+	if authVals[0] != "[REDACTED]" {
+		t.Errorf("Authorization header = %q, want %q (matcher-only config must fail closed)", authVals[0], "[REDACTED]")
+	}
+
+	parsedURL, err := url.Parse(tape.Request.URL)
+	if err != nil {
+		t.Fatalf("parse fixture URL: %v", err)
+	}
+	if parsedURL.Query().Get("token") != "[REDACTED]" {
+		t.Errorf("token query param = %q, want %q (matcher-only config must fail closed)", parsedURL.Query().Get("token"), "[REDACTED]")
+	}
+}
+
+// TestProxyFailClosed_MatcherOnlyConfigRedactsAuthAndToken verifies that proxy,
+// when given a --config with no sanitization rules (matcher-only), still applies
+// the safe default sanitizer before persisting to L2.
+func TestProxyFailClosed_MatcherOnlyConfigRedactsAuthAndToken(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	fixturesDir, _ := runLiveCommandAndCapture(t,
+		[]string{"proxy", "--upstream", upstream.URL, "--config", matcherOnlyConfigPath(t)},
+		makeProbeWithAuthAndToken(upstream),
+	)
+
+	tape := loadFirstTapeFromDir(t, fixturesDir)
+
+	authVals := tape.Request.Headers.Values("Authorization")
+	if len(authVals) == 0 {
+		t.Fatal("fixture missing Authorization header entirely")
+	}
+	if authVals[0] != "[REDACTED]" {
+		t.Errorf("Authorization header = %q, want %q (matcher-only config must fail closed)", authVals[0], "[REDACTED]")
+	}
+
+	parsedURL, err := url.Parse(tape.Request.URL)
+	if err != nil {
+		t.Fatalf("parse fixture URL: %v", err)
+	}
+	if parsedURL.Query().Get("token") != "[REDACTED]" {
+		t.Errorf("token query param = %q, want %q (matcher-only config must fail closed)", parsedURL.Query().Get("token"), "[REDACTED]")
+	}
+}
+
+// TestRecordFailClosed_MatcherOnlyConfigWarnsSafeDefault verifies that record
+// prints the emptyRulesConfigWarning (naming Authorization) when a matcher-only
+// --config is supplied, so operators are not silently surprised by the fallback.
+func TestRecordFailClosed_MatcherOnlyConfigWarnsSafeDefault(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	_, stderr := runLiveCommandAndCapture(t,
+		[]string{"record", "--upstream", upstream.URL, "--config", matcherOnlyConfigPath(t)},
+		makeProbeWithAuthAndToken(upstream),
+	)
+
+	if !strings.Contains(stderr, "contains no sanitization rules") {
+		t.Errorf("stderr does not contain matcher-only config warning\ngot: %s", stderr)
+	}
+	if !strings.Contains(stderr, "Authorization") {
+		t.Errorf("stderr does not name Authorization in empty-rules warning\ngot: %s", stderr)
+	}
+}
+
+// TestProxyFailClosed_MatcherOnlyConfigWarnsSafeDefault verifies that proxy
+// prints the emptyRulesConfigWarning when a matcher-only --config is supplied.
+func TestProxyFailClosed_MatcherOnlyConfigWarnsSafeDefault(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	_, stderr := runLiveCommandAndCapture(t,
+		[]string{"proxy", "--upstream", upstream.URL, "--config", matcherOnlyConfigPath(t)},
+		makeProbeWithAuthAndToken(upstream),
+	)
+
+	if !strings.Contains(stderr, "contains no sanitization rules") {
+		t.Errorf("stderr does not contain matcher-only config warning\ngot: %s", stderr)
+	}
+	if !strings.Contains(stderr, "Authorization") {
+		t.Errorf("stderr does not name Authorization in empty-rules warning\ngot: %s", stderr)
+	}
+}
+
+// TestSafeDefaultWarningsDiscloseBodiesNotRedacted asserts that both warning
+// strings explicitly tell users that request/response bodies are NOT covered by
+// the safe default sanitizer, closing the false-assurance gap.
+func TestSafeDefaultWarningsDiscloseBodiesNotRedacted(t *testing.T) {
+	const bodyDisclosure = "BODIES are NOT redacted"
+	warnings := []struct {
+		name    string
+		warning string
+	}{
+		{"safeDefaultWarning", safeDefaultWarning},
+		{"emptyRulesConfigWarning", emptyRulesConfigWarning},
+	}
+	for _, w := range warnings {
+		if !strings.Contains(w.warning, bodyDisclosure) {
+			t.Errorf("%s does not disclose body non-coverage; want substring %q\ngot: %s",
+				w.name, bodyDisclosure, w.warning)
 		}
+	}
+}
+
+// TestRecordUnsafeRawPlusConfigDoesNotTouchDisk verifies that the
+// --unsafe-raw + --config mutual-exclusion check fires before NewFileStore's
+// MkdirAll, so the error path leaves the fixtures directory uncreated.
+func TestRecordUnsafeRawPlusConfigDoesNotTouchDisk(t *testing.T) {
+	nestedFixtures := filepath.Join(t.TempDir(), "sub", "fx")
+
+	got := run([]string{
+		"record",
+		"--upstream", "http://example.com",
+		"--fixtures", nestedFixtures,
+		"--unsafe-raw",
+		"--config", "/nonexistent.json",
+	})
+	if got != exitUsage {
+		t.Errorf("got exit %d, want %d (usage error for --unsafe-raw + --config)", got, exitUsage)
+	}
+	if _, err := os.Stat(nestedFixtures); !os.IsNotExist(err) {
+		t.Errorf("fixtures dir %q was created despite usage error (disk access must not precede the check)", nestedFixtures)
+	}
+}
+
+// TestProxyUnsafeRawPlusConfigDoesNotTouchDisk verifies that the
+// --unsafe-raw + --config mutual-exclusion check fires before NewFileStore's
+// MkdirAll in the proxy subcommand, so the error path leaves the fixtures
+// directory uncreated.
+func TestProxyUnsafeRawPlusConfigDoesNotTouchDisk(t *testing.T) {
+	nestedFixtures := filepath.Join(t.TempDir(), "sub", "fx")
+
+	got := run([]string{
+		"proxy",
+		"--upstream", "http://example.com",
+		"--fixtures", nestedFixtures,
+		"--unsafe-raw",
+		"--config", "/nonexistent.json",
+	})
+	if got != exitUsage {
+		t.Errorf("got exit %d, want %d (usage error for --unsafe-raw + --config)", got, exitUsage)
+	}
+	if _, err := os.Stat(nestedFixtures); !os.IsNotExist(err) {
+		t.Errorf("fixtures dir %q was created despite usage error (disk access must not precede the check)", nestedFixtures)
 	}
 }

--- a/decisions.md
+++ b/decisions.md
@@ -7782,6 +7782,24 @@ fixtures + captured stderr keeps the two subcommands' tests DRY.
   the drift-guard test prevents silent divergence from the canonical default
   slices without coupling the user-facing copy to runtime list ordering.
 
+##### Amendment 2026-08-05 (#306): empty-rules configs fail closed; body non-coverage disclosed
+
+ADR-49 clause 1 ("--config → load the config-derived pipeline exactly ... No default
+prepended/appended") is refined: it applies only when the config has a non-empty
+"rules" array. A --config whose "rules" is empty (matcher-only or absent) is a no-op
+sanitizer — record/proxy ignore the matcher block — so it now fails closed exactly like
+the no-config default: defaultCLISanitizer() is applied and emptyRulesConfigWarning is
+printed. Non-empty rules are still used verbatim with no default layered in. Config.Validate
+is unchanged: matcher-only configs remain valid because serve relies on them.
+
+The safe-default warnings now disclose that request/response BODIES are NOT redacted by
+the header+query default (shared safeDefaultCoverage string), closing the false-assurance
+gap.
+
+The --config/--unsafe-raw mutual-exclusion check is moved before NewFileStore (MkdirAll)
+and BuildTLSConfig (PEM reads) in both runRecord and runProxy, honoring this ADR's
+"error path must not touch disk" statement literally (previously it ran after those).
+
 ---
 
 ## PM Log


### PR DESCRIPTION
Closes #306

## Summary

- **Fail closed on matcher-only configs**: when `--config` is supplied but contains no sanitization rules (`len(cfg.Rules) == 0`), `record` and `proxy` now apply `defaultCLISanitizer()` and print `emptyRulesConfigWarning` instead of silently falling through to a no-op pipeline. Configs with non-empty rules are still used verbatim (ADR-49 clause 1 preserved).
- **Disclose body non-coverage**: both `safeDefaultWarning` and `emptyRulesConfigWarning` now share a `safeDefaultCoverage` constant that explicitly states request/response BODIES are NOT redacted by the header+query default, closing the false-assurance gap.
- **Mutual-exclusion check before disk writes**: the `--config`/`--unsafe-raw` conflict check is moved before `NewFileStore` (`os.MkdirAll`) and `BuildTLSConfig` (PEM reads) in both `runRecord` and `runProxy`, so the error path never touches disk as ADR-49 literally requires.
- **ADR-49 amendment**: appended to `decisions.md` documenting all three changes. `decisions.md` is committed in this PR.

## Test plan

- `TestRecordFailClosed_MatcherOnlyConfigRedactsAuthAndToken` / `TestProxyFailClosed_MatcherOnlyConfigRedactsAuthAndToken` — live probe with matcher-only config; asserts Authorization and token are `[REDACTED]` on disk.
- `TestRecordFailClosed_MatcherOnlyConfigWarnsSafeDefault` / proxy twin — asserts `emptyRulesConfigWarning` substring appears on stderr.
- `TestSafeDefaultWarningsDiscloseBodiesNotRedacted` — asserts both warning strings contain `"BODIES are NOT redacted"`.
- `TestSafeDefaultWarningDriftGuard` (extended) — now table-driven over both `safeDefaultWarning` and `emptyRulesConfigWarning`; asserts every `DefaultSensitiveHeaders()` and `DefaultSensitiveQueryParams()` token appears in each.
- `TestRecordUnsafeRawPlusConfigDoesNotTouchDisk` / `TestProxyUnsafeRawPlusConfigDoesNotTouchDisk` — uses a nested non-existent fixtures path; asserts exit is `exitUsage` AND `os.Stat` returns `IsNotExist`, proving disk is untouched.
- `go test ./... -race -count=1` — all green locally.