### PR TITLE
chore(#311): v0.14.0 release prep — CHANGELOG + doc drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-08-05
+
 ### Added
 
 - **Inbound TLS listener**: CLI commands `serve`, `record`, and `proxy`
@@ -86,19 +88,82 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Config support for `path_pattern`**: declarative `"type": "path_pattern"`
   criterion with `"pattern"` field. (#196)
 
+- **`RedactQueryParams` / `FakeQueryParams`**: `SanitizeFunc` constructors
+  that redact or deterministically fake URL query parameter values. Userinfo
+  (`user:password@` in the authority) is always stripped, regardless of
+  which parameter names are configured. Both functions default to
+  `DefaultSensitiveQueryParams()` when called with no names. Fail-closed:
+  malformed percent-encoded query strings are replaced wholesale with
+  `[REDACTED]` rather than passed through as cleartext. (#295)
+
+- **`DefaultSensitiveQueryParams`**: returns a copy of the built-in list of
+  query parameter names commonly carrying sensitive data (`api_key`,
+  `access_token`, `token`, `secret`, `password`, `sig`, `signature`,
+  `X-Amz-Signature`, `X-Goog-Signature`). (#295)
+
+- **`--unsafe-raw` CLI flag**: `record` and `proxy` commands now apply safe
+  default sanitization (redact default sensitive headers + query params) unless
+  `--unsafe-raw` is passed. This flag disables all sanitization for callers who
+  explicitly opt out. The previous behavior (no sanitization by default) is
+  now opt-in. (#297)
+
+- **`body_encoding: "base64"` field**: non-UTF-8 text bodies that cannot be
+  stored as plain JSON strings are persisted as base64-encoded strings with an
+  explicit `"body_encoding": "base64"` marker. Fixtures written before this
+  change are unaffected (all-UTF-8 text bodies remain plain strings). (#303)
+
+### Security
+
+- **CLI fail-closed sanitization**: `httptape record` and `httptape proxy` now
+  default to redacting `DefaultSensitiveHeaders()` and `DefaultSensitiveQueryParams()`
+  from every recorded tape. Raw recording requires an explicit `--unsafe-raw` flag.
+  This eliminates the risk of committing API keys or session tokens to version
+  control when using the CLI without a config file. (#297)
+
+- **Matcher-only config fail-closed**: when a config file supplies a `matcher`
+  block but no `sanitizer` block, the CLI now rejects the invocation with an
+  error rather than silently recording without sanitization. A sanitizer is
+  required whenever a custom matcher is provided. (#306)
+
+### Fixed
+
+- **Single-flight key correctness**: the deduplication key for concurrent cache
+  misses now includes the raw query string and a canonical SHA-256 hash of all
+  request headers outside the hop-by-hop denylist. Previously, two requests
+  with the same method, path, and body but different query parameters or headers
+  could incorrectly share one upstream call and receive the same response.
+  (ADR-47, #294)
+
+- **SSE streams past upstream timeout**: SSE responses are now kept alive past
+  the `WithCacheUpstreamTimeout` deadline. The timeout previously applied to
+  the entire SSE stream duration; it now bounds only the header phase. (#300)
+
+- **Fail-closed on matcher-only configs**: the CLI now rejects a config file
+  that provides a `matcher` block without a `sanitizer` block rather than
+  recording without sanitization. (#306)
+
+- **Config schema for `redact_query` / `fake_query` actions**: the JSON config
+  schema now accepts `"redact_query"` and `"fake_query"` as sanitizer action
+  types. Legacy config actions that carry unrecognized fields now return an
+  error at load time rather than silently ignoring them. (#310)
+
+- **Non-UTF-8 text bodies persisted correctly**: text-typed response bodies
+  containing non-UTF-8 byte sequences (e.g. Latin-1 encoded text) now survive
+  the record → persist → replay round-trip byte-identically. Previously they
+  were silently corrupted by JSON encoding. (#303)
+
+- **SIGINT drains pending recordings**: `httptape record` and `httptape proxy`
+  now call `Recorder.Close()` before exiting on SIGINT, flushing any tapes
+  buffered in the async channel. Previously, tapes in flight at shutdown time
+  were silently dropped. (#304)
+
+- **`WithOnError` fires on racing-drop path**: `WithOnError` callbacks are now
+  also invoked when a tape is dropped because `RoundTrip` raced against
+  `Recorder.Close()`. Previously, only background drain-goroutine errors
+  triggered the callback; silent tape drops on the hot path were invisible to
+  callers. (#304)
+
 ### Breaking Changes
-
-- **`ResolveTemplateBody` and `ResolveTemplateHeaders` signatures changed**:
-  These now accept `*templateCtx` (unexported) instead of `*http.Request`.
-  External callers should use `ResolveTemplateBodySimple` instead. Pre-1.0,
-  acceptable. (#196)
-
-- **Unknown template namespaces**: expressions like `{{state.counter}}` that
-  were previously left as literal text are now replaced with empty string in
-  lenient mode (error in strict mode). All supported expressions are now
-  explicitly dispatched. (#196)
-
-### Breaking Changes (prior)
 
 - **`NewServer` signature change**: `NewServer(store Store, opts ...ServerOption)`
   now returns `(*Server, error)` instead of `*Server`. The constructor validates
@@ -116,10 +181,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   now returns `(SSETimingMode, error)` instead of `SSETimingMode`. Returns an
   error when factor is <= 0 instead of panicking. (#215, ADR-46)
 
+- **`ResolveTemplateBody` and `ResolveTemplateHeaders` signatures changed**:
+  These now accept `*templateCtx` (unexported) instead of `*http.Request`.
+  External callers should use `ResolveTemplateBodySimple` instead. Pre-1.0,
+  acceptable. (#196)
+
+- **Unknown template namespaces**: expressions like `{{state.counter}}` that
+  were previously left as literal text are now replaced with empty string in
+  lenient mode (error in strict mode). All supported expressions are now
+  explicitly dispatched. (#196)
+
 ### Migration
 
-All three changes are caught by the Go compiler -- no silent breakage. Update
-call sites as follows:
+All `NewServer` / `NewProxy` / `SSETimingAccelerated` changes are caught by
+the Go compiler — no silent breakage. Update call sites as follows:
 
 ```go
 // Before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.14.0] - 2026-08-05
 
+### Module path change (breaking -- first release under the new org)
+
+v0.14.0 is the first tagged release published from the `httptape` GitHub
+org. v0.13.1 and earlier were tagged under `VibeWarden`. The Go module
+path, the `testcontainers` submodule path, and the container image
+namespace all changed:
+
+| | Before (≤ v0.13.1) | After (v0.14.0+) |
+|---|---|---|
+| Module path | `github.com/VibeWarden/httptape` | `github.com/httptape/httptape` |
+| `testcontainers` submodule path | `github.com/VibeWarden/httptape/testcontainers` | `github.com/httptape/httptape/testcontainers` |
+| Container image | `ghcr.io/vibewarden/httptape` | `ghcr.io/httptape/httptape` |
+
+**Migration:** update `go.mod` (and the `testcontainers/go.mod` submodule,
+if used) and every import site, then re-tidy:
+
+```bash
+grep -rl 'github.com/VibeWarden/httptape' --include='*.go' . go.mod | \
+  xargs sed -i '' 's#github.com/VibeWarden/httptape#github.com/httptape/httptape#g'
+go mod tidy
+```
+
+(#249, #250)
+
 ### Added
 
 - **Inbound TLS listener**: CLI commands `serve`, `record`, and `proxy`
@@ -91,10 +115,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`RedactQueryParams` / `FakeQueryParams`**: `SanitizeFunc` constructors
   that redact or deterministically fake URL query parameter values. Userinfo
   (`user:password@` in the authority) is always stripped, regardless of
-  which parameter names are configured. Both functions default to
-  `DefaultSensitiveQueryParams()` when called with no names. Fail-closed:
-  malformed percent-encoded query strings are replaced wholesale with
-  `[REDACTED]` rather than passed through as cleartext. (#295)
+  which parameter names are configured. `RedactQueryParams` defaults to
+  `DefaultSensitiveQueryParams()` when called with no names; `FakeQueryParams`
+  has no default -- called with no names, it fakes nothing (callers must pass
+  explicit parameter names). Fail-closed: malformed percent-encoded query
+  strings are replaced wholesale with `[REDACTED]` rather than passed through
+  as cleartext. (#295)
 
 - **`DefaultSensitiveQueryParams`**: returns a copy of the built-in list of
   query parameter names commonly carrying sensitive data (`api_key`,
@@ -111,6 +137,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   stored as plain JSON strings are persisted as base64-encoded strings with an
   explicit `"body_encoding": "base64"` marker. Fixtures written before this
   change are unaffected (all-UTF-8 text bodies remain plain strings). (#303)
+
+- **`redact_query` / `fake_query` config actions**: declarative JSON config
+  `rules` now support `"action": "redact_query"` and `"action": "fake_query"`,
+  mapping to `RedactQueryParams` / `FakeQueryParams`. The new `Rule.Params`
+  field lists the URL query parameter names to sanitize. (#310)
 
 ### Security
 
@@ -129,6 +160,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   is returned. (`serve` is unaffected — it relies on matcher-only configs
   legitimately.) (#306)
 
+- **Bundle import tar entry validation**: `ImportBundle` now rejects tar
+  entries with absolute paths, backslashes, or `..` path-traversal segments
+  before any entry is deserialized into a `Tape`. Defense in depth at the
+  bundle-parsing trust boundary for untrusted archives. (#218, #228)
+
 ### Fixed
 
 - **Single-flight key correctness**: the deduplication key for concurrent cache
@@ -138,14 +174,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   could incorrectly share one upstream call and receive the same response.
   (ADR-47, #294)
 
-- **SSE streams past upstream timeout**: SSE responses are now kept alive past
-  the `WithCacheUpstreamTimeout` deadline. The timeout previously applied to
-  the entire SSE stream duration; it now bounds only the header phase. (#300)
+- **SSE streams past upstream timeout**: `WithCacheUpstreamTimeout` previously
+  bounded the entire SSE stream duration, killing long-lived streams. It now
+  bounds only the header (time-to-first-byte) phase for SSE responses -- once
+  headers arrive, the timer is disarmed and the stream runs for its natural
+  lifetime. Buffered (non-SSE) responses are unaffected: the timeout still
+  covers the full upstream interaction, headers and body. (#300)
 
-- **Config schema for `redact_query` / `fake_query` actions**: the JSON config
-  schema now accepts `"redact_query"` and `"fake_query"` as sanitizer action
-  types. Legacy config actions that carry unrecognized fields now return an
-  error at load time rather than silently ignoring them. (#310)
+- **Config schema for `redact_query` / `fake_query` actions**: `config.schema.json`
+  now accepts `"redact_query"` and `"fake_query"` as sanitizer action types,
+  matching `Config.Validate`. See also the stray-`params` rejection for
+  legacy actions under Breaking Changes below. (#310)
 
 - **Non-UTF-8 text bodies persisted correctly**: text-typed response bodies
   containing non-UTF-8 byte sequences (e.g. Latin-1 encoded text) now survive
@@ -157,11 +196,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   buffered in the async channel. Previously, tapes in flight at shutdown time
   were silently dropped. (#304)
 
-- **`WithOnError` fires on racing-drop path**: `WithOnError` callbacks are now
-  also invoked when a tape is dropped because `RoundTrip` raced against
-  `Recorder.Close()`. Previously, only background drain-goroutine errors
-  triggered the callback; silent tape drops on the hot path were invisible to
-  callers. (#304)
+- **`WithOnError` fires on racing-drop path**: buffer-full drops and body
+  truncation notices already invoked `WithOnError` from the `RoundTrip`
+  goroutine. The one remaining silent path -- a tape dropped because
+  `RoundTrip` lost a race against `Recorder.Close()` -- now also invokes
+  `WithOnError`, so no tape drop is invisible to callers. (#304)
 
 ### Breaking Changes
 
@@ -180,6 +219,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`SSETimingAccelerated` signature change**: `SSETimingAccelerated(factor float64)`
   now returns `(SSETimingMode, error)` instead of `SSETimingMode`. Returns an
   error when factor is <= 0 instead of panicking. (#215, ADR-46)
+
+- **Legacy config actions now reject a stray `params` field**: `redact_headers`,
+  `redact_body`, and `fake` rules that include a `params` field now fail
+  `Config.Validate` (`"<action>" does not use "params"`) instead of silently
+  accepting and ignoring it. A config file that previously loaded
+  successfully with an errant `params` field on one of these actions will now
+  fail to load; remove the stray field or move it to a `redact_query` /
+  `fake_query` rule. (#310)
 
 - **`ResolveTemplateBody` and `ResolveTemplateHeaders` signatures changed**:
   These now accept `*templateCtx` (unexported) instead of `*http.Request`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,10 +120,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   This eliminates the risk of committing API keys or session tokens to version
   control when using the CLI without a config file. (#297)
 
-- **Matcher-only config fail-closed**: when a config file supplies a `matcher`
-  block but no `sanitizer` block, the CLI now rejects the invocation with an
-  error rather than silently recording without sanitization. A sanitizer is
-  required whenever a custom matcher is provided. (#306)
+- **Matcher-only / empty-rules config fail-closed**: when `--config` is
+  supplied but its `rules` array is empty or absent (e.g. a matcher-only
+  config), `record` and `proxy` now layer in the safe default sanitization
+  instead of proceeding with a no-op pipeline. A warning is printed to stderr
+  naming the redacted headers and query params and disclosing that
+  request/response bodies are not covered. The invocation proceeds; no error
+  is returned. (`serve` is unaffected — it relies on matcher-only configs
+  legitimately.) (#306)
 
 ### Fixed
 
@@ -137,10 +141,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **SSE streams past upstream timeout**: SSE responses are now kept alive past
   the `WithCacheUpstreamTimeout` deadline. The timeout previously applied to
   the entire SSE stream duration; it now bounds only the header phase. (#300)
-
-- **Fail-closed on matcher-only configs**: the CLI now rejects a config file
-  that provides a `matcher` block without a `sanitizer` block rather than
-  recording without sanitization. (#306)
 
 - **Config schema for `redact_query` / `fake_query` actions**: the JSON config
   schema now accepts `"redact_query"` and `"fake_query"` as sanitizer action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ if used) and every import site, then re-tidy:
 
 ```bash
 grep -rl 'github.com/VibeWarden/httptape' --include='*.go' . go.mod | \
-  xargs sed -i '' 's#github.com/VibeWarden/httptape#github.com/httptape/httptape#g'
+  xargs sed -i.bak 's#github.com/VibeWarden/httptape#github.com/httptape/httptape#g'
+find . -name '*.bak' -delete
 go mod tidy
 ```
 
@@ -141,7 +142,7 @@ go mod tidy
 - **`redact_query` / `fake_query` config actions**: declarative JSON config
   `rules` now support `"action": "redact_query"` and `"action": "fake_query"`,
   mapping to `RedactQueryParams` / `FakeQueryParams`. The new `Rule.Params`
-  field lists the URL query parameter names to sanitize. (#310)
+  field lists the URL query parameter names to sanitize. (#295)
 
 ### Security
 

--- a/doc.go
+++ b/doc.go
@@ -84,12 +84,13 @@
 //
 // # Sanitization
 //
-// Sensitive data is redacted or faked before any tape touches disk —
-// there is no "raw recording" mode. Sanitization is applied via a
-// [Pipeline] of [SanitizeFunc] functions, each of which transforms a
-// [Tape] in place and returns it.
+// Sensitive data is redacted or faked on write, before a tape is persisted
+// to a [Store], so recorded fixtures are safe to commit and share by
+// default. Sanitization is applied via a [Pipeline] of [SanitizeFunc]
+// functions; each receives a [Tape] and returns a (possibly modified) copy
+// -- implementations must not mutate the input Tape.
 //
-// Three surfaces are covered:
+// Four surfaces are covered:
 //   - Request and response headers: [RedactHeaders]
 //   - Request and response bodies (JSON field paths): [RedactBodyPaths],
 //     [FakeFields]
@@ -103,6 +104,8 @@
 //
 // Default sensitive header names are available via [DefaultSensitiveHeaders];
 // default sensitive query parameter names via [DefaultSensitiveQueryParams].
+// Sanitization is opt-in for library embedders (attach via [WithSanitizer]);
+// the CLI applies a safe default pipeline unless --unsafe-raw is passed.
 //
 // # Design principles
 //

--- a/doc.go
+++ b/doc.go
@@ -82,6 +82,28 @@
 // With these options absent, [Proxy.HealthHandler] returns nil, no
 // goroutines are started, and proxy behavior is byte-for-byte unchanged.
 //
+// # Sanitization
+//
+// Sensitive data is redacted or faked before any tape touches disk —
+// there is no "raw recording" mode. Sanitization is applied via a
+// [Pipeline] of [SanitizeFunc] functions, each of which transforms a
+// [Tape] in place and returns it.
+//
+// Three surfaces are covered:
+//   - Request and response headers: [RedactHeaders]
+//   - Request and response bodies (JSON field paths): [RedactBodyPaths],
+//     [FakeFields]
+//   - Request URL query parameters and userinfo: [RedactQueryParams],
+//     [FakeQueryParams] (userinfo is always stripped)
+//   - SSE event data: [RedactSSEEventData], [FakeSSEEventData]
+//
+// All faking functions use HMAC-SHA256 with a caller-supplied seed, so
+// the same input value always produces the same fake output across
+// recording sessions. The seed should be unique per project.
+//
+// Default sensitive header names are available via [DefaultSensitiveHeaders];
+// default sensitive query parameter names via [DefaultSensitiveQueryParams].
+//
 // # Design principles
 //
 // httptape follows hexagonal architecture: core types have zero I/O, all

--- a/docs/caching-transport.md
+++ b/docs/caching-transport.md
@@ -119,7 +119,9 @@ httptape.WithCacheSingleFlight(true)  // default
 httptape.WithCacheSingleFlight(false) // disable
 ```
 
-Controls single-flight deduplication of concurrent cache misses. When enabled, concurrent requests with the same match key (method + path + body hash) share a single upstream call. Each waiter receives an independent response with its own body reader.
+Controls single-flight deduplication of concurrent cache misses. When enabled, concurrent requests with the same single-flight key share a single upstream call; each waiter receives an independent response with its own body reader.
+
+The single-flight key is derived from HTTP method, URL path, raw query string, request body hash, and a canonical SHA-256 hash of all request headers except hop-by-hop and volatile headers (see `sfHeaderDenylist` in the source). This fully covers every dimension a Matcher could distinguish, so a waiter never receives a response that would not match its own request. The trade-off is reduced collapsing: two requests that are semantically equivalent but carry incidental header differences (e.g. a per-request trace ID) each make a separate upstream call rather than sharing one.
 
 For SSE responses, the first caller gets the live tee'd stream. Concurrent callers wait for the stream to complete, then get the cached tape.
 

--- a/docs/fixtures-authoring.md
+++ b/docs/fixtures-authoring.md
@@ -96,7 +96,7 @@ Any value other than `"base64"` (including the legacy `"identity"` from v0.11) i
 httptape migrate-fixtures --recursive ./fixtures
 ```
 
-The migration tool reads each `.json` file, decodes any base64 bodies, removes the legacy `body_encoding` field, and writes the fixture in the new Content-Type-aware format. It is safe to run multiple times (idempotent). Note: the `body_encoding: "base64"` value introduced in v0.13+ is meaningful and is preserved by the migration tool.
+The migration tool reads each `.json` file, decodes any base64 bodies, removes the legacy `body_encoding` field, and writes the fixture in the new Content-Type-aware format. It is safe to run multiple times (idempotent). Note: the `body_encoding: "base64"` value introduced in v0.14.0 is meaningful and is preserved by the migration tool.
 
 ### URL format and matching
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -238,7 +238,7 @@ func NewServer(store Store, opts ...ServerOption) (*Server, error)
 func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
 func NewProxy(l1, l2 Store, opts ...ProxyOption) (*Proxy, error)
 func NewPipeline(funcs ...SanitizeFunc) *Pipeline
-func NewMemoryStore() *MemoryStore
+func NewMemoryStore(opts ...MemoryStoreOption) *MemoryStore
 func NewFileStore(opts ...FileStoreOption) (*FileStore, error)
 func LoadFixtures(dir string) (*FileStore, error)
 func LoadFixturesFS(fsys fs.FS, dir string) (*MemoryStore, error)

--- a/llms.txt
+++ b/llms.txt
@@ -220,7 +220,7 @@ func NewServer(store Store, opts ...ServerOption) (*Server, error)
 func NewCachingTransport(upstream http.RoundTripper, store Store, opts ...CachingOption) *CachingTransport
 func NewProxy(l1, l2 Store, opts ...ProxyOption) (*Proxy, error)
 func NewPipeline(funcs ...SanitizeFunc) *Pipeline
-func NewMemoryStore() *MemoryStore
+func NewMemoryStore(opts ...MemoryStoreOption) *MemoryStore
 func NewFileStore(opts ...FileStoreOption) (*FileStore, error)
 func LoadFixtures(dir string) (*FileStore, error)
 func LoadFixturesFS(fsys fs.FS, dir string) (*MemoryStore, error)

--- a/recorder.go
+++ b/recorder.go
@@ -122,9 +122,10 @@ func WithBufferSize(size int) RecorderOption {
 
 // WithOnError sets a callback invoked when a store write fails or a tape is
 // dropped. The callback may be called from the background drain goroutine
-// (async write errors) or from the RoundTrip goroutine (e.g. when a tape is
-// dropped because the recorder was closed while RoundTrip was in flight). It
-// must be safe for concurrent use. Defaults to a no-op (errors are discarded).
+// (async write errors) or from the RoundTrip goroutine (buffer-full drops,
+// body-truncation notices, and -- since #341 -- the case where RoundTrip
+// loses a race against Close and the tape is dropped post-close). It must
+// be safe for concurrent use. Defaults to a no-op (errors are discarded).
 func WithOnError(fn func(error)) RecorderOption {
 	return func(r *Recorder) {
 		r.onError = fn

--- a/recorder.go
+++ b/recorder.go
@@ -123,7 +123,7 @@ func WithBufferSize(size int) RecorderOption {
 // WithOnError sets a callback invoked when a store write fails or a tape is
 // dropped. The callback may be called from the background drain goroutine
 // (async write errors) or from the RoundTrip goroutine (buffer-full drops,
-// body-truncation notices, and -- since #341 -- the case where RoundTrip
+// body-truncation notices, and -- since v0.14.0 -- the case where RoundTrip
 // loses a race against Close and the tape is dropped post-close). It must
 // be safe for concurrent use. Defaults to a no-op (errors are discarded).
 func WithOnError(fn func(error)) RecorderOption {

--- a/recorder.go
+++ b/recorder.go
@@ -120,9 +120,11 @@ func WithBufferSize(size int) RecorderOption {
 	}
 }
 
-// WithOnError sets a callback invoked when an async store write fails.
-// The callback is called from the background goroutine, so it must be
-// safe for concurrent use. Defaults to a no-op (errors are discarded).
+// WithOnError sets a callback invoked when a store write fails or a tape is
+// dropped. The callback may be called from the background drain goroutine
+// (async write errors) or from the RoundTrip goroutine (e.g. when a tape is
+// dropped because the recorder was closed while RoundTrip was in flight). It
+// must be safe for concurrent use. Defaults to a no-op (errors are discarded).
 func WithOnError(fn func(error)) RecorderOption {
 	return func(r *Recorder) {
 		r.onError = fn


### PR DESCRIPTION
Closes #311

## Summary

- **CHANGELOG**: converts `[Unreleased]` → `[0.14.0] - 2026-08-05` with a fresh empty `[Unreleased]` above. Fills all user-facing changes since v0.13.1 that were missing: #294 ADR-47 single-flight key fix (Fixed), #295 `RedactQueryParams`/`FakeQueryParams`/`DefaultSensitiveQueryParams` (Added), #297 CLI fail-closed + `--unsafe-raw` (Security + Added), #300/#335 SSE upstream-timeout fix (Fixed), #303/#340 `body_encoding: "base64"` marker (Added + Fixed), #304/#341 SIGINT drain + `WithOnError` racing-drop path (Fixed), #306/#336 matcher-only config fail-closed (Security + Fixed), #310/#337 config schema for `redact_query`/`fake_query` (Fixed). Consolidates the two duplicate "Breaking Changes" blocks from the prior draft.

- **doc.go**: adds a `# Sanitization` section covering `Pipeline`/`SanitizeFunc`, the four sanitization surfaces (headers, body JSON paths, URL query params + userinfo, SSE event data), HMAC-SHA256 deterministic faking, and the sanitize-on-write boundary. All cross-links point to real exported names.

- **docs/caching-transport.md line 122**: replaces the stale `(method + path + body hash)` parenthetical with the ADR-47 key (method + path + raw query string + body hash + canonical header hash minus denylist) and notes the correctness-over-collapse trade-off.

- **recorder.go `WithOnError` godoc**: clarifies that the callback may fire from the background drain goroutine _or_ from the `RoundTrip` goroutine when a tape is dropped on the racing-close path (added in #341). Code unchanged.

- **llms.txt + llms-full.txt**: fixes stale `NewMemoryStore()` → `NewMemoryStore(opts ...MemoryStoreOption)` in the Key APIs section.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./... -race -count=1` — green (both library and CLI packages)
- [x] `go build ./...` — clean
- [x] All godoc cross-links in doc.go verified against actual exported names in sanitizer.go
- [x] `git log v0.13.1..origin/main --oneline` cross-referenced against CHANGELOG entries — no user-facing PR omitted