### PR TITLE
chore: agent models via family aliases — no more stale pins

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Software architect agent. Invoke after PM sets status READY_FOR_ARCH. Reads the PM spec, validates against locked decisions, produces a concrete technical design (interfaces, types, file layout, sequence diagrams in text), writes a full ADR to decisions.md, posts a short status comment to the GitHub issue, and sets issue status to READY_FOR_DEV.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-8
+model: opus
 ---
 
 You are the httptape Software Architect. You own technical correctness, architectural

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -2,7 +2,7 @@
 name: dev
 description: Senior Go developer agent. Invoke after architect sets status READY_FOR_DEV. Reads the architectural design from the issue comments, implements it precisely following the project's flat package structure, writes tests, commits, and opens a PR. Sets issue status to READY_FOR_REVIEW.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 You are the httptape Senior Go Developer. You implement exactly what the architect

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -2,7 +2,7 @@
 name: pm
 description: Product manager agent. Invoke when you need to turn a feature idea or GitHub issue into a detailed spec ready for the architect. Use for: writing acceptance criteria, breaking epics into stories, creating GitHub issues via gh CLI, setting issue status to READY_FOR_ARCH.
 tools: Read, Write, Edit, Bash
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 You are the httptape Product Manager. You translate product ideas and rough GitHub issues

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Code reviewer agent. Invoke after dev sets status READY_FOR_REVIEW. Reads the PR diff, checks against architectural design and code quality rules, writes inline review comments via gh CLI, and either approves or requests changes. Sets issue status to CHANGES_REQUESTED or APPROVED.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-8
+model: opus
 ---
 
 You are the httptape Code Reviewer. You are the last automated gate before the human


### PR DESCRIPTION
Switches .claude/agents/*.md frontmatter from pinned model IDs to family aliases:

- pm, dev: `claude-sonnet-4-6` → `sonnet`
- architect, reviewer: `claude-opus-4-8` → `opus`

Bare aliases resolve to the newest model of the family at invocation time (per code.claude.com/docs/en/sub-agents — there is no `@latest` syntax; the bare alias is the mechanism). Ends the recurring manual bump chore (#267, #278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)