### PR TITLE
fix(#310): config schema accepts redact_query/fake_query; legacy actions reject stray params

### DIFF
--- a/config.go
+++ b/config.go
@@ -168,6 +168,9 @@ func (c *Config) Validate() error {
 			if rule.Seed != "" {
 				errs = append(errs, fmt.Sprintf("%s: %q does not use \"seed\"", prefix, rule.Action))
 			}
+			if len(rule.Params) > 0 {
+				errs = append(errs, fmt.Sprintf("%s: %q does not use \"params\"", prefix, rule.Action))
+			}
 
 		case ActionRedactBody:
 			if len(rule.Paths) == 0 {
@@ -183,6 +186,9 @@ func (c *Config) Validate() error {
 			}
 			if rule.Seed != "" {
 				errs = append(errs, fmt.Sprintf("%s: %q does not use \"seed\"", prefix, rule.Action))
+			}
+			if len(rule.Params) > 0 {
+				errs = append(errs, fmt.Sprintf("%s: %q does not use \"params\"", prefix, rule.Action))
 			}
 
 		case ActionFake:
@@ -212,6 +218,9 @@ func (c *Config) Validate() error {
 			}
 			if len(rule.Headers) > 0 {
 				errs = append(errs, fmt.Sprintf("%s: %q does not use \"headers\"", prefix, rule.Action))
+			}
+			if len(rule.Params) > 0 {
+				errs = append(errs, fmt.Sprintf("%s: %q does not use \"params\"", prefix, rule.Action))
 			}
 
 		case ActionRedactQuery:

--- a/config.schema.json
+++ b/config.schema.json
@@ -217,6 +217,46 @@
               }
             ],
             "additionalProperties": false
+          },
+          {
+            "properties": {
+              "action": {
+                "const": "redact_query"
+              },
+              "params": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "description": "URL query parameter names to redact. Case-sensitive (RFC 3986). If omitted or empty, DefaultSensitiveQueryParams are used (api_key, access_token, token, secret, password, sig, signature, X-Amz-Signature, X-Goog-Signature). Userinfo (user:pass@host) is always stripped regardless of this list."
+              }
+            },
+            "required": ["action"],
+            "additionalProperties": false
+          },
+          {
+            "properties": {
+              "action": {
+                "const": "fake_query"
+              },
+              "seed": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Project-level seed for HMAC-SHA256 deterministic faking. Same seed + same input = same fake output."
+              },
+              "params": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1,
+                "description": "URL query parameter names to fake. Case-sensitive (RFC 3986). Required and must be non-empty; an empty list is rejected as a likely misconfiguration. Userinfo (user:pass@host) is always stripped regardless of this list."
+              }
+            },
+            "required": ["action", "seed", "params"],
+            "additionalProperties": false
           }
         ]
       }

--- a/config_test.go
+++ b/config_test.go
@@ -118,6 +118,21 @@ func TestLoadConfig_ValidationErrors(t *testing.T) {
 			input:   `{"version": "1", "rules": [{"action": "fake", "seed": "s", "paths": ["$.x"], "headers": ["Auth"]}]}`,
 			wantErr: `does not use "headers"`,
 		},
+		{
+			name:    "redact_headers rejects stray params field",
+			input:   `{"version": "1", "rules": [{"action": "redact_headers", "params": ["api_key"]}]}`,
+			wantErr: `does not use "params"`,
+		},
+		{
+			name:    "redact_body rejects stray params field",
+			input:   `{"version": "1", "rules": [{"action": "redact_body", "paths": ["$.x"], "params": ["api_key"]}]}`,
+			wantErr: `does not use "params"`,
+		},
+		{
+			name:    "fake rejects stray params field",
+			input:   `{"version": "1", "rules": [{"action": "fake", "seed": "s", "paths": ["$.x"], "params": ["api_key"]}]}`,
+			wantErr: `does not use "params"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -247,6 +247,8 @@ func (p *Pipeline) Sanitize(t Tape) Tape // implements Sanitizer
 | RedactBodyPaths | `RedactBodyPaths(paths ...string) SanitizeFunc` |
 | FakeFields | `FakeFields(seed string, paths ...string) SanitizeFunc` |
 | FakeFieldsWith | `FakeFieldsWith(seed string, fields map[string]Faker) SanitizeFunc` |
+| RedactQueryParams | `RedactQueryParams(names ...string) SanitizeFunc` |
+| FakeQueryParams | `FakeQueryParams(seed string, names ...string) SanitizeFunc` |
 
 ### Faker interface
 
@@ -285,6 +287,7 @@ PII-shaped and generic fakers leave non-string inputs unchanged. `RedactedFaker`
 const Redacted = "[REDACTED]"
 
 func DefaultSensitiveHeaders() []string
+func DefaultSensitiveQueryParams() []string
 ```
 
 **Details:** [Redaction](sanitization.md#typed-fakers)
@@ -433,8 +436,9 @@ type MatcherConfig struct {
 }
 
 type CriterionConfig struct {
-    Type  string   `json:"type"`
-    Paths []string `json:"paths,omitempty"`
+    Type    string   `json:"type"`
+    Paths   []string `json:"paths,omitempty"`
+    Pattern string   `json:"pattern,omitempty"`
 }
 
 type Rule struct {
@@ -443,13 +447,14 @@ type Rule struct {
     Paths   []string       `json:"paths,omitempty"`
     Seed    string         `json:"seed,omitempty"`
     Fields  map[string]any `json:"fields,omitempty"`
+    Params  []string       `json:"params,omitempty"`
 }
 
 func LoadConfig(r io.Reader) (*Config, error)
 func LoadConfigFile(path string) (*Config, error)
 func (c *Config) Validate() error
 func (c *Config) BuildPipeline() *Pipeline
-func (c *Config) BuildMatcher() *CompositeMatcher // returns nil when no matcher section
+func (c *Config) BuildMatcher() (Matcher, error)
 ```
 
 For `fake` rules, set either `Paths` (for auto-detect, mapping to `FakeFields`) or `Fields` (for typed fakers, mapping to `FakeFieldsWith`) -- the two are mutually exclusive. Each value in `Fields` is either a string shorthand (for example `"email"`) or an object (for example `{"type": "numeric", "length": 3}`). See [Config -> Typed fake fields](config.md#typed-fake-fields) for the full syntax.
@@ -480,6 +485,8 @@ const (
     ActionRedactHeaders = "redact_headers"
     ActionRedactBody    = "redact_body"
     ActionFake          = "fake"
+    ActionRedactQuery   = "redact_query"
+    ActionFakeQuery     = "fake_query"
 )
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -119,6 +119,38 @@ Maps to `RedactBodyPaths()`. Redacts specific fields in JSON bodies.
 
 The `paths` field is required and must be non-empty.
 
+### redact_query
+
+Maps to `RedactQueryParams()`. Replaces URL query-parameter values with `"[REDACTED]"`. Userinfo credentials (`user:pass@host`) are unconditionally stripped as well.
+
+```json
+{ "action": "redact_query" }
+```
+
+Optionally specify which parameters to redact (default: `DefaultSensitiveQueryParams`):
+
+```json
+{ "action": "redact_query", "params": ["api_key", "access_token", "sig"] }
+```
+
+The `params` field is optional. When omitted or empty, the default sensitive parameter list is used: `api_key`, `access_token`, `token`, `secret`, `password`, `sig`, `signature`, `X-Amz-Signature`, `X-Goog-Signature`.
+
+Parameter name matching is **case-sensitive** per RFC 3986 (unlike header matching, which is case-insensitive). `api_key` does not redact `API_KEY`.
+
+If the URL's query string contains malformed percent-encoding (e.g., `?api_key=ab%ZZcd`), the entire query string is replaced with `[REDACTED]` rather than passing through (fail-closed behavior).
+
+### fake_query
+
+Maps to `FakeQueryParams()`. Replaces URL query-parameter values with deterministic HMAC-based fakes. Userinfo credentials (`user:pass@host`) are unconditionally stripped as well.
+
+```json
+{ "action": "fake_query", "seed": "my-project-seed", "params": ["api_key", "access_token"] }
+```
+
+Both `seed` and `params` are required. An empty `params` array is rejected as a likely misconfiguration (use `redact_query` if you want a default list).
+
+The same seed and original value always produce the same fake output (deterministic HMAC-SHA256). Case-sensitive name matching applies.
+
 ### fake
 
 Replaces values with deterministic HMAC-based fakes. The `seed` field is always required. The faking strategy is selected by which other field you set:
@@ -245,7 +277,7 @@ err := cfg.Validate()
 Validation checks:
 - Version must be `"1"`
 - Rules may be empty only when a `matcher` section is present (the config is matcher-only)
-- Each rule must have a known action (`redact_headers`, `redact_body`, `fake`)
+- Each rule must have a known action (`redact_headers`, `redact_body`, `fake`, `redact_query`, `fake_query`)
 - Action-specific required fields must be present
 - All paths must use valid JSONPath-like syntax (`$.field`, `$.nested.field`, `$.array[*].field`)
 - Fields irrelevant to an action are rejected (e.g., `paths` on `redact_headers`)
@@ -258,6 +290,15 @@ Additional rules for `fake`:
 - Each value in `fields` must be either a known string shorthand or an object with a known `type`.
 - Object-form fakers must include their required parameters (`numeric.length`, `pattern.pattern`, `prefix.prefix`, `fixed.value`); `date.format` is optional.
 - Anything else (numbers, arrays, nulls) as a `fields` value is rejected.
+
+Additional rules for `redact_query`:
+- `params` is optional. When omitted, `DefaultSensitiveQueryParams` is used.
+- Fields irrelevant to this action are rejected (`paths`, `seed`, `fields`, `headers`).
+
+Additional rules for `fake_query`:
+- `seed` must be present and non-empty.
+- `params` must be present and non-empty (an empty list is rejected as a likely misconfiguration).
+- Fields irrelevant to this action are rejected (`paths`, `fields`, `headers`).
 
 Additional rules for `matcher`:
 - `criteria` must be a non-empty array.
@@ -289,6 +330,10 @@ Reference it in your config file:
     {
       "action": "redact_headers",
       "headers": ["Authorization", "Cookie", "X-Api-Key"]
+    },
+    {
+      "action": "redact_query",
+      "params": ["api_key", "access_token"]
     },
     {
       "action": "redact_body",

--- a/docs/sanitization.md
+++ b/docs/sanitization.md
@@ -25,6 +25,7 @@ type Sanitizer interface {
 ```go
 sanitizer := httptape.NewPipeline(
     httptape.RedactHeaders(),
+    httptape.RedactQueryParams(),
     httptape.RedactBodyPaths("$.password", "$.ssn"),
     httptape.FakeFields("my-seed", "$.email", "$.user_id"),
 )
@@ -34,7 +35,7 @@ rec := httptape.NewRecorder(store,
 )
 ```
 
-Functions are applied in order. In this example: headers are redacted first, then body fields are redacted, then remaining fields get deterministic fakes.
+Functions are applied in order. In this example: headers are redacted first, then URL query parameters are redacted, then body fields are redacted, then remaining fields get deterministic fakes.
 
 ## RedactHeaders
 
@@ -401,6 +402,63 @@ sanitizer := httptape.NewPipeline(
 
 Make sure your implementation is deterministic (same seed + original always produces the same output) and does not mutate `original` -- httptape passes the value pulled out of `json.Unmarshal` directly.
 
+## RedactQueryParams
+
+Replaces URL query-parameter values with `"[REDACTED]"` in `t.Request.URL`. Userinfo credentials (`user:pass@host`) are unconditionally stripped as well, regardless of which parameter names are configured.
+
+```go
+// Redact the default sensitive query parameters:
+httptape.RedactQueryParams()
+
+// Redact specific named parameters:
+httptape.RedactQueryParams("api_key", "access_token", "sig")
+```
+
+Default sensitive parameters (used when called with no arguments):
+- `api_key` -- generic API key authentication
+- `access_token` -- OAuth access tokens
+- `token` -- generic tokens
+- `secret` -- generic secrets
+- `password` -- plaintext passwords in URLs
+- `sig` -- presigned URL signatures (short form)
+- `signature` -- presigned URL signatures (long form)
+- `X-Amz-Signature` -- AWS presigned URL signature
+- `X-Goog-Signature` -- Google Cloud presigned URL signature
+
+You can retrieve the default list programmatically:
+
+```go
+defaults := httptape.DefaultSensitiveQueryParams()
+```
+
+Parameter name matching is **case-sensitive** per RFC 3986. `api_key` does not match `API_KEY`. This is intentional: query keys are case-sensitive by specification, and silent case-folding would risk redacting the wrong parameter.
+
+**Fail-closed behavior:** if the URL's query string contains malformed percent-encoding (e.g., `?api_key=ab%ZZcd`), the entire query string is replaced with `[REDACTED]` rather than passed through. This prevents cleartext secrets from reaching disk when a value cannot be safely decoded.
+
+**Fragment handling:** OAuth implicit-flow tokens and some presigned-URL schemes embed credentials in the URL fragment (`#access_token=...`). `RedactQueryParams` applies the same name-based redaction to fragment key=value pairs. On a fragment parse error the entire fragment is replaced with `[REDACTED]`.
+
+**Byte-stable on no-match:** when no configured parameter name matches and no userinfo is present, the URL is returned byte-identical (no re-encoding, no key reordering). When a match occurs or userinfo is stripped, the query string is re-encoded and keys may be re-sorted alphabetically -- this is safe for all built-in matchers, which compare by key/value map, not by string order.
+
+Headers, body, and response are left byte-identical after URL sanitization.
+
+If the URL fails to parse structurally (invalid scheme, etc.), it is returned unchanged (silent skip, consistent with body sanitization behavior).
+
+## FakeQueryParams
+
+Replaces URL query-parameter values with deterministic HMAC-SHA256 fakes. Userinfo credentials (`user:pass@host`) are unconditionally stripped as well.
+
+```go
+httptape.FakeQueryParams("my-project-seed", "api_key", "access_token")
+```
+
+The first argument is the project-level seed (same as `FakeFields`). The same seed and original value always produce the same fake output. Different seeds produce different outputs. Use the same seed as the rest of your sanitization pipeline to maintain cross-fixture consistency.
+
+The fake value is computed as `fakeString(HMAC-SHA256(seed, original_value))`, producing a `"fake_<hex>"` string. This is the same algorithm used by `HMACFaker` for generic string fields.
+
+All the same behavioral guarantees as `RedactQueryParams` apply: case-sensitive name matching, fail-closed on malformed query/fragment, unconditional userinfo stripping, byte-stable on no-match.
+
+The declarative config equivalent is the `fake_query` action. Unlike `redact_query`, the `params` field is required for `fake_query` -- an empty list is rejected as a likely misconfiguration.
+
 ## Combining redaction and faking
 
 Order matters. Typically, redact first (remove things that should be gone entirely), then fake (replace things that need consistent stand-in values):
@@ -445,13 +503,14 @@ Instead of building pipelines in code, you can define redaction rules in a JSON 
   "version": "1",
   "rules": [
     { "action": "redact_headers" },
+    { "action": "redact_query" },
     { "action": "redact_body", "paths": ["$.password"] },
     { "action": "fake", "seed": "my-seed", "paths": ["$.user.email"] }
   ]
 }
 ```
 
-The `fake` action also accepts a `fields` map that selects a typed faker per path -- the JSON-config equivalent of `FakeFieldsWith`. See [Config](config.md#typed-fake-fields) for syntax and the full list of shorthands.
+The `fake` action also accepts a `fields` map that selects a typed faker per path -- the JSON-config equivalent of `FakeFieldsWith`. The `fake_query` action is the config equivalent of `FakeQueryParams`. See [Config](config.md) for the full config syntax and all supported actions.
 
 ## SSE event redaction
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -60,6 +60,8 @@ sanitizer := httptape.NewPipeline(
     httptape.RedactHeaders("Authorization", "Cookie"),
     httptape.RedactBodyPaths("$.password", "$.ssn"),
     httptape.FakeFields("seed", "$.email", "$.user_id"),
+    httptape.RedactQueryParams("api_key", "access_token"),
+    httptape.FakeQueryParams("seed", "sig"),
     httptape.RedactSSEEventData("$.choices[*].delta.content"),
     httptape.FakeSSEEventData("seed", "$.user.email"),
 )
@@ -68,6 +70,8 @@ sanitizer := httptape.NewPipeline(
 - RedactHeaders: replace header values with "[REDACTED]"
 - RedactBodyPaths: type-aware JSON field redaction
 - FakeFields: deterministic HMAC-SHA256 fakes (emails, UUIDs, numbers, strings)
+- RedactQueryParams: replace URL query-param values with "[REDACTED]"; strips userinfo unconditionally
+- FakeQueryParams: deterministic HMAC-SHA256 fakes for URL query-param values; strips userinfo unconditionally
 - RedactSSEEventData: redact fields within each SSE event's JSON data
 - FakeSSEEventData: deterministic faking within each SSE event's JSON data
 
@@ -207,12 +211,15 @@ docker pull ghcr.io/httptape/httptape:latest
  ]},
  "rules":[
   {"action":"redact_headers","headers":["Authorization"]},
+  {"action":"redact_query","params":["api_key","access_token"]},
   {"action":"redact_body","paths":["$.password"]},
-  {"action":"fake","seed":"s","paths":["$.email"]}
+  {"action":"fake","seed":"s","paths":["$.email"]},
+  {"action":"fake_query","seed":"s","params":["sig"]}
 ]}
 ```
 
-Matcher criterion types: method, path, body_fuzzy (requires paths), content_negotiation.
+Actions: redact_headers, redact_body, fake, redact_query, fake_query.
+Matcher criterion types: method, path, body_fuzzy (requires paths), content_negotiation, path_pattern.
 
 ## How it compares
 
@@ -1101,6 +1108,7 @@ type Sanitizer interface {
 ```go
 sanitizer := httptape.NewPipeline(
     httptape.RedactHeaders(),
+    httptape.RedactQueryParams(),
     httptape.RedactBodyPaths("$.password", "$.ssn"),
     httptape.FakeFields("my-seed", "$.email", "$.user_id"),
 )
@@ -1477,6 +1485,63 @@ sanitizer := httptape.NewPipeline(
 
 Make sure your implementation is deterministic (same seed + original always produces the same output) and does not mutate `original` -- httptape passes the value pulled out of `json.Unmarshal` directly.
 
+## RedactQueryParams
+
+Replaces URL query-parameter values with `"[REDACTED]"` in `t.Request.URL`. Userinfo credentials (`user:pass@host`) are unconditionally stripped as well, regardless of which parameter names are configured.
+
+```go
+// Redact the default sensitive query parameters:
+httptape.RedactQueryParams()
+
+// Redact specific named parameters:
+httptape.RedactQueryParams("api_key", "access_token", "sig")
+```
+
+Default sensitive parameters (used when called with no arguments):
+- `api_key` -- generic API key authentication
+- `access_token` -- OAuth access tokens
+- `token` -- generic tokens
+- `secret` -- generic secrets
+- `password` -- plaintext passwords in URLs
+- `sig` -- presigned URL signatures (short form)
+- `signature` -- presigned URL signatures (long form)
+- `X-Amz-Signature` -- AWS presigned URL signature
+- `X-Goog-Signature` -- Google Cloud presigned URL signature
+
+You can retrieve the default list programmatically:
+
+```go
+defaults := httptape.DefaultSensitiveQueryParams()
+```
+
+Parameter name matching is **case-sensitive** per RFC 3986. `api_key` does not match `API_KEY`. This is intentional: query keys are case-sensitive by specification, and silent case-folding would risk redacting the wrong parameter.
+
+**Fail-closed behavior:** if the URL's query string contains malformed percent-encoding (e.g., `?api_key=ab%ZZcd`), the entire query string is replaced with `[REDACTED]` rather than passed through. This prevents cleartext secrets from reaching disk when a value cannot be safely decoded.
+
+**Fragment handling:** OAuth implicit-flow tokens and some presigned-URL schemes embed credentials in the URL fragment (`#access_token=...`). `RedactQueryParams` applies the same name-based redaction to fragment key=value pairs. On a fragment parse error the entire fragment is replaced with `[REDACTED]`.
+
+**Byte-stable on no-match:** when no configured parameter name matches and no userinfo is present, the URL is returned byte-identical (no re-encoding, no key reordering). When a match occurs or userinfo is stripped, the query string is re-encoded and keys may be re-sorted alphabetically -- this is safe for all built-in matchers, which compare by key/value map, not by string order.
+
+Headers, body, and response are left byte-identical after URL sanitization.
+
+If the URL fails to parse structurally (invalid scheme, etc.), it is returned unchanged (silent skip, consistent with body sanitization behavior).
+
+## FakeQueryParams
+
+Replaces URL query-parameter values with deterministic HMAC-SHA256 fakes. Userinfo credentials (`user:pass@host`) are unconditionally stripped as well.
+
+```go
+httptape.FakeQueryParams("my-project-seed", "api_key", "access_token")
+```
+
+The first argument is the project-level seed (same as `FakeFields`). The same seed and original value always produce the same fake output. Different seeds produce different outputs. Use the same seed as the rest of your sanitization pipeline to maintain cross-fixture consistency.
+
+The fake value is computed as `fakeString(HMAC-SHA256(seed, original_value))`, producing a `"fake_<hex>"` string. This is the same algorithm used by `HMACFaker` for generic string fields.
+
+All the same behavioral guarantees as `RedactQueryParams` apply: case-sensitive name matching, fail-closed on malformed query/fragment, unconditional userinfo stripping, byte-stable on no-match.
+
+The declarative config equivalent is the `fake_query` action. Unlike `redact_query`, the `params` field is required for `fake_query` -- an empty list is rejected as a likely misconfiguration.
+
 ## Combining redaction and faking
 
 Order matters. Typically, redact first (remove things that should be gone entirely), then fake (replace things that need consistent stand-in values):
@@ -1521,13 +1586,14 @@ Instead of building pipelines in code, you can define redaction rules in a JSON 
   "version": "1",
   "rules": [
     { "action": "redact_headers" },
+    { "action": "redact_query" },
     { "action": "redact_body", "paths": ["$.password"] },
     { "action": "fake", "seed": "my-seed", "paths": ["$.user.email"] }
   ]
 }
 ```
 
-The `fake` action also accepts a `fields` map that selects a typed faker per path -- the JSON-config equivalent of `FakeFieldsWith`. See [Config](config.md#typed-fake-fields) for syntax and the full list of shorthands.
+The `fake` action also accepts a `fields` map that selects a typed faker per path -- the JSON-config equivalent of `FakeFieldsWith`. The `fake_query` action is the config equivalent of `FakeQueryParams`. See [Config](config.md) for the full config syntax and all supported actions.
 
 ## SSE event redaction
 
@@ -4037,7 +4103,7 @@ err := cfg.Validate()
 Validation checks:
 - Version must be `"1"`
 - Rules may be empty only when a `matcher` section is present (the config is matcher-only)
-- Each rule must have a known action (`redact_headers`, `redact_body`, `fake`)
+- Each rule must have a known action (`redact_headers`, `redact_body`, `fake`, `redact_query`, `fake_query`)
 - Action-specific required fields must be present
 - All paths must use valid JSONPath-like syntax (`$.field`, `$.nested.field`, `$.array[*].field`)
 - Fields irrelevant to an action are rejected (e.g., `paths` on `redact_headers`)
@@ -4051,10 +4117,20 @@ Additional rules for `fake`:
 - Object-form fakers must include their required parameters (`numeric.length`, `pattern.pattern`, `prefix.prefix`, `fixed.value`); `date.format` is optional.
 - Anything else (numbers, arrays, nulls) as a `fields` value is rejected.
 
+Additional rules for `redact_query`:
+- `params` is optional. When omitted, `DefaultSensitiveQueryParams` is used.
+- Fields irrelevant to this action are rejected (`paths`, `seed`, `fields`, `headers`).
+
+Additional rules for `fake_query`:
+- `seed` must be present and non-empty.
+- `params` must be present and non-empty (an empty list is rejected as a likely misconfiguration).
+- Fields irrelevant to this action are rejected (`paths`, `fields`, `headers`).
+
 Additional rules for `matcher`:
 - `criteria` must be a non-empty array.
-- Each criterion must have a known `type` (`method`, `path`, `body_fuzzy`, `content_negotiation`).
+- Each criterion must have a known `type` (`method`, `path`, `body_fuzzy`, `content_negotiation`, `path_pattern`).
 - `body_fuzzy` requires a non-empty `paths` array with valid JSONPath-like paths.
+- `path_pattern` requires a non-empty `pattern` string with a leading `/`.
 - `method`, `path`, and `content_negotiation` do not accept `paths`; specifying them is rejected.
 - Unknown criterion fields are rejected.
 

--- a/llms.txt
+++ b/llms.txt
@@ -68,6 +68,8 @@ sanitizer := httptape.NewPipeline(
 - RedactHeaders: replace header values with "[REDACTED]"
 - RedactBodyPaths: type-aware JSON field redaction
 - FakeFields: deterministic HMAC-SHA256 fakes (emails, UUIDs, numbers, strings)
+- RedactQueryParams: replace URL query-param values with "[REDACTED]"; strips userinfo unconditionally
+- FakeQueryParams: deterministic HMAC-SHA256 fakes for URL query-param values; strips userinfo unconditionally
 - RedactSSEEventData: redact fields within each SSE event's JSON data
 - FakeSSEEventData: deterministic faking within each SSE event's JSON data
 
@@ -191,12 +193,15 @@ docker pull ghcr.io/httptape/httptape:latest
  ]},
  "rules":[
   {"action":"redact_headers","headers":["Authorization"]},
+  {"action":"redact_query","params":["api_key","access_token"]},
   {"action":"redact_body","paths":["$.password"]},
-  {"action":"fake","seed":"s","paths":["$.email"]}
+  {"action":"fake","seed":"s","paths":["$.email"]},
+  {"action":"fake_query","seed":"s","params":["sig"]}
 ]}
 ```
 
-Matcher criterion types: method, path, body_fuzzy (requires paths), content_negotiation.
+Actions: redact_headers, redact_body, fake, redact_query, fake_query.
+Matcher criterion types: method, path, body_fuzzy (requires paths), content_negotiation, path_pattern.
 
 ## How it compares
 


### PR DESCRIPTION
Closes #310

## Summary

Three self-contained fixes for the gap between `config.go` implementation and the schema/docs/validation:

**Part 1 — `config.schema.json`**
Added two `oneOf` branches to `rules.items` (lines 99–139 area):
- `redact_query`: `action` const `"redact_query"`, optional `params` array of non-empty strings, `additionalProperties: false`
- `fake_query`: `action` const `"fake_query"`, required non-empty `seed` string, required non-empty `params` array, `additionalProperties: false`
Both branches follow the same structure and `additionalProperties: false` style as the existing three branches.

**Part 2 — `config.go Validate()`**
Added `params` rejection to the three legacy action cases (`redact_headers`, `redact_body`, `fake`), producing the same `"does not use \"params\""` error format as the new actions produce for irrelevant fields. Before this fix, passing `params` to any legacy action was silently accepted.

**Part 3 — Docs**
- `docs/config.md`: action list updated to five actions; `redact_query`/`fake_query` subsections added matching existing subsection format; validation rules section extended; complete example updated
- `docs/api-reference.md`: `RedactQueryParams`/`FakeQueryParams` added to sanitize-funcs table; `DefaultSensitiveQueryParams` added to constants/helpers; `ActionRedactQuery`/`ActionFakeQuery` added to action constants; `Params` field added to `Rule` struct; `Pattern` field added to `CriterionConfig` struct (was missing); `BuildMatcher` signature corrected (was `*CompositeMatcher`, actually `(Matcher, error)`)
- `docs/sanitization.md`: full per-function sections for `RedactQueryParams` and `FakeQueryParams` with fail-closed semantics, userinfo stripping, fragment coverage, byte-stability, and case-sensitivity rationale — all verified against `sanitizer.go` and ADR-48
- `llms.txt` / `llms-full.txt`: all doc additions mirrored

## Test plan

- `go test ./... -race -count=1` green (verified locally)
- `go vet ./...` clean
- New table-driven cases in `TestLoadConfig_ValidationErrors`:
  - `redact_headers rejects stray params field`
  - `redact_body rejects stray params field`
  - `fake rejects stray params field`
- No schema-validation test harness exists in the repo; noted here per task spec — a harness would require a third-party JSON Schema validator (rejected by stdlib-only constraint)
- Existing `TestLoadConfig_RedactQuery_Valid`, `TestLoadConfig_FakeQuery_Valid`, and all validation-error tests continue to pass