### PR TITLE
fix(#303): non-UTF-8 text bodies survive persist byte-identically

### DIFF
--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/httptape/httptape"
 )
@@ -1103,9 +1104,22 @@ func fixLegacyEndpoint(raw json.RawMessage, encoding string) json.RawMessage {
 			fields["body"] = json.RawMessage(reEncoded)
 		}
 	} else if parseErr == nil && httptape.IsText(mt) {
-		// Text: write as JSON string.
-		encoded, _ := json.Marshal(string(decoded))
-		fields["body"] = json.RawMessage(encoded)
+		if utf8.Valid(decoded) {
+			// Valid UTF-8 text: inline as a plain JSON string (v0.12+ format).
+			encoded, _ := json.Marshal(string(decoded))
+			fields["body"] = json.RawMessage(encoded)
+		} else {
+			// Non-UTF-8 text (Latin-1, Shift-JIS, etc.): encoding/json replaces
+			// invalid UTF-8 with U+FFFD, so we cannot inline these bytes as a plain
+			// JSON string without corruption. Keep the body as the base64 JSON string
+			// (bodyRaw is already the correct value) and re-add the body_encoding
+			// marker so the ADR-50 round-trip stays byte-identical. This also makes
+			// the migration tool idempotent: re-migrating a v0.13 non-UTF-8 fixture
+			// is a no-op.
+			fields["body"] = bodyRaw
+			markerVal, _ := json.Marshal("base64")
+			fields["body_encoding"] = json.RawMessage(markerVal)
+		}
 	} else {
 		// Binary or unknown: keep as base64 string (the new format's convention).
 		// Already a base64 string, so leave bodyRaw as-is.

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -886,6 +886,157 @@ func TestMigrateFixtures_AlreadyMigratedTape(t *testing.T) {
 	}
 }
 
+// TestMigrateFixtures_NonUTF8TextBody covers the three migration scenarios
+// introduced by ADR-50 (body_encoding:"base64" marker for non-UTF-8 text bodies):
+//
+//  1. A v0.11 legacy fixture whose decoded text body is non-UTF-8 (Latin-1, etc.)
+//     must be migrated to the ADR-50 format: base64 body + body_encoding:"base64".
+//  2. A v0.11 legacy fixture whose decoded text body is valid UTF-8 must still be
+//     inlined as a plain JSON string with no marker (existing behavior).
+//  3. A v0.13 fixture that already carries the body_encoding:"base64" marker for a
+//     non-UTF-8 text body must be a byte-identical no-op after migration
+//     (idempotency guarantee).
+func TestMigrateFixtures_NonUTF8TextBody(t *testing.T) {
+	// "café au lait" in ISO-8859-1: 0xe9 is the Latin-1 code point for é.
+	// base64.StdEncoding.EncodeToString([]byte("caf\xe9 au lait")) == "Y2Fm6SBhdSBsYWl0"
+	const latin1B64 = "Y2Fm6SBhdSBsYWl0"
+
+	// "hello" in plain ASCII — valid UTF-8.
+	// base64.StdEncoding.EncodeToString([]byte("hello")) == "aGVsbG8="
+	const asciiB64 = "aGVsbG8="
+
+	tests := []struct {
+		name         string
+		fixture      string
+		wantB64Body  bool   // true → body field must remain a base64 string
+		wantMarker   bool   // true → body_encoding:"base64" must be present
+		wantBodyText string // if non-empty, the body field must contain this substring
+	}{
+		{
+			name: "v0.11 legacy fixture with non-UTF-8 text body keeps base64 and gets ADR-50 marker",
+			fixture: `{
+  "id": "non-utf8-001",
+  "route": "api",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "request": {
+    "method": "POST",
+    "url": "http://example.com/api",
+    "headers": {"Content-Type": ["text/plain; charset=iso-8859-1"]},
+    "body": "` + latin1B64 + `",
+    "body_hash": "",
+    "body_encoding": "base64"
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {"Content-Type": ["application/json"]},
+    "body": {"ok": true}
+  }
+}`,
+			wantB64Body:  true,
+			wantMarker:   true,
+			wantBodyText: latin1B64,
+		},
+		{
+			name: "v0.11 legacy fixture with valid UTF-8 text body is inlined as plain string",
+			fixture: `{
+  "id": "utf8-001",
+  "route": "api",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "request": {
+    "method": "POST",
+    "url": "http://example.com/api",
+    "headers": {"Content-Type": ["text/plain"]},
+    "body": "` + asciiB64 + `",
+    "body_hash": "",
+    "body_encoding": "base64"
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {"Content-Type": ["application/json"]},
+    "body": {"ok": true}
+  }
+}`,
+			wantB64Body:  false,
+			wantMarker:   false,
+			wantBodyText: `"hello"`,
+		},
+		{
+			name: "v0.13 fixture with body_encoding:base64 marker is idempotent no-op",
+			fixture: `{
+  "id": "non-utf8-v13-001",
+  "route": "api",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "request": {
+    "method": "POST",
+    "url": "http://example.com/api",
+    "headers": {"Content-Type": ["text/plain; charset=iso-8859-1"]},
+    "body": "` + latin1B64 + `",
+    "body_encoding": "base64",
+    "body_hash": ""
+  },
+  "response": {
+    "status_code": 200,
+    "headers": {"Content-Type": ["application/json"]},
+    "body": {"ok": true}
+  }
+}`,
+			wantB64Body:  true,
+			wantMarker:   true,
+			wantBodyText: latin1B64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "tape.json")
+			if err := os.WriteFile(path, []byte(tt.fixture), 0644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+
+			got := run([]string{"migrate-fixtures", dir})
+			if got != exitOK {
+				t.Fatalf("migrate-fixtures exit = %d, want %d", got, exitOK)
+			}
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read migrated fixture: %v", err)
+			}
+			s := string(data)
+
+			hasMarker := strings.Contains(s, `"body_encoding": "base64"`) ||
+				strings.Contains(s, `"body_encoding":"base64"`)
+
+			if tt.wantMarker && !hasMarker {
+				t.Errorf("expected body_encoding:base64 in output, got:\n%s", s)
+			}
+			if !tt.wantMarker && hasMarker {
+				t.Errorf("unexpected body_encoding field in output, got:\n%s", s)
+			}
+
+			if tt.wantBodyText != "" && !strings.Contains(s, tt.wantBodyText) {
+				t.Errorf("expected body to contain %q in output, got:\n%s", tt.wantBodyText, s)
+			}
+
+			// For the idempotency case: migrate again and assert byte-identical output.
+			if tt.wantMarker {
+				got2 := run([]string{"migrate-fixtures", dir})
+				if got2 != exitOK {
+					t.Fatalf("second migrate-fixtures exit = %d, want %d", got2, exitOK)
+				}
+				data2, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read after second migration: %v", err)
+				}
+				if string(data2) != string(data) {
+					t.Errorf("migration is not idempotent:\n  first:  %s\n  second: %s", data, data2)
+				}
+			}
+		})
+	}
+}
+
 func TestServeWithSynthesize(t *testing.T) {
 	// --synthesize flag should be accepted without error.
 	got := run([]string{"serve", "--fixtures", t.TempDir(), "--synthesize", "-h"})

--- a/decisions.md
+++ b/decisions.md
@@ -7800,6 +7800,49 @@ The --config/--unsafe-raw mutual-exclusion check is moved before NewFileStore (M
 and BuildTLSConfig (PEM reads) in both runRecord and runProxy, honoring this ADR's
 "error path must not touch disk" statement literally (previously it ran after those).
 
+### ADR-50: base64 fallback + `body_encoding` marker for non-UTF-8 text bodies
+
+**Date**: 2026-08-05
+**Issue**: #303
+**Status**: Accepted
+
+#### Context
+
+`marshalBody` emitted text-Content-Type bodies as `string(body)`. `encoding/json`
+replaces invalid UTF-8 with U+FFFD, so non-UTF-8 text bodies (Latin-1, Shift-JIS, …)
+were silently corrupted on persist and the stored `body_hash` no longer matched the
+stored body; replay/diff/export propagated the corruption. ADR-41 had removed the
+`body_encoding` field, assuming Content-Type alone determines body shape — which holds
+only for valid UTF-8 text.
+
+#### Decision
+
+Gate the text path on `utf8.Valid`. Valid UTF-8 text → JSON string (unchanged).
+Non-UTF-8 text → base64 string plus a `"body_encoding": "base64"` marker.
+
+The text unmarshal path takes the string verbatim, so a base64 fallback there is
+undetectable from Content-Type alone. Try-base64-first is rejected: any legitimate text
+body that is valid base64 would be silently misdecoded — a worse bug than the original.
+The marker disambiguates authoritatively: base64-decode on load iff the marker is present.
+
+Scope is minimal: the marker is emitted (`omitempty`) only for the non-UTF-8 text case.
+JSON, valid-UTF-8 text, binary, and nil bodies are byte-identical to before, so no existing
+fixture changes on disk. On unmarshal the marker is honored only for JSON-string bodies and
+takes priority over Content-Type; object/array/null tokens ignore it (legacy `identity`
+stays ignored). Reusing the value `"base64"` is compatible with, and quietly repairs, any
+v0.11 fixtures that carried it. A marker asserting base64 over un-decodable data is a hard
+error (fail closed).
+
+#### Consequences
+
+- Non-UTF-8 text bodies round-trip byte-identically; `body_hash` stays consistent.
+- The fixture format gains one narrowly-scoped, self-describing field; documented in
+  `docs/fixtures-authoring.md`.
+- Not fixed here: a JSON-CT body that is a scalar JSON string whose contents are valid
+  base64 (e.g. `"body": "aGVsbG8="` under `application/json`) can still be misdecoded by
+  the pre-existing json-fallback path. It is orthogonal to #303 (marshal never flags it as
+  base64) and tracked separately if it surfaces.
+
 ---
 
 ## PM Log

--- a/docs/fixtures-authoring.md
+++ b/docs/fixtures-authoring.md
@@ -59,23 +59,44 @@ Every fixture file is a single JSON object with these fields:
 
 The `body` field's JSON representation depends on the `Content-Type` header:
 
-| Content-Type | Body shape | Example |
-|---|---|---|
-| `application/json`, `+json` suffix | Native JSON object/array | `{"name": "Alice"}` |
-| `text/*`, `application/xml`, `application/javascript` | JSON string | `"Hello, world!"` |
-| Binary (`image/*`, `application/octet-stream`, etc.) | Base64-encoded string | `"aGVsbG8="` |
-| Missing or unknown | Base64-encoded string | `"aGVsbG8="` |
-| Nil or empty body | `null` | `null` |
+| Content-Type | Body bytes | Body shape | `body_encoding` field |
+|---|---|---|---|
+| `application/json`, `+json` suffix | Valid JSON | Native JSON object/array | absent |
+| `application/json`, `+json` suffix | Invalid JSON | Base64-encoded string | absent |
+| `text/*`, `application/xml`, `application/javascript` | Valid UTF-8 | JSON string | absent |
+| `text/*`, `application/xml`, `application/javascript` | Non-UTF-8 (Latin-1, Shift-JIS, …) | Base64-encoded string | `"base64"` |
+| Binary (`image/*`, `application/octet-stream`, etc.) | Any | Base64-encoded string | absent |
+| Missing or unknown | Any | Base64-encoded string | absent |
+| Nil or empty body | — | `null` | absent |
 
-This means JSON fixtures are human-readable: response bodies appear as native JSON objects, not opaque base64 strings.
+This means JSON fixtures are human-readable: response bodies appear as native JSON objects, not opaque base64 strings. UTF-8 text bodies appear as plain JSON strings.
 
-**Migrating from v0.11:** Fixtures created with v0.11 used base64 encoding for all bodies and included a `body_encoding` field. Use the migration tool to convert:
+#### The `body_encoding` field
+
+The `body_encoding` field is present only for non-UTF-8 text bodies (e.g., Latin-1, Shift-JIS, Windows-1252). When the field value is `"base64"`, unmarshal base64-decodes the `body` string regardless of the `Content-Type`. This marker disambiguates the non-UTF-8 text fallback from a legitimate UTF-8 text body that happens to look like a base64 string.
+
+Hand-authored fixtures for UTF-8 text do not need this field. Omit `body_encoding` and write the body as a plain JSON string:
+
+```json
+"body": "Hello, world!"
+```
+
+For non-UTF-8 text that you need to fixture by hand, base64-encode the raw bytes and add the marker:
+
+```json
+"body": "Y2Fm6SBhdSBsYWl0",
+"body_encoding": "base64"
+```
+
+Any value other than `"base64"` (including the legacy `"identity"` from v0.11) is ignored for JSON-string bodies.
+
+**Migrating from v0.11:** Fixtures created with v0.11 used base64 encoding for all bodies and included a `body_encoding: "identity"` field. Use the migration tool to convert:
 
 ```bash
 httptape migrate-fixtures --recursive ./fixtures
 ```
 
-The migration tool reads each `.json` file, decodes any base64 bodies, removes the `body_encoding` field, and writes the fixture in the new Content-Type-aware format. It is safe to run multiple times (idempotent).
+The migration tool reads each `.json` file, decodes any base64 bodies, removes the legacy `body_encoding` field, and writes the fixture in the new Content-Type-aware format. It is safe to run multiple times (idempotent). Note: the `body_encoding: "base64"` value introduced in v0.13+ is meaningful and is preserved by the migration tool.
 
 ### URL format and matching
 

--- a/tape.go
+++ b/tape.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Tape represents a single recorded HTTP interaction (request + response pair).
@@ -52,7 +54,10 @@ type Tape struct {
 // The Body field is always stored as []byte in Go. When marshaled to JSON,
 // the body representation depends on the Content-Type header:
 //   - JSON Content-Type (application/json, +json suffix): native JSON object/array
-//   - Text Content-Type (text/*, application/xml, etc.): JSON string
+//   - Text Content-Type (text/*, application/xml, etc.) with valid UTF-8: JSON string
+//   - Text Content-Type with non-UTF-8 bytes: base64-encoded JSON string; the
+//     companion field "body_encoding":"base64" (omitempty) marks this case so that
+//     unmarshal can distinguish it from a legitimate text body that is valid base64.
 //   - Binary or missing Content-Type: base64-encoded JSON string
 //   - Nil or empty body: JSON null
 type RecordedReq struct {
@@ -96,8 +101,9 @@ type RecordedReq struct {
 //
 // The Body field is always stored as []byte in Go. When marshaled to JSON,
 // the body representation depends on the Content-Type header (same rules as
-// RecordedReq). For SSE (text/event-stream) responses, the discrete events
-// are stored in SSEEvents and Body is nil.
+// RecordedReq, including the "body_encoding":"base64" marker for non-UTF-8 text).
+// For SSE (text/event-stream) responses, the discrete events are stored in
+// SSEEvents and Body is nil.
 //
 // During replay, if SSEEvents is non-nil and non-empty the tape is treated
 // as an SSE tape and Body is ignored (even if present).
@@ -144,7 +150,9 @@ func (r RecordedResp) IsSSE() bool {
 // MarshalJSON implements json.Marshaler for RecordedReq.
 // The body field's JSON representation depends on the Content-Type from Headers:
 //   - JSON Content-Type: native JSON value (object/array/primitive)
-//   - Text Content-Type: JSON string (UTF-8)
+//   - Text Content-Type with valid UTF-8: JSON string
+//   - Text Content-Type with non-UTF-8 bytes: base64-encoded JSON string; the
+//     "body_encoding" field is set to "base64" to mark this case for unmarshal.
 //   - Binary or missing Content-Type: base64-encoded JSON string
 //   - Nil or empty body: JSON null
 func (r RecordedReq) MarshalJSON() ([]byte, error) {
@@ -154,30 +162,34 @@ func (r RecordedReq) MarshalJSON() ([]byte, error) {
 		URLPattern       string      `json:"url_pattern,omitempty"`
 		Headers          http.Header `json:"headers"`
 		Body             any         `json:"body"`
+		BodyEncoding     string      `json:"body_encoding,omitempty"`
 		BodyHash         string      `json:"body_hash"`
 		Truncated        bool        `json:"truncated,omitempty"`
 		OriginalBodySize int64       `json:"original_body_size,omitempty"`
 	}
 
+	bodyVal, bodyEnc := marshalBody(r.Body, r.Headers)
 	a := alias{
 		Method:           r.Method,
 		URL:              r.URL,
 		URLPattern:       r.URLPattern,
 		Headers:          r.Headers,
-		Body:             nil, // default: null
+		Body:             bodyVal,
+		BodyEncoding:     bodyEnc,
 		BodyHash:         r.BodyHash,
 		Truncated:        r.Truncated,
 		OriginalBodySize: r.OriginalBodySize,
 	}
 
-	a.Body = marshalBody(r.Body, r.Headers)
 	return json.Marshal(a)
 }
 
 // UnmarshalJSON implements json.Unmarshaler for RecordedReq.
 // It detects the JSON token type of the body field and decodes accordingly:
 //   - JSON object/array: body stored as compact JSON bytes
-//   - JSON string: text or base64 based on Content-Type
+//   - JSON string with body_encoding=="base64": base64-decoded bytes
+//   - JSON string (text Content-Type, no marker): verbatim UTF-8 bytes
+//   - JSON string (binary/unknown Content-Type): base64-decoded bytes
 //   - JSON null: body is nil
 func (r *RecordedReq) UnmarshalJSON(data []byte) error {
 	type alias struct {
@@ -186,6 +198,7 @@ func (r *RecordedReq) UnmarshalJSON(data []byte) error {
 		URLPattern       string          `json:"url_pattern,omitempty"`
 		Headers          http.Header     `json:"headers"`
 		Body             json.RawMessage `json:"body"`
+		BodyEncoding     string          `json:"body_encoding"`
 		BodyHash         string          `json:"body_hash"`
 		Truncated        bool            `json:"truncated,omitempty"`
 		OriginalBodySize int64           `json:"original_body_size,omitempty"`
@@ -204,7 +217,7 @@ func (r *RecordedReq) UnmarshalJSON(data []byte) error {
 	r.Truncated = a.Truncated
 	r.OriginalBodySize = a.OriginalBodySize
 
-	body, err := unmarshalBody(a.Body, a.Headers)
+	body, err := unmarshalBody(a.Body, a.Headers, a.BodyEncoding)
 	if err != nil {
 		return fmt.Errorf("unmarshal RecordedReq body: %w", err)
 	}
@@ -214,40 +227,45 @@ func (r *RecordedReq) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements json.Marshaler for RecordedResp.
 // The body field's JSON representation depends on the Content-Type from Headers
-// (same rules as RecordedReq.MarshalJSON).
+// (same rules as RecordedReq.MarshalJSON, including the "body_encoding":"base64"
+// marker for non-UTF-8 text bodies).
 func (r RecordedResp) MarshalJSON() ([]byte, error) {
 	type alias struct {
 		StatusCode       int         `json:"status_code"`
 		Headers          http.Header `json:"headers"`
 		Body             any         `json:"body"`
+		BodyEncoding     string      `json:"body_encoding,omitempty"`
 		Truncated        bool        `json:"truncated,omitempty"`
 		OriginalBodySize int64       `json:"original_body_size,omitempty"`
 		SSEEvents        []SSEEvent  `json:"sse_events,omitempty"`
 		ElapsedMS        int64       `json:"elapsed_ms,omitempty"`
 	}
 
+	bodyVal, bodyEnc := marshalBody(r.Body, r.Headers)
 	a := alias{
 		StatusCode:       r.StatusCode,
 		Headers:          r.Headers,
-		Body:             nil,
+		Body:             bodyVal,
+		BodyEncoding:     bodyEnc,
 		Truncated:        r.Truncated,
 		OriginalBodySize: r.OriginalBodySize,
 		SSEEvents:        r.SSEEvents,
 		ElapsedMS:        r.ElapsedMS,
 	}
 
-	a.Body = marshalBody(r.Body, r.Headers)
 	return json.Marshal(a)
 }
 
 // UnmarshalJSON implements json.Unmarshaler for RecordedResp.
 // It detects the JSON token type of the body field and decodes accordingly
-// (same rules as RecordedReq.UnmarshalJSON).
+// (same rules as RecordedReq.UnmarshalJSON, including the "body_encoding":"base64"
+// marker for non-UTF-8 text bodies).
 func (r *RecordedResp) UnmarshalJSON(data []byte) error {
 	type alias struct {
 		StatusCode       int             `json:"status_code"`
 		Headers          http.Header     `json:"headers"`
 		Body             json.RawMessage `json:"body"`
+		BodyEncoding     string          `json:"body_encoding"`
 		Truncated        bool            `json:"truncated,omitempty"`
 		OriginalBodySize int64           `json:"original_body_size,omitempty"`
 		SSEEvents        []SSEEvent      `json:"sse_events,omitempty"`
@@ -266,7 +284,7 @@ func (r *RecordedResp) UnmarshalJSON(data []byte) error {
 	r.SSEEvents = a.SSEEvents
 	r.ElapsedMS = a.ElapsedMS
 
-	body, err := unmarshalBody(a.Body, a.Headers)
+	body, err := unmarshalBody(a.Body, a.Headers, a.BodyEncoding)
 	if err != nil {
 		return fmt.Errorf("unmarshal RecordedResp body: %w", err)
 	}
@@ -275,10 +293,20 @@ func (r *RecordedResp) UnmarshalJSON(data []byte) error {
 }
 
 // marshalBody returns the appropriate JSON value for the body field based on
-// the Content-Type from headers. Returns nil for nil/empty bodies.
-func marshalBody(body []byte, headers http.Header) any {
+// the Content-Type from headers, and the body_encoding marker string (non-empty
+// only for the non-UTF-8 text fallback case).
+//
+// Encoding rules:
+//   - nil/empty body → (nil, "")
+//   - JSON Content-Type, valid JSON → (json.RawMessage, "")
+//   - JSON Content-Type, invalid JSON → (base64 string, "")
+//   - Text Content-Type, valid UTF-8 → (string, "")
+//   - Text Content-Type, non-UTF-8 bytes → (base64 string, "base64")
+//   - Binary/unknown Content-Type → (base64 string, "")
+//   - Missing/unparseable Content-Type → (base64 string, "")
+func marshalBody(body []byte, headers http.Header) (any, string) {
 	if len(body) == 0 {
-		return nil
+		return nil, ""
 	}
 
 	ct := ""
@@ -288,30 +316,45 @@ func marshalBody(body []byte, headers http.Header) any {
 
 	mt, err := ParseMediaType(ct)
 	if err != nil || ct == "" {
-		// Unknown/missing CT: base64
-		return base64.StdEncoding.EncodeToString(body)
+		// Unknown/missing CT: base64, no marker.
+		return base64.StdEncoding.EncodeToString(body), ""
 	}
 
 	if IsJSON(mt) {
 		// Verify the body is valid JSON before emitting as native.
 		if json.Valid(body) {
-			return json.RawMessage(body)
+			return json.RawMessage(body), ""
 		}
-		// Invalid JSON despite JSON CT: fall back to base64.
-		return base64.StdEncoding.EncodeToString(body)
+		// Invalid JSON despite JSON CT: fall back to base64, no marker.
+		return base64.StdEncoding.EncodeToString(body), ""
 	}
 
 	if IsText(mt) {
-		return string(body)
+		if utf8.Valid(body) {
+			// Valid UTF-8 text: emit as a JSON string, no marker.
+			return string(body), ""
+		}
+		// Non-UTF-8 text (Latin-1, Shift-JIS, etc.): emit as base64 and set
+		// the body_encoding marker so unmarshal can distinguish this from a
+		// legitimate text body that happens to look like base64.
+		return base64.StdEncoding.EncodeToString(body), "base64"
 	}
 
-	// Binary: base64
-	return base64.StdEncoding.EncodeToString(body)
+	// Binary: base64, no marker.
+	return base64.StdEncoding.EncodeToString(body), ""
 }
 
-// unmarshalBody decodes the body JSON value based on its token type and the
-// Content-Type from headers. Returns nil for JSON null or missing body.
-func unmarshalBody(raw json.RawMessage, headers http.Header) ([]byte, error) {
+// unmarshalBody decodes the body JSON value based on its token type, the
+// Content-Type from headers, and an optional body_encoding marker.
+//
+// When encoding is "base64" (case-insensitive), JSON-string bodies are
+// base64-decoded unconditionally and authoritatively — Content-Type is not
+// consulted. A malformed base64 value under a "base64" marker is a hard error
+// (fail closed). All other encoding values (empty, "identity", or any unknown
+// string) are ignored for non-object/array tokens.
+//
+// Returns nil for JSON null or a missing body.
+func unmarshalBody(raw json.RawMessage, headers http.Header, encoding string) ([]byte, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil, nil
 	}
@@ -332,10 +375,23 @@ func unmarshalBody(raw json.RawMessage, headers http.Header) ([]byte, error) {
 		return buf.Bytes(), nil
 
 	case firstByte == '"':
-		// JSON string: could be text or base64.
+		// JSON string: could be text, base64, or a non-UTF-8 text fallback.
 		var s string
 		if err := json.Unmarshal(raw, &s); err != nil {
 			return nil, fmt.Errorf("decode body string: %w", err)
+		}
+
+		// The body_encoding marker takes priority over Content-Type for string
+		// bodies. This is the only safe disambiguation for the text path: a
+		// legitimate UTF-8 text body might look like valid base64, so we never
+		// try-base64-first for text. The marker is only emitted for non-UTF-8
+		// text bodies and is authoritative when present.
+		if strings.EqualFold(encoding, "base64") {
+			decoded, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return nil, fmt.Errorf("decode base64 body (body_encoding=base64): %w", err)
+			}
+			return decoded, nil
 		}
 
 		ct := ""
@@ -361,7 +417,9 @@ func unmarshalBody(raw json.RawMessage, headers http.Header) ([]byte, error) {
 		}
 
 		if parseErr == nil && IsText(mt) {
-			// Text CT: store string as UTF-8 bytes.
+			// Text CT without a base64 marker: store string verbatim as bytes.
+			// This correctly handles both normal UTF-8 text AND any text body
+			// that happens to look like valid base64 (e.g., "SGVsbG8=").
 			return []byte(s), nil
 		}
 

--- a/tape_test.go
+++ b/tape_test.go
@@ -991,6 +991,380 @@ func TestRecordedResp_JSON_RoundTrip_WithElapsedMS(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ADR-50: non-UTF-8 text body encoding tests
+// ---------------------------------------------------------------------------
+
+// TestRoundTrip_Latin1TextBody_SurvivesByteIdentically is the primary repro
+// for #303: a Latin-1 text body must survive marshal → unmarshal byte-identically.
+// encoding/json replaces invalid UTF-8 with U+FFFD when marshaling a string, so
+// without the base64 fallback the body would be silently corrupted on persist.
+func TestRoundTrip_Latin1TextBody_SurvivesByteIdentically(t *testing.T) {
+	// "café au lait" in ISO-8859-1: 0xe9 is the Latin-1 code point for é.
+	latin1Body := []byte("caf\xe9 au lait")
+	headers := http.Header{"Content-Type": {"text/plain; charset=iso-8859-1"}}
+
+	req := RecordedReq{
+		Method:   "POST",
+		URL:      "http://example.com/api",
+		Headers:  headers,
+		Body:     latin1Body,
+		BodyHash: BodyHashFromBytes(latin1Body),
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// Fixture must contain the body_encoding marker.
+	if !strings.Contains(string(data), `"body_encoding":"base64"`) {
+		t.Errorf("expected body_encoding:base64 in fixture, got: %s", data)
+	}
+
+	var req2 RecordedReq
+	if err := json.Unmarshal(data, &req2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !bytes.Equal(req2.Body, latin1Body) {
+		t.Errorf("body mismatch after round-trip:\n  want: %v\n  got:  %v", latin1Body, req2.Body)
+	}
+}
+
+// TestRoundTrip_Latin1TextBody_Resp_SurvivesByteIdentically mirrors the repro
+// on RecordedResp to ensure both marshal paths are covered.
+func TestRoundTrip_Latin1TextBody_Resp_SurvivesByteIdentically(t *testing.T) {
+	latin1Body := []byte("caf\xe9 au lait")
+	headers := http.Header{"Content-Type": {"text/plain; charset=iso-8859-1"}}
+
+	resp := RecordedResp{
+		StatusCode: 200,
+		Headers:    headers,
+		Body:       latin1Body,
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"body_encoding":"base64"`) {
+		t.Errorf("expected body_encoding:base64 in fixture, got: %s", data)
+	}
+
+	var resp2 RecordedResp
+	if err := json.Unmarshal(data, &resp2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !bytes.Equal(resp2.Body, latin1Body) {
+		t.Errorf("body mismatch after round-trip:\n  want: %v\n  got:  %v", latin1Body, resp2.Body)
+	}
+}
+
+// TestBodyHash_MatchesStoredBody_ForNonUTF8Text asserts that after a round-trip
+// the stored body_hash still matches the round-tripped body. This is the
+// divergence guard for #303: before the fix, body_hash was computed over the
+// original bytes but the stored body was U+FFFD-corrupted.
+func TestBodyHash_MatchesStoredBody_ForNonUTF8Text(t *testing.T) {
+	latin1Body := []byte("caf\xe9 au lait")
+	headers := http.Header{"Content-Type": {"text/plain; charset=iso-8859-1"}}
+	originalHash := BodyHashFromBytes(latin1Body)
+
+	req := RecordedReq{
+		Method:   "POST",
+		URL:      "http://example.com",
+		Headers:  headers,
+		Body:     latin1Body,
+		BodyHash: originalHash,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var req2 RecordedReq
+	if err := json.Unmarshal(data, &req2); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	roundTripHash := BodyHashFromBytes(req2.Body)
+	if roundTripHash != originalHash {
+		t.Errorf("body_hash mismatch after round-trip: stored=%q computed-over-body=%q",
+			originalHash, roundTripHash)
+	}
+}
+
+// TestMarshalBody_TextCTShapes exercises marshalBody for the text Content-Type
+// branch covering valid UTF-8 (no marker) and several non-UTF-8 encodings (marker set).
+func TestMarshalBody_TextCTShapes(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        []byte
+		ct          string
+		wantEncoded bool   // true → base64 in JSON; false → plain string
+		wantMarker  string // expected body_encoding value in emitted JSON ("" = absent)
+	}{
+		{
+			name:        "valid UTF-8 text emits plain string without marker",
+			body:        []byte("hello world"),
+			ct:          "text/plain",
+			wantEncoded: false,
+			wantMarker:  "",
+		},
+		{
+			name:        "Latin-1 byte emits base64 with base64 marker",
+			body:        []byte("caf\xe9 au lait"),
+			ct:          "text/plain; charset=iso-8859-1",
+			wantEncoded: true,
+			wantMarker:  "base64",
+		},
+		{
+			name:        "lone 0xFF byte emits base64 with base64 marker",
+			body:        []byte{0xFF},
+			ct:          "text/plain",
+			wantEncoded: true,
+			wantMarker:  "base64",
+		},
+		{
+			name:        "Shift-JIS sample emits base64 with base64 marker",
+			body:        []byte{0x82, 0xb1, 0x82, 0xf1, 0x82, 0xc9, 0x82, 0xbf, 0x82, 0xcd}, // "こんにちは" in Shift-JIS
+			ct:          "text/plain; charset=shift_jis",
+			wantEncoded: true,
+			wantMarker:  "base64",
+		},
+		{
+			name:        "application/xml valid UTF-8 no marker",
+			body:        []byte("<root/>"),
+			ct:          "application/xml",
+			wantEncoded: false,
+			wantMarker:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := http.Header{"Content-Type": {tt.ct}}
+			req := RecordedReq{Method: "POST", URL: "http://x", Headers: headers, Body: tt.body}
+			data, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			s := string(data)
+
+			hasMarker := strings.Contains(s, `"body_encoding":"base64"`)
+			if tt.wantMarker == "base64" && !hasMarker {
+				t.Errorf("expected body_encoding:base64 in output, got: %s", s)
+			}
+			if tt.wantMarker == "" && hasMarker {
+				t.Errorf("unexpected body_encoding field in output, got: %s", s)
+			}
+
+			// Verify round-trip restores the original bytes.
+			var req2 RecordedReq
+			if err := json.Unmarshal(data, &req2); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			if !bytes.Equal(req2.Body, tt.body) {
+				t.Errorf("body mismatch after round-trip:\n  want: %v\n  got:  %v", tt.body, req2.Body)
+			}
+		})
+	}
+}
+
+// TestUnmarshalBody_Base64MarkerTakesPriorityOverContentType asserts that when
+// body_encoding is "base64", the body is base64-decoded regardless of Content-Type.
+func TestUnmarshalBody_Base64MarkerTakesPriorityOverContentType(t *testing.T) {
+	// base64("café") with a text/plain Content-Type and the explicit marker.
+	// Without the marker, a text CT would store this verbatim as "Y2Fmw6k=".
+	latin1Body := []byte("caf\xe9 au lait")
+	encoded := "Y2Fm6SBhdSBsYWl0" // base64.StdEncoding of latin1Body
+
+	input := `{
+		"method": "POST",
+		"url": "http://example.com",
+		"headers": {"Content-Type": ["text/plain; charset=iso-8859-1"]},
+		"body": "` + encoded + `",
+		"body_encoding": "base64",
+		"body_hash": ""
+	}`
+
+	var req RecordedReq
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !bytes.Equal(req.Body, latin1Body) {
+		t.Errorf("Body = %v, want %v", req.Body, latin1Body)
+	}
+}
+
+// TestUnmarshalBody_LegitTextThatLooksLikeBase64_ReadVerbatim guards the
+// ambiguity that drove the marker decision: a legitimate UTF-8 text body that
+// happens to be valid base64 must be read verbatim (not decoded) when no marker
+// is present.
+func TestUnmarshalBody_LegitTextThatLooksLikeBase64_ReadVerbatim(t *testing.T) {
+	// "SGVsbG8=" is the base64 encoding of "Hello". As a text/plain body it
+	// should be stored verbatim — the literal string "SGVsbG8=" — not decoded
+	// to "Hello". This is the key regression guard for try-base64-first rejection.
+	input := `{
+		"method": "GET",
+		"url": "http://example.com",
+		"headers": {"Content-Type": ["text/plain"]},
+		"body": "SGVsbG8=",
+		"body_hash": ""
+	}`
+
+	var req RecordedReq
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	want := "SGVsbG8="
+	if string(req.Body) != want {
+		t.Errorf("Body = %q, want %q (must be verbatim, not base64-decoded)", string(req.Body), want)
+	}
+}
+
+// TestUnmarshalBody_Base64MarkerWithBadBase64_Errors asserts that a body marked
+// as base64 but containing invalid base64 data is a hard error (fail closed),
+// not silent corruption.
+func TestUnmarshalBody_Base64MarkerWithBadBase64_Errors(t *testing.T) {
+	input := `{
+		"method": "POST",
+		"url": "http://example.com",
+		"headers": {"Content-Type": ["text/plain"]},
+		"body": "!!!not-valid-base64!!!",
+		"body_encoding": "base64",
+		"body_hash": ""
+	}`
+
+	var req RecordedReq
+	err := json.Unmarshal([]byte(input), &req)
+	if err == nil {
+		t.Error("expected error for invalid base64 under body_encoding=base64, got nil")
+	}
+}
+
+// TestUnmarshalBody_ExistingFixturesWithoutMarker_UnchangedBehavior is the
+// backwards-compatibility regression: fixtures without body_encoding must
+// unmarshal identically to before ADR-50.
+func TestUnmarshalBody_ExistingFixturesWithoutMarker_UnchangedBehavior(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string // expected Body as string
+	}{
+		{
+			name: "text/plain body without marker stays verbatim",
+			input: `{
+				"method": "GET",
+				"url": "http://example.com",
+				"headers": {"Content-Type": ["text/plain"]},
+				"body": "hello world",
+				"body_hash": ""
+			}`,
+			want: "hello world",
+		},
+		{
+			name: "JSON body without marker stays native JSON",
+			input: `{
+				"method": "POST",
+				"url": "http://example.com",
+				"headers": {"Content-Type": ["application/json"]},
+				"body": {"key": "value"},
+				"body_hash": ""
+			}`,
+			want: `{"key":"value"}`,
+		},
+		{
+			name: "legacy body_encoding identity is ignored (object body)",
+			input: `{
+				"method": "POST",
+				"url": "http://example.com",
+				"headers": {"Content-Type": ["application/json"]},
+				"body": {"ok": true},
+				"body_encoding": "identity",
+				"body_hash": ""
+			}`,
+			want: `{"ok":true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req RecordedReq
+			if err := json.Unmarshal([]byte(tt.input), &req); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			if string(req.Body) != tt.want {
+				t.Errorf("Body = %q, want %q", string(req.Body), tt.want)
+			}
+		})
+	}
+}
+
+// TestMarshalBody_NoMarkerOnUTF8TextOrOtherCTs verifies that the body_encoding
+// field is completely absent (omitempty) for all non-non-UTF-8-text cases,
+// keeping existing fixture files byte-identical on disk.
+func TestMarshalBody_NoMarkerOnUTF8TextOrOtherCTs(t *testing.T) {
+	tests := []struct {
+		name string
+		req  RecordedReq
+	}{
+		{
+			name: "UTF-8 text body",
+			req: RecordedReq{
+				Method:  "POST",
+				URL:     "http://x",
+				Headers: http.Header{"Content-Type": {"text/plain"}},
+				Body:    []byte("hello"),
+			},
+		},
+		{
+			name: "JSON body",
+			req: RecordedReq{
+				Method:  "POST",
+				URL:     "http://x",
+				Headers: http.Header{"Content-Type": {"application/json"}},
+				Body:    []byte(`{"a":1}`),
+			},
+		},
+		{
+			name: "binary body",
+			req: RecordedReq{
+				Method:  "GET",
+				URL:     "http://x",
+				Headers: http.Header{"Content-Type": {"image/png"}},
+				Body:    []byte{0x89, 0x50, 0x4e, 0x47},
+			},
+		},
+		{
+			name: "nil body",
+			req: RecordedReq{
+				Method:  "GET",
+				URL:     "http://x",
+				Headers: http.Header{"Content-Type": {"application/json"}},
+				Body:    nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.req)
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			if strings.Contains(string(data), "body_encoding") {
+				t.Errorf("unexpected body_encoding field in output for %s: %s", tt.name, data)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // elapsedMS helper
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #303

## Root cause

`marshalBody` (`tape.go`) emitted any text-Content-Type body as `string(body)`. Go's `encoding/json` replaces invalid UTF-8 sequences with U+FFFD when marshaling a string, so a `text/plain; charset=iso-8859-1` body (`caf\xe9 au lait`) was silently mangled to `caf\xef\xbf\xbd au lait` on persist. The `body_hash` was computed over the original bytes, so after this it no longer matched the stored body; replay/diff/export served the corrupted bytes.

## Fix: UTF-8 guard + explicit `body_encoding` marker

`marshalBody` now gates the text path on `utf8.Valid`:

- **Valid UTF-8** → plain JSON string, no marker (unchanged, byte-identical output)
- **Non-UTF-8 bytes** → base64 string + `"body_encoding":"base64"` field (`omitempty`)

`unmarshalBody` accepts the marker as a third parameter. When it equals `"base64"` (case-insensitive), the body string is base64-decoded **before** Content-Type classification, authoritatively and exclusively. A malformed base64 under a `"base64"` marker is a hard error (fail closed — consistent with #297). All other marker values (`"identity"`, absent, empty) are ignored for string-token bodies.

## Why an explicit marker — not try-base64-first

The text unmarshal path today stores a JSON string verbatim as bytes, because for text CT the expected shape *is* a literal string. Making it "try base64 first" would silently misdecode any legitimate UTF-8 text body that happens to be valid base64 (`"SGVsbG8="`, short tokens, a doc that literally contains a base64 blob). That is a strictly worse bug than #303 because it hits normal UTF-8 text, not just exotic charsets. The marker removes the ambiguity entirely: decode iff the marshaller recorded that it encoded.

## Backwards compatibility

- `body_encoding` uses `omitempty` — absent on all existing fixture shapes (JSON, valid-UTF-8 text, binary, nil). On-disk bytes for existing fixtures are **byte-identical**.
- Legacy `body_encoding:"identity"` paired with a native-JSON object body — object token path, marker ignored. Still works (`TestRecordedReq_UnmarshalJSON_LegacyBodyEncoding` passes unchanged).
- Reusing the value `"base64"` is compatible with, and quietly repairs, any v0.11 fixtures that carried it.

## Changes

| File | Change |
|---|---|
| `tape.go` | `marshalBody` returns `(any, string)`; UTF-8 guard added; `unmarshalBody` accepts `encoding string`; both alias structs gain `BodyEncoding` |
| `tape_test.go` | 8 new behavior-named tests (see Test plan below) |
| `docs/fixtures-authoring.md` | Body-shape table updated with non-UTF-8 row; `body_encoding` field documented with hand-authoring guidance |
| `decisions.md` | ADR-50 appended (verified: highest existing ADR was 49) |

## Test plan

New tests added to `tape_test.go`:

- `TestRoundTrip_Latin1TextBody_SurvivesByteIdentically` — primary repro; `caf\xe9 au lait` round-trips byte-identically; fixture contains `body_encoding:"base64"`
- `TestRoundTrip_Latin1TextBody_Resp_SurvivesByteIdentically` — mirrors repro on `RecordedResp`
- `TestBodyHash_MatchesStoredBody_ForNonUTF8Text` — hash divergence guard; `BodyHashFromBytes(round-tripped body) == original hash`
- `TestMarshalBody_TextCTShapes` — table: valid UTF-8 → no marker; Latin-1, lone `0xFF`, Shift-JIS → `base64` marker; plus round-trip assertion for each
- `TestUnmarshalBody_Base64MarkerTakesPriorityOverContentType` — text CT + marker → base64-decoded
- `TestUnmarshalBody_LegitTextThatLooksLikeBase64_ReadVerbatim` — text CT, `"SGVsbG8="`, no marker → body is literal `"SGVsbG8="` (guards the ambiguity we rejected)
- `TestUnmarshalBody_Base64MarkerWithBadBase64_Errors` — marker set + invalid base64 → error
- `TestUnmarshalBody_ExistingFixturesWithoutMarker_UnchangedBehavior` — regression table: plain text, JSON body, legacy `identity` marker all unchanged
- `TestMarshalBody_NoMarkerOnUTF8TextOrOtherCTs` — UTF-8 text, JSON, binary, nil → no `body_encoding` field emitted

All existing tests pass unchanged. `go test ./... -race -count=1` green on both packages.