### PR TITLE
docs(#309): CLI sanitization is safe-by-default — fix opt-in framing everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ ts := httptest.NewServer(srv)
 Use httptape as a mock backend while building your UI -- no real backend needed.
 
 ```bash
-# Hand-write fixtures or record from a staging API
-httptape record --upstream https://staging-api.example.com \
-    --fixtures ./mocks --config redact.json
+# Record from a staging API (safe-by-default: sensitive headers + query params + userinfo redacted)
+httptape record --upstream https://staging-api.example.com --fixtures ./mocks
 
 # Serve as a mock backend for your frontend
 httptape serve --fixtures ./mocks --port 3001
@@ -71,23 +70,22 @@ Your frontend on `localhost:3000` hits httptape on `localhost:3001`. Edit JSON f
 Record a sample of live traffic, safely redacted:
 
 ```bash
-docker run -v ./fixtures:/fixtures -v ./config.json:/config/config.json \
+docker run -v ./fixtures:/fixtures \
     tibtof/httptape record \
     --upstream https://api.internal:8080 \
-    --fixtures /fixtures --config /config/config.json
+    --fixtures /fixtures
 ```
 
-Sensitive data (secrets, PII) is redacted before it touches disk. Export redacted fixtures for dev/CI use.
+`record` fails closed: sensitive headers, query params, and URL userinfo are redacted automatically before anything touches disk. A warning names exactly what is covered; use `--config` to add body-level rules or customise the pipeline.
 
 ### Fallback proxy
 Use proxy mode for frontend development with automatic fallback to cached responses when the backend is unavailable:
 
 ```bash
-httptape proxy --upstream https://api.example.com \
-    --fixtures ./cache --config redact.json
+httptape proxy --upstream https://api.example.com --fixtures ./cache
 ```
 
-When the upstream is reachable, requests are forwarded and responses are cached in two tiers (L1 in-memory, L2 on disk). When the upstream is down, httptape transparently serves cached responses. See [Proxy Mode](https://httptape.dev/docs/proxy/) for details.
+`proxy` fails closed: the same built-in safe sanitization pipeline is applied to L2 (disk) writes automatically. When the upstream is reachable, requests are forwarded and responses are cached in two tiers (L1 in-memory, L2 on disk). When the upstream is down, httptape transparently serves cached responses. Use `--config` to customise the sanitization pipeline. See [Proxy Mode](https://httptape.dev/docs/proxy/) for details.
 
 ### Recording LLM streaming responses
 Record SSE streams from OpenAI, Anthropic, or any SSE-based API. Each event is stored individually with timing metadata, so replay can simulate the original streaming behavior.
@@ -291,11 +289,14 @@ httptape.ImportBundle(ctx, store, r)
 
 ```bash
 httptape serve   --fixtures ./mocks --port 8081
-httptape record  --upstream https://api.example.com --fixtures ./mocks --config redact.json
-httptape proxy   --upstream https://api.example.com --fixtures ./cache --config redact.json
+httptape record  --upstream https://api.example.com --fixtures ./mocks          # safe-by-default
+httptape record  --upstream https://api.example.com --fixtures ./mocks --config redact.json  # custom rules
+httptape proxy   --upstream https://api.example.com --fixtures ./cache          # safe-by-default
 httptape export  --fixtures ./mocks --output bundle.tar.gz
 httptape import  --fixtures ./mocks --input bundle.tar.gz
 ```
+
+`record` and `proxy` fail closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically. Use `--config` to supply custom rules; use `--unsafe-raw` to disable all sanitization (not recommended).
 
 ## Docker
 
@@ -314,15 +315,18 @@ freely.
 # Replay mode
 docker run -v ./mocks:/fixtures -p 8081:8081 tibtof/httptape serve --fixtures /fixtures
 
-# Record mode (with redaction)
+# Record mode (safe-by-default — no config needed)
+docker run -v ./mocks:/fixtures -p 8081:8081 \
+    tibtof/httptape record --upstream https://api.example.com --fixtures /fixtures
+
+# Record mode (custom rules)
 docker run -v ./mocks:/fixtures -v ./config.json:/config/config.json -p 8081:8081 \
     tibtof/httptape record --upstream https://api.example.com \
     --fixtures /fixtures --config /config/config.json
 
-# Proxy mode (with fallback-to-cache)
-docker run -v ./cache:/fixtures -v ./config.json:/config/config.json -p 8081:8081 \
-    tibtof/httptape proxy --upstream https://api.example.com \
-    --fixtures /fixtures --config /config/config.json
+# Proxy mode (safe-by-default — no config needed)
+docker run -v ./cache:/fixtures -p 8081:8081 \
+    tibtof/httptape proxy --upstream https://api.example.com --fixtures /fixtures
 ```
 
 ## Testcontainers

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,7 +57,8 @@ httptape record --upstream <url> --fixtures <dir> [flags]
 |------|---------|-------------|
 | `--upstream` | (required) | Upstream URL (e.g., `https://api.example.com`) |
 | `--fixtures` | (required) | Path to fixture directory |
-| `--config` | (none) | Path to redaction config JSON |
+| `--config` | (none) | Path to sanitization config JSON. Replaces the built-in safe sanitization; if the config's `rules` list is empty, the safe default is layered in with a warning. Mutually exclusive with `--unsafe-raw`. See [Config](config.md). |
+| `--unsafe-raw` | `false` | Disable all sanitization and record raw traffic. Prints a loud warning. Mutually exclusive with `--config`. Not recommended outside controlled environments. |
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
 | `--tls-cert` | (none) | Path to PEM client certificate for mTLS. See [TLS](tls.md). |
@@ -69,11 +70,24 @@ httptape record --upstream <url> --fixtures <dir> [flags]
 | `--tls-listener-auto` | `false` | Generate a self-signed cert at startup. See [TLS](tls.md). |
 | `--tls-listener-san` | `localhost,127.0.0.1,::1` | Comma-separated SANs for auto-cert (requires `--tls-listener-auto`). |
 
-The recorder starts a reverse proxy on the specified port. All requests are forwarded to the upstream, and responses are recorded (with optional redaction) to the fixtures directory.
+`record` fails closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically and a warning naming what is redacted is printed to stderr. Bodies are NOT redacted by the safe default — use `--config` with `redact_body` or `fake` rules to cover secrets in bodies. Supply `--config` to replace the safe default with custom rules; use `--unsafe-raw` to disable all sanitization (not recommended).
+
+The recorder starts a reverse proxy on the specified port. All requests are forwarded to the upstream and responses are recorded and sanitized to the fixtures directory.
 
 The upstream URL must include the scheme and host (e.g., `https://api.example.com`).
 
-**Example:**
+**Example (safe default — no config needed):**
+
+```bash
+httptape record \
+  --upstream https://api.github.com \
+  --fixtures ./fixtures \
+  --port 8081
+```
+
+Point your application at `http://localhost:8081`. Traffic is recorded with the built-in safe sanitization pipeline applied automatically; a warning lists exactly what is redacted.
+
+**Example (custom rules):**
 
 ```bash
 httptape record \
@@ -83,7 +97,7 @@ httptape record \
   --port 8081
 ```
 
-Then point your application at `http://localhost:8081` instead of the real API. All traffic is recorded and redacted.
+When `--config` is supplied its `rules` replace the safe default pipeline (full control).
 
 ### proxy
 
@@ -97,7 +111,8 @@ httptape proxy --upstream <url> --fixtures <dir> [flags]
 |------|---------|-------------|
 | `--upstream` | (required) | Upstream URL (e.g., `https://api.example.com`) |
 | `--fixtures` | (required) | Path to fixture directory for L2 (persistent) cache |
-| `--config` | (none) | Path to redaction config JSON (applied to L2 writes only) |
+| `--config` | (none) | Path to sanitization config JSON (applied to L2 writes only). Replaces the built-in safe sanitization; if the config's `rules` list is empty, the safe default is layered in with a warning. Mutually exclusive with `--unsafe-raw`. See [Config](config.md). |
+| `--unsafe-raw` | `false` | Disable all sanitization and record raw traffic to L2. Prints a loud warning. Mutually exclusive with `--config`. Not recommended outside controlled environments. |
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
 | `--fallback-on-5xx` | `false` | Also fall back on 5xx responses from upstream |
@@ -110,6 +125,8 @@ httptape proxy --upstream <url> --fixtures <dir> [flags]
 | `--tls-listener-key` | (none) | Path to PEM private key for inbound TLS. See [TLS](tls.md). |
 | `--tls-listener-auto` | `false` | Generate a self-signed cert at startup. See [TLS](tls.md). |
 | `--tls-listener-san` | `localhost,127.0.0.1,::1` | Comma-separated SANs for auto-cert (requires `--tls-listener-auto`). |
+
+`proxy` fails closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically to L2 writes and a warning is printed to stderr. Bodies are NOT redacted by the safe default — use `--config` with `redact_body` or `fake` rules to cover secrets in bodies. Supply `--config` to replace the safe default with custom rules; use `--unsafe-raw` to disable all sanitization (not recommended).
 
 When the upstream is reachable, requests are forwarded and responses are cached:
 
@@ -244,11 +261,10 @@ The `serve`, `record`, and `proxy` commands handle SIGINT and SIGTERM for gracef
 ## Typical workflow
 
 ```bash
-# 1. Record traffic from a real API (with redaction)
+# 1. Record traffic from a real API (safe-by-default sanitization applied automatically)
 httptape record \
   --upstream https://api.example.com \
-  --fixtures ./fixtures \
-  --config redact.json
+  --fixtures ./fixtures
 
 # 2. Export the fixtures
 httptape export --fixtures ./fixtures --output fixtures.tar.gz

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -24,9 +24,19 @@ The `--fixtures` flag inside the container always points to `/fixtures` (the mou
 
 ## Record mode
 
-Proxy and record traffic from an upstream (with redaction):
+The container records safe-by-default: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically and a warning is printed to stderr. Bodies are NOT redacted by the safe default — mount a `--config` to cover secrets in bodies or to customise the pipeline.
 
 ```bash
+# Safe-by-default (no config needed)
+docker run --rm \
+  -v ./fixtures:/fixtures \
+  -p 8081:8081 \
+  ghcr.io/httptape/httptape:latest \
+  record --upstream https://api.example.com \
+         --fixtures /fixtures \
+         --port 8081
+
+# Custom rules (config replaces the safe default)
 docker run --rm \
   -v ./fixtures:/fixtures \
   -v ./redact.json:/config/config.json:ro \
@@ -42,9 +52,20 @@ Note: the fixtures volume is mounted read-write (no `:ro`) so the recorder can w
 
 ## Proxy mode
 
-Forward to upstream with automatic fallback to cached responses:
+The container records safe-by-default: without `--config`, the same built-in safe sanitization pipeline is applied to L2 (disk) writes and a warning is printed to stderr. Supply `--config` to customise the pipeline.
 
 ```bash
+# Safe-by-default (no config needed)
+docker run --rm \
+  -v ./cache:/fixtures \
+  -p 8081:8081 \
+  ghcr.io/httptape/httptape:latest \
+  proxy --upstream https://api.example.com \
+        --fixtures /fixtures \
+        --port 8081 \
+        --cors
+
+# Custom rules (config replaces the safe default)
 docker run --rm \
   -v ./cache:/fixtures \
   -v ./redact.json:/config/config.json:ro \
@@ -57,7 +78,7 @@ docker run --rm \
         --cors
 ```
 
-The `--fixtures` volume stores the L2 (persistent, redacted) cache. The L1 (in-memory) cache is managed internally and is lost when the container stops. Add `--fallback-on-5xx` to also fall back on upstream 5xx responses.
+The `--fixtures` volume stores the L2 (persistent, sanitized) cache. The L1 (in-memory) cache is managed internally and is lost when the container stops. Add `--fallback-on-5xx` to also fall back on upstream 5xx responses.
 
 See [Proxy Mode](proxy.md) for a full guide.
 
@@ -102,6 +123,8 @@ services:
 
 ### Record mode
 
+Safe sanitization is applied automatically without `--config`; mount a config only when you need custom rules.
+
 ```yaml
 services:
   recorder:
@@ -112,15 +135,12 @@ services:
       - https://api.example.com
       - --fixtures
       - /fixtures
-      - --config
-      - /config/config.json
       - --port
       - "8081"
     ports:
       - "8081:8081"
     volumes:
       - ./fixtures:/fixtures
-      - ./redact.json:/config/config.json:ro
 ```
 
 ### Proxy mode (frontend dev with fallback)

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,13 +83,16 @@ func main() {
 Or using the CLI:
 
 ```bash
-# Record from a real API (with redaction)
+# Record from a real API (safe-by-default sanitization applied automatically)
+httptape record --upstream https://api.github.com --fixtures ./mocks
+
+# Record with custom rules (config replaces the safe default)
 httptape record --upstream https://api.github.com --fixtures ./mocks --config redact.json
 
 # Replay as a mock server
 httptape serve --fixtures ./mocks --port 8081
 
-# Proxy with automatic fallback
+# Proxy with automatic fallback (safe-by-default; add --config for custom rules)
 httptape proxy --upstream https://api.github.com --fixtures ./cache
 ```
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -145,12 +145,15 @@ httptape proxy --upstream https://api.example.com \
 |------|---------|-------------|
 | `--upstream` | (required) | Upstream URL (e.g., `https://api.example.com`) |
 | `--fixtures` | (required) | Path to fixture directory for L2 cache |
-| `--config` | (none) | Path to redaction config JSON (applied to L2 writes only) |
+| `--config` | (none) | Path to sanitization config JSON (applied to L2 writes only). Replaces the built-in safe sanitization; if the config's `rules` list is empty, the safe default is layered in with a warning. Mutually exclusive with `--unsafe-raw`. |
+| `--unsafe-raw` | `false` | Disable all sanitization and record raw traffic to L2. Mutually exclusive with `--config`. Not recommended outside controlled environments. |
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
 | `--fallback-on-5xx` | `false` | Also fall back on 5xx responses from upstream |
 
-The L1 cache is always an in-memory store managed internally. The `--fixtures` directory is the L2 (persistent, redacted) cache.
+`proxy` fails closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically to L2 writes and a warning is printed to stderr. Bodies are NOT redacted by the safe default.
+
+The L1 cache is always an in-memory store managed internally. The `--fixtures` directory is the L2 (persistent, sanitized) cache.
 
 ## Docker
 

--- a/docs/sanitization.md
+++ b/docs/sanitization.md
@@ -482,13 +482,16 @@ sanitizer := httptape.NewPipeline(
 
 ## CLI and Docker
 
-Redaction is available in all httptape modes (record, proxy) via a JSON config file:
+The `record` and `proxy` commands fail closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically and a warning naming what is redacted is printed to stderr. The safe default does **not** redact request or response bodies — use `--config` with `redact_body` or `fake` rules to cover secrets in bodies. Supply `--config` to replace the safe default with a custom pipeline; use `--unsafe-raw` to disable all sanitization (not recommended, prints a loud warning).
 
 ```bash
-# Record with redaction
+# Safe-by-default (no config needed — headers + query params + userinfo are redacted)
+httptape record --upstream https://api.example.com --fixtures ./mocks
+
+# Custom rules (config replaces the safe default)
 httptape record --upstream https://api.example.com --fixtures ./mocks --config redact.json
 
-# Proxy with redaction (applied to L2/disk cache only)
+# Proxy with custom rules (applied to L2/disk cache only)
 httptape proxy --upstream https://api.example.com --fixtures ./cache --config redact.json
 ```
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -13,7 +13,7 @@ httptape was extracted from [VibeWarden](https://vibewarden.dev/), where we need
 
 We tried WireMock (Java process, no SSE replay), go-vcr (test-time-only, redaction via user hooks), and a handful of intercept-the-client mocking libraries. None of them treated the safe path as the default. So we built httptape and shipped it as a Go library, a CLI, and a 3 MB Docker image.
 
-The locked decision: **there is no "raw" recording mode**. Sanitization happens on write, deterministically (HMAC-SHA256 for fakes), before any tape touches a store. The safe path is the only path.
+The locked decision: the CLI is **safe-by-default with a loud explicit opt-out**. Sanitization happens on write, deterministically (HMAC-SHA256 for fakes), before any tape touches a store. Running `record` or `proxy` without `--config` applies a built-in safe pipeline automatically; the only way to disable it is `--unsafe-raw`, which prints a prominent warning. The embedded library API leaves sanitization to the embedder (the library's `NewRecorder` default is a no-op pipeline so embedders have full control), but the CLI enforces fail-closed behavior (ADR-49).
 
 ## How it compares to other tools
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1573,13 +1573,16 @@ sanitizer := httptape.NewPipeline(
 
 ## CLI and Docker
 
-Redaction is available in all httptape modes (record, proxy) via a JSON config file:
+The `record` and `proxy` commands fail closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically and a warning naming what is redacted is printed to stderr. The safe default does **not** redact request or response bodies — use `--config` with `redact_body` or `fake` rules to cover secrets in bodies. Supply `--config` to replace the safe default with a custom pipeline; use `--unsafe-raw` to disable all sanitization (not recommended, prints a loud warning).
 
 ```bash
-# Record with redaction
+# Safe-by-default (no config needed — headers + query params + userinfo are redacted)
+httptape record --upstream https://api.example.com --fixtures ./mocks
+
+# Custom rules (config replaces the safe default)
 httptape record --upstream https://api.example.com --fixtures ./mocks --config redact.json
 
-# Proxy with redaction (applied to L2/disk cache only)
+# Proxy with custom rules (applied to L2/disk cache only)
 httptape proxy --upstream https://api.example.com --fixtures ./cache --config redact.json
 ```
 
@@ -1827,7 +1830,6 @@ proxy := httptape.NewProxy(l1, l2,
 ```bash
 httptape proxy --upstream https://api.example.com \
     --fixtures ./cache \
-    --config redact.json \
     --port 8081
 ```
 
@@ -1835,24 +1837,25 @@ httptape proxy --upstream https://api.example.com \
 |------|---------|-------------|
 | `--upstream` | (required) | Upstream URL (e.g., `https://api.example.com`) |
 | `--fixtures` | (required) | Path to fixture directory for L2 cache |
-| `--config` | (none) | Path to redaction config JSON (applied to L2 writes only) |
+| `--config` | (none) | Path to sanitization config JSON (applied to L2 writes only). Replaces the built-in safe sanitization; if the config's `rules` list is empty, the safe default is layered in with a warning. Mutually exclusive with `--unsafe-raw`. |
+| `--unsafe-raw` | `false` | Disable all sanitization and record raw traffic to L2. Mutually exclusive with `--config`. Not recommended outside controlled environments. |
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
 | `--fallback-on-5xx` | `false` | Also fall back on 5xx responses from upstream |
 
-The L1 cache is always an in-memory store managed internally. The `--fixtures` directory is the L2 (persistent, redacted) cache.
+`proxy` fails closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically to L2 writes and a warning is printed to stderr. Bodies are NOT redacted by the safe default.
+
+The L1 cache is always an in-memory store managed internally. The `--fixtures` directory is the L2 (persistent, sanitized) cache.
 
 ## Docker
 
 ```bash
 docker run --rm \
   -v ./cache:/fixtures \
-  -v ./redact.json:/config/config.json:ro \
   -p 8081:8081 \
   ghcr.io/httptape/httptape:latest \
   proxy --upstream https://api.example.com \
         --fixtures /fixtures \
-        --config /config/config.json \
         --port 8081
 ```
 
@@ -1868,8 +1871,6 @@ services:
       - https://api.staging.example.com
       - --fixtures
       - /fixtures
-      - --config
-      - /config/config.json
       - --port
       - "3001"
       - --cors
@@ -1877,7 +1878,6 @@ services:
       - "3001:3001"
     volumes:
       - ./cache:/fixtures
-      - ./redact.json:/config/config.json:ro
 
   frontend:
     build:
@@ -1898,16 +1898,15 @@ A typical frontend development workflow using proxy mode:
 
 1. Start the proxy pointing at your staging/development API
 2. Build your UI -- all requests go through the proxy to the real API
-3. Responses are cached to disk (L2) with secrets redacted
+3. Responses are cached to disk (L2) with secrets redacted automatically (safe default)
 4. If the API goes down (network issue, deployment, VPN disconnect), the proxy serves cached responses
 5. When the API comes back, fresh responses are served and the cache is updated
 
 ```bash
-# Start proxy with redaction
+# Start proxy (safe-by-default sanitization applied automatically)
 httptape proxy \
     --upstream https://staging-api.example.com \
     --fixtures ./api-cache \
-    --config redact.json \
     --port 3001 \
     --cors
 
@@ -4302,7 +4301,7 @@ httptape serve --fixtures ./testdata/fixtures --port 9090 --fallback-status 502
 
 ### record
 
-Proxy requests to an upstream server, record and redact responses.
+Proxy requests to an upstream server, record and sanitize responses.
 
 ```bash
 httptape record --upstream <url> --fixtures <dir> [flags]
@@ -4312,7 +4311,8 @@ httptape record --upstream <url> --fixtures <dir> [flags]
 |------|---------|-------------|
 | `--upstream` | (required) | Upstream URL (e.g., `https://api.example.com`) |
 | `--fixtures` | (required) | Path to fixture directory |
-| `--config` | (none) | Path to redaction config JSON |
+| `--config` | (none) | Path to sanitization config JSON. Replaces the built-in safe sanitization; if the config's `rules` list is empty, the safe default is layered in with a warning. Mutually exclusive with `--unsafe-raw`. See [Config](config.md). |
+| `--unsafe-raw` | `false` | Disable all sanitization and record raw traffic. Prints a loud warning. Mutually exclusive with `--config`. Not recommended outside controlled environments. |
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
 | `--tls-cert` | (none) | Path to PEM client certificate for mTLS. See [TLS](tls.md). |
@@ -4320,11 +4320,24 @@ httptape record --upstream <url> --fixtures <dir> [flags]
 | `--tls-ca` | (none) | Path to PEM CA certificate(s) for upstream verification. See [TLS](tls.md). |
 | `--tls-insecure` | `false` | Skip TLS verification (development only). See [TLS](tls.md). |
 
-The recorder starts a reverse proxy on the specified port. All requests are forwarded to the upstream, and responses are recorded (with optional redaction) to the fixtures directory.
+`record` fails closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically and a warning naming what is redacted is printed to stderr. Bodies are NOT redacted by the safe default — use `--config` with `redact_body` or `fake` rules to cover secrets in bodies. Supply `--config` to replace the safe default with custom rules; use `--unsafe-raw` to disable all sanitization (not recommended).
+
+The recorder starts a reverse proxy on the specified port. All requests are forwarded to the upstream and responses are recorded and sanitized to the fixtures directory.
 
 The upstream URL must include the scheme and host (e.g., `https://api.example.com`).
 
-**Example:**
+**Example (safe default — no config needed):**
+
+```bash
+httptape record \
+  --upstream https://api.github.com \
+  --fixtures ./fixtures \
+  --port 8081
+```
+
+Point your application at `http://localhost:8081`. Traffic is recorded with the built-in safe sanitization pipeline applied automatically; a warning lists exactly what is redacted.
+
+**Example (custom rules):**
 
 ```bash
 httptape record \
@@ -4334,7 +4347,7 @@ httptape record \
   --port 8081
 ```
 
-Then point your application at `http://localhost:8081` instead of the real API. All traffic is recorded and redacted.
+When `--config` is supplied its `rules` replace the safe default pipeline (full control).
 
 ### proxy
 
@@ -4348,7 +4361,8 @@ httptape proxy --upstream <url> --fixtures <dir> [flags]
 |------|---------|-------------|
 | `--upstream` | (required) | Upstream URL (e.g., `https://api.example.com`) |
 | `--fixtures` | (required) | Path to fixture directory for L2 (persistent) cache |
-| `--config` | (none) | Path to redaction config JSON (applied to L2 writes only) |
+| `--config` | (none) | Path to sanitization config JSON (applied to L2 writes only). Replaces the built-in safe sanitization; if the config's `rules` list is empty, the safe default is layered in with a warning. Mutually exclusive with `--unsafe-raw`. See [Config](config.md). |
+| `--unsafe-raw` | `false` | Disable all sanitization and record raw traffic to L2. Prints a loud warning. Mutually exclusive with `--config`. Not recommended outside controlled environments. |
 | `--port` | `8081` | Listen port |
 | `--cors` | `false` | Enable CORS headers |
 | `--fallback-on-5xx` | `false` | Also fall back on 5xx responses from upstream |
@@ -4358,20 +4372,21 @@ httptape proxy --upstream <url> --fixtures <dir> [flags]
 | `--tls-ca` | (none) | Path to PEM CA certificate(s) for upstream verification. See [TLS](tls.md). |
 | `--tls-insecure` | `false` | Skip TLS verification (development only). See [TLS](tls.md). |
 
+`proxy` fails closed: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically to L2 writes and a warning is printed to stderr. Bodies are NOT redacted by the safe default — use `--config` with `redact_body` or `fake` rules to cover secrets in bodies. Supply `--config` to replace the safe default with custom rules; use `--unsafe-raw` to disable all sanitization (not recommended).
+
 When the upstream is reachable, requests are forwarded and responses are cached:
 
 - **L1 (memory):** raw, unsanitized responses for best within-session fidelity
-- **L2 (disk):** redacted responses that persist across restarts
+- **L2 (disk):** sanitized responses that persist across restarts
 
 When the upstream is unreachable (or returns 5xx with `--fallback-on-5xx`), the proxy serves cached responses. The `X-Httptape-Source` header indicates whether a response came from `l1-cache`, `l2-cache`, or the real upstream (header absent).
 
-**Example:**
+**Example (safe default — no config needed):**
 
 ```bash
 httptape proxy \
   --upstream https://api.staging.example.com \
   --fixtures ./cache \
-  --config redact.json \
   --port 3001 \
   --cors \
   --fallback-on-5xx
@@ -4491,11 +4506,10 @@ The `serve`, `record`, and `proxy` commands handle SIGINT and SIGTERM for gracef
 ## Typical workflow
 
 ```bash
-# 1. Record traffic from a real API (with redaction)
+# 1. Record traffic from a real API (safe-by-default sanitization applied automatically)
 httptape record \
   --upstream https://api.example.com \
-  --fixtures ./fixtures \
-  --config redact.json
+  --fixtures ./fixtures
 
 # 2. Export the fixtures
 httptape export --fixtures ./fixtures --output fixtures.tar.gz
@@ -4539,9 +4553,19 @@ The `--fixtures` flag inside the container always points to `/fixtures` (the mou
 
 ## Record mode
 
-Proxy and record traffic from an upstream (with redaction):
+The container records safe-by-default: without `--config`, a built-in safe sanitization pipeline (default sensitive headers, query params, and URL userinfo) is applied automatically and a warning is printed to stderr. Bodies are NOT redacted by the safe default — mount a `--config` to cover secrets in bodies or to customise the pipeline.
 
 ```bash
+# Safe-by-default (no config needed)
+docker run --rm \
+  -v ./fixtures:/fixtures \
+  -p 8081:8081 \
+  ghcr.io/httptape/httptape:latest \
+  record --upstream https://api.example.com \
+         --fixtures /fixtures \
+         --port 8081
+
+# Custom rules (config replaces the safe default)
 docker run --rm \
   -v ./fixtures:/fixtures \
   -v ./redact.json:/config/config.json:ro \
@@ -4557,9 +4581,20 @@ Note: the fixtures volume is mounted read-write (no `:ro`) so the recorder can w
 
 ## Proxy mode
 
-Forward to upstream with automatic fallback to cached responses:
+The container records safe-by-default: without `--config`, the same built-in safe sanitization pipeline is applied to L2 (disk) writes and a warning is printed to stderr. Supply `--config` to customise the pipeline.
 
 ```bash
+# Safe-by-default (no config needed)
+docker run --rm \
+  -v ./cache:/fixtures \
+  -p 8081:8081 \
+  ghcr.io/httptape/httptape:latest \
+  proxy --upstream https://api.example.com \
+        --fixtures /fixtures \
+        --port 8081 \
+        --cors
+
+# Custom rules (config replaces the safe default)
 docker run --rm \
   -v ./cache:/fixtures \
   -v ./redact.json:/config/config.json:ro \
@@ -4572,7 +4607,7 @@ docker run --rm \
         --cors
 ```
 
-The `--fixtures` volume stores the L2 (persistent, redacted) cache. The L1 (in-memory) cache is managed internally and is lost when the container stops. Add `--fallback-on-5xx` to also fall back on upstream 5xx responses.
+The `--fixtures` volume stores the L2 (persistent, sanitized) cache. The L1 (in-memory) cache is managed internally and is lost when the container stops. Add `--fallback-on-5xx` to also fall back on upstream 5xx responses.
 
 See [Proxy Mode](proxy.md) for a full guide.
 
@@ -4617,6 +4652,8 @@ services:
 
 ### Record mode
 
+Safe sanitization is applied automatically without `--config`; mount a config only when you need custom rules.
+
 ```yaml
 services:
   recorder:
@@ -4627,15 +4664,12 @@ services:
       - https://api.example.com
       - --fixtures
       - /fixtures
-      - --config
-      - /config/config.json
       - --port
       - "8081"
     ports:
       - "8081:8081"
     volumes:
       - ./fixtures:/fixtures
-      - ./redact.json:/config/config.json:ro
 ```
 
 ### Proxy mode (frontend dev with fallback)
@@ -4650,8 +4684,6 @@ services:
       - https://api.staging.example.com
       - --fixtures
       - /fixtures
-      - --config
-      - /config/config.json
       - --port
       - "3001"
       - --cors
@@ -4659,7 +4691,6 @@ services:
       - "3001:3001"
     volumes:
       - ./cache:/fixtures
-      - ./redact.json:/config/config.json:ro
 
   frontend:
     build:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -185,12 +185,17 @@ defer srv.Close()
 
 ```
 httptape serve             --fixtures <dir> [--port 8081] [--cors] [--delay 200ms] [--config config.json]
-httptape record            --upstream <url> --fixtures <dir> [--config redact.json]
-httptape proxy             --upstream <url> --fixtures <dir> [--config redact.json] [--fallback-on-5xx]
+httptape record            --upstream <url> --fixtures <dir> [--config redact.json] [--unsafe-raw]
+httptape proxy             --upstream <url> --fixtures <dir> [--config redact.json] [--unsafe-raw] [--fallback-on-5xx]
 httptape export            --fixtures <dir> [--output file.tar.gz] [--routes r1,r2]
 httptape import            --fixtures <dir> [--input file.tar.gz]
 httptape migrate-fixtures  [--recursive] <dir>
 ```
+
+record/proxy fail closed: without --config a built-in safe sanitization pipeline (sensitive
+headers + query params + URL userinfo) is applied automatically; bodies are NOT covered.
+--config replaces the safe default (if config rules are empty, safe default is layered in).
+--unsafe-raw disables all sanitization; mutually exclusive with --config.
 
 migrate-fixtures: converts v0.11 fixtures (base64 bodies, body_encoding field)
 to v0.12 format (Content-Type-driven body shape). Idempotent. Skips non-tape files.
@@ -340,13 +345,16 @@ func main() {
 Or using the CLI:
 
 ```bash
-# Record from a real API (with redaction)
+# Record from a real API (safe-by-default sanitization applied automatically)
+httptape record --upstream https://api.github.com --fixtures ./mocks
+
+# Record with custom rules (config replaces the safe default)
 httptape record --upstream https://api.github.com --fixtures ./mocks --config redact.json
 
 # Replay as a mock server
 httptape serve --fixtures ./mocks --port 8081
 
-# Proxy with automatic fallback
+# Proxy with automatic fallback (safe-by-default; add --config for custom rules)
 httptape proxy --upstream https://api.github.com --fixtures ./cache
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -167,12 +167,17 @@ defer srv.Close()
 
 ```
 httptape serve             --fixtures <dir> [--port 8081] [--cors] [--delay 200ms] [--config config.json]
-httptape record            --upstream <url> --fixtures <dir> [--config redact.json]
-httptape proxy             --upstream <url> --fixtures <dir> [--config redact.json] [--fallback-on-5xx]
+httptape record            --upstream <url> --fixtures <dir> [--config redact.json] [--unsafe-raw]
+httptape proxy             --upstream <url> --fixtures <dir> [--config redact.json] [--unsafe-raw] [--fallback-on-5xx]
 httptape export            --fixtures <dir> [--output file.tar.gz] [--routes r1,r2]
 httptape import            --fixtures <dir> [--input file.tar.gz]
 httptape migrate-fixtures  [--recursive] <dir>
 ```
+
+record/proxy fail closed: without --config a built-in safe sanitization pipeline (sensitive
+headers + query params + URL userinfo) is applied automatically; bodies are NOT covered.
+--config replaces the safe default (if config rules are empty, safe default is layered in).
+--unsafe-raw disables all sanitization; mutually exclusive with --config.
 
 migrate-fixtures: converts v0.11 fixtures (base64 bodies, body_encoding field)
 to v0.12 format (Content-Type-driven body shape). Idempotent. Skips non-tape files.


### PR DESCRIPTION
Closes #309

## Summary

- `docs/cli.md` — `record` and `proxy` flag tables each gain an `--unsafe-raw` row; `--config` description updated to "replaces the built-in safe sanitization (if its rules list is empty, the safe default is layered in)"; removed "(with optional redaction)" framing; example updated to show safe-default invocation first
- `docs/proxy.md` — CLI flag table updated with `--unsafe-raw` row, `--config` description corrected, and fail-closed paragraph added
- `docs/docker.md` — record and proxy mode sections updated to show safe-by-default (no config needed) as the primary example, with a custom-rules variant; Docker Compose record example simplified to no-config form; "redacted" → "sanitized" in L2 description
- `docs/sanitization.md` — "CLI and Docker" section rewritten: redaction is on by default, `--config` customises, body non-coverage of the safe default disclosed, `--unsafe-raw` named
- `llms.txt` + `llms-full.txt` — CLI synopses show `[--unsafe-raw]` on `record`/`proxy`; prose note added explaining fail-closed default, body non-coverage, and `--unsafe-raw` semantics; Getting Started CLI example updated
- `README.md` — frontend-first, production-capture, fallback-proxy, CLI synopsis, and Docker sections all updated: safe-by-default stated, `--config` framed as customisation not prerequisite, `--unsafe-raw` mentioned in CLI block
- `docs/why.md` — "there is no raw recording mode" reframed as "safe-by-default with a loud explicit opt-out (`--unsafe-raw`); the embedded library API leaves sanitization to the embedder (ADR-49)"

No Go code changes. `go vet ./...` and `go test ./... -race -count=1` pass unchanged.

## Test plan

- [ ] Read each modified file and verify the claim "config-less run records raw" is gone
- [ ] Verify `--unsafe-raw` appears in both flag tables (`docs/cli.md` record + proxy, `docs/proxy.md`)
- [ ] Verify body non-coverage disclosure appears in `docs/cli.md`, `docs/proxy.md`, and `docs/sanitization.md`
- [ ] Verify `go test ./... -race -count=1` still green (no Go changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)