### PR TITLE
fix(#304): record no longer drops buffered recordings on interrupt

### DIFF
--- a/cmd/httptape/main.go
+++ b/cmd/httptape/main.go
@@ -519,6 +519,18 @@ func runRecord(args []string) error {
 	}
 
 	recorder := httptape.NewRecorder(store, recorderOpts...)
+	// Drain async recordings synchronously before runRecord returns so that
+	// buffered tapes are never dropped on SIGINT. Without this defer,
+	// ListenAndServe returns (triggering run() exit) before the signal
+	// goroutine reaches recorder.Close(), losing all queued tapes. Close is
+	// idempotent via sync.Once, so the goroutine's Close (if reached) is safe.
+	defer func() {
+		if err := recorder.Close(); err != nil {
+			logger.Printf("recorder close error: %v", err)
+		} else {
+			logger.Println("recorder flushed")
+		}
+	}()
 
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
@@ -568,11 +580,7 @@ func runRecord(args []string) error {
 			logger.Printf("graceful shutdown failed: %v, forcing close", err)
 			httpServer.Close()
 		}
-		if err := recorder.Close(); err != nil {
-			logger.Printf("recorder close error: %v", err)
-		} else {
-			logger.Println("recorder flushed")
-		}
+		// recorder.Close() is handled by the defer above; no call needed here.
 	}()
 
 	scheme := "http"

--- a/cmd/httptape/main_test.go
+++ b/cmd/httptape/main_test.go
@@ -1603,14 +1603,12 @@ func runLiveCommandAndCapture(
 		t.Fatal("CLI did not exit after SIGINT")
 	}
 
-	// The recorder's Close() (which flushes async writes to disk) runs in the
-	// shutdown goroutine after httpServer.Shutdown returns. Because
-	// ListenAndServe returns as soon as Shutdown signals it, run() exits before
-	// the flush goroutine finishes. Poll until a fixture file appears so we can
-	// be confident the flush — and its final logger write ("recorder flushed")
-	// — has completed before we close the pipe and restore logger. Closing the
-	// pipe while the goroutine still holds a reference to the redirected logger
-	// would be a data race.
+	// After the fix for issue #304, recorder.Close() is called synchronously via
+	// defer in runRecord before run() returns. The fixture is therefore on disk
+	// when <-done unblocks. The short poll below is a safety net for proxy tests
+	// (where tapeProxy.Close is also deferred) and for any edge case where the
+	// OS write buffer is not yet visible. It exits in the first iteration when
+	// the fixture is already present.
 	flushDeadline := time.Now().Add(3 * time.Second)
 	for {
 		entries, _ := os.ReadDir(fixturesDir)
@@ -1625,10 +1623,9 @@ func runLiveCommandAndCapture(
 		time.Sleep(10 * time.Millisecond)
 	}
 flushed:
-	// Add a small settle window for the goroutine's final logger.Println call
-	// (e.g. "recorder flushed") to complete before we restore the logger.
-	// The file poll above confirms the write finished, but the goroutine may
-	// still be executing the logger call itself.
+	// Small settle window so any goroutine still holding a reference to the
+	// redirected logger (e.g. the proxy shutdown goroutine) has time to finish
+	// its final write before we close the pipe and restore the logger.
 	time.Sleep(25 * time.Millisecond)
 
 	w.Close()
@@ -2196,6 +2193,95 @@ func TestRecordUnsafeRawPlusConfigDoesNotTouchDisk(t *testing.T) {
 	}
 	if _, err := os.Stat(nestedFixtures); !os.IsNotExist(err) {
 		t.Errorf("fixtures dir %q was created despite usage error (disk access must not precede the check)", nestedFixtures)
+	}
+}
+
+// TestRecordPersistsBufferedTapesOnInterrupt is a regression test for issue #304.
+//
+// Before the fix, recorder.Close() (which drains the async tape channel to disk)
+// was called only inside the signal-handler goroutine, after httpServer.Shutdown
+// returned. ListenAndServe returns as soon as Shutdown is called, so run() exited
+// and os.Exit terminated the process while the goroutine was still flushing —
+// dropping all buffered tapes.
+//
+// After the fix, recorder.Close() is called via defer in runRecord, which executes
+// synchronously before run() returns. All buffered tapes must be on disk by the
+// time the done channel is unblocked — no additional polling is needed.
+func TestRecordPersistsBufferedTapesOnInterrupt(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	fixturesDir := t.TempDir()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	done := make(chan int, 1)
+	go func() {
+		done <- run([]string{
+			"record",
+			"--upstream", upstream.URL,
+			"--fixtures", fixturesDir,
+			"--port", itoa(port),
+			"--unsafe-raw",
+		})
+	}()
+
+	// Wait for the listener to be ready.
+	addr := "127.0.0.1:" + itoa(port)
+	listenerDeadline := time.Now().Add(5 * time.Second)
+	for {
+		conn, dialErr := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if dialErr == nil {
+			conn.Close()
+			break
+		}
+		if time.Now().After(listenerDeadline) {
+			t.Fatalf("listener never came up: %v", dialErr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Make a probe request so that a tape is queued in the recorder's async channel.
+	resp, err := http.Get("http://" + addr + "/probe")
+	if err == nil {
+		resp.Body.Close()
+	}
+
+	// Send SIGINT to trigger graceful shutdown.
+	p, _ := os.FindProcess(os.Getpid())
+	_ = p.Signal(os.Interrupt)
+
+	// Wait for run() to return. With the fix, recorder.Close() completes (draining
+	// the async channel) inside a defer before run() returns, so all buffered tapes
+	// are guaranteed to be on disk by this point — no additional sleep or polling.
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("record command did not exit after SIGINT")
+	}
+
+	// The fixture must be present immediately after run() returns.
+	// A missing fixture indicates the async drain raced with process exit.
+	entries, err := os.ReadDir(fixturesDir)
+	if err != nil {
+		t.Fatalf("read fixtures dir: %v", err)
+	}
+	var found bool
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".json" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("no fixture found after record exited: buffered tapes were not drained synchronously before exit (issue #304)")
 	}
 }
 

--- a/recorder.go
+++ b/recorder.go
@@ -448,7 +448,10 @@ func (r *Recorder) persistTape(ctx context.Context, tape Tape) {
 		r.sendMu.Lock()
 		if r.closed.Load() {
 			r.sendMu.Unlock()
-			// recorder closed -- drop tape silently
+			// recorder already closed; notify via onError so data loss is visible
+			if r.onError != nil {
+				r.onError(fmt.Errorf("httptape: recorder closed, tape dropped"))
+			}
 		} else {
 			select {
 			case r.tapeCh <- tape:


### PR DESCRIPTION
Closes #304

## Summary

- **Root cause** — `recorder.Close()` (which drains the async tape channel) was called only inside the signal-handler goroutine, *after* `httpServer.Shutdown` returned. `ListenAndServe` returns as soon as `Shutdown` is called, so `run()` — and in a real binary, `os.Exit` — completed before the goroutine reached `Close()`. All buffered tapes were silently dropped.

- **Fix in `cmd/httptape/main.go`** — added `defer recorder.Close()` in `runRecord` immediately after the recorder is created. The drain now runs synchronously before `runRecord` returns, guaranteeing every queued tape is on disk before the process exits. The now-redundant `recorder.Close()` call in the signal goroutine is removed and replaced with a comment (Close is idempotent via `sync.Once`, so double-close is safe regardless).

- **Fix in `recorder.go`** — the post-close silent-drop path in `persistTape` (hit when a `RoundTrip` races with `Close()`) now calls `onError` so data loss is never invisible, matching the existing behaviour of the buffer-full path.

- **Checked `runProxy`** — already safe: `defer tapeProxy.Close()` was already in place.

- **Checked `runServe`, `runExport`, `runImport`, `runMigrateFixtures`** — no async recorder, no changes needed.

## Test plan

- `TestRecordPersistsBufferedTapesOnInterrupt` (new) — starts the record command against a fake upstream, makes a probe request, sends SIGINT, waits for `run()` to return, then asserts the fixture is present *immediately* with no additional polling. This is the exact scenario that was broken before the fix.
- Updated comment in `runLiveCommandAndCapture` to reflect that the fixture-poll is now a no-op safety net (fixture is on disk when `done` unblocks).

Verified locally:
```
go build ./...
go vet ./...
go test ./... -race -count=1
go test -run TestRecordPersistsBufferedTapesOnInterrupt ./cmd/httptape/ -race -count=5
```
All green (5/5 for the new test).